### PR TITLE
docs: add sprint demo video link to Sprint 1 report

### DIFF
--- a/docs/docs/sprint-reviews/sprint-1.md
+++ b/docs/docs/sprint-reviews/sprint-1.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Sprint 1 Report (01/26/26 – 03/01/26)
 
-**Sprint demo video:** https://youtu.be/3PZzi8RMt3c
+[**Sprint demo video**](https://youtu.be/3PZzi8RMt3c)
 
 ## What's New (User Facing)
 

--- a/docs/docs/sprint-reviews/sprint-1.md
+++ b/docs/docs/sprint-reviews/sprint-1.md
@@ -4,6 +4,8 @@ sidebar_position: 1
 
 # Sprint 1 Report (01/26/26 – 03/01/26)
 
+**Sprint demo video:** https://youtu.be/3PZzi8RMt3c
+
 ## What's New (User Facing)
 
 - **User Authentication System** — Users can now sign up, log in, and manage their accounts securely through Clerk authentication


### PR DESCRIPTION
## Description

Updates the Sprint 1 report to include the latest demo video link so readers have the current recording.

---

## Type of change

- [ ] New feature (non-breaking)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / chore

---

## Changes

- **Docs (Sprint report)**
  - Added/updated the sprint demo video URL to: https://youtu.be/3PZzi8RMt3c
  - Ensured the link is visible near the top of the Sprint 1 report for quick access

---

## How has this been tested?

- Manually reviewed the rendered markdown in docs
- Verified the YouTube URL opens correctly

---

## Checklist

- [x] Self-reviewed code
- [ ] Added/updated tests
- [x] No new warnings introduced
- [ ] `go mod tidy` / `pnpm install` verified (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a sprint demo video link to the Sprint 1 review page for easy access.
  * Content-only update — no functional, API, or data-model changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->