### PR TITLE
docs: add Sprint 2 report and blog recap

### DIFF
--- a/docs/blog/2026-04-04-sprint-2-recap.md
+++ b/docs/blog/2026-04-04-sprint-2-recap.md
@@ -5,40 +5,32 @@ authors: [askatlas]
 tags: [sprint]
 ---
 
-Sprint 2 focused on turning our foundation into something users can actually interact with — file management, study guide views, and a real dashboard.
+Sprint 2 focused on building the core user-facing features of AskAtlas now that the foundational infrastructure from Sprint 1 was in place.
 
 <!-- truncate -->
 
 ## What We Built
 
-Building on Sprint 1's infrastructure, we shipped:
+With the infrastructure solid, we shifted to the features users will actually interact with:
 
-- **File deletion with async workers** — DELETE endpoint queues work to a background worker instead of blocking the request. Files are soft-deleted for recoverability.
-- **File renaming** — PATCH endpoint for updating file metadata, starting with the ability to rename files.
-- **Auto-generated API docs** — Migrated from manually maintained API reference files to OpenAPI-generated documentation that stays in sync with the codebase.
-- **Dashboard, Study Guide View, and Library UIs** — Three major frontend pages progressed from design to implementation, though still being connected to live data.
+- **Dashboard redesign** — Metrics cards, recent study guides list, and activity history sidebar give users an at-a-glance view of their progress.
+- **Study Guide View** — Dedicated page displaying guide details, linked quizzes, and referenced resources.
+- **Resource Library** — Document upload with drag-and-drop, file management, and list/grid view toggle.
+- **File renaming** — PATCH endpoint for updating file metadata with input validation, ownership checks, and full test coverage.
 
-## Architecture Highlights
+## How We Worked
 
-### Async File Deletion
+A recurring theme this sprint was intentional use of mock data on the frontend while backend endpoints are still being developed. This allowed UI work to move forward in parallel without blocking on API availability. Luca led the dashboard and library UI, Nathaniel completed the study guide view, and David contributed the file rename API.
 
-Instead of deleting files synchronously in the API handler, we implemented a worker-based flow. The API marks the file for deletion and enqueues a job. A background worker picks it up and handles the actual cleanup. This keeps API response times predictable and sets a pattern we can reuse for other heavy operations like file processing.
-
-### Soft Deletes
-
-Files are now soft-deleted rather than permanently removed. The repository layer filters out deleted records by default, but they remain in the database for recovery. This is a safer pattern for user-facing delete operations.
-
-### OpenAPI as Source of Truth
-
-We migrated from hand-written API documentation to auto-generated docs from our OpenAPI spec. The Docusaurus site now pulls API reference content directly from the spec, so docs stay accurate as endpoints change.
+All four pieces of work are in review via open pull requests and pending final merge — no actively worked issues were left incomplete.
 
 ## What's Next
 
-Sprint 3 will focus on closing the loop on features that are in progress and building out the content pipeline:
+Sprint 3 will focus on wiring frontend to real backend data and tackling the CRUD backlog:
 
-- Merge open PRs for dashboard, study guide view, library, and file renaming
-- File upload pipeline via Garage (S3-compatible storage)
-- Course and study guide CRUD operations
-- Connecting frontend pages to live API data
+- Connect frontend pages to live API endpoints as coverage grows
+- Begin course and study guide CRUD operations
+- Address code review feedback on open PRs before opening new ones
+- Run linters and formatters locally to reduce avoidable CI failures
 
 For the full sprint report with issue details, see the [Sprint 2 Review](/docs/sprint-reviews/sprint-2).

--- a/docs/blog/2026-04-04-sprint-2-recap.md
+++ b/docs/blog/2026-04-04-sprint-2-recap.md
@@ -1,0 +1,44 @@
+---
+slug: sprint-2-recap
+title: "Sprint 2: Building the Core Experience"
+authors: [askatlas]
+tags: [sprint]
+---
+
+Sprint 2 focused on turning our foundation into something users can actually interact with — file management, study guide views, and a real dashboard.
+
+<!-- truncate -->
+
+## What We Built
+
+Building on Sprint 1's infrastructure, we shipped:
+
+- **File deletion with async workers** — DELETE endpoint queues work to a background worker instead of blocking the request. Files are soft-deleted for recoverability.
+- **File renaming** — PATCH endpoint for updating file metadata, starting with the ability to rename files.
+- **Auto-generated API docs** — Migrated from manually maintained API reference files to OpenAPI-generated documentation that stays in sync with the codebase.
+- **Dashboard, Study Guide View, and Library UIs** — Three major frontend pages progressed from design to implementation, though still being connected to live data.
+
+## Architecture Highlights
+
+### Async File Deletion
+
+Instead of deleting files synchronously in the API handler, we implemented a worker-based flow. The API marks the file for deletion and enqueues a job. A background worker picks it up and handles the actual cleanup. This keeps API response times predictable and sets a pattern we can reuse for other heavy operations like file processing.
+
+### Soft Deletes
+
+Files are now soft-deleted rather than permanently removed. The repository layer filters out deleted records by default, but they remain in the database for recovery. This is a safer pattern for user-facing delete operations.
+
+### OpenAPI as Source of Truth
+
+We migrated from hand-written API documentation to auto-generated docs from our OpenAPI spec. The Docusaurus site now pulls API reference content directly from the spec, so docs stay accurate as endpoints change.
+
+## What's Next
+
+Sprint 3 will focus on closing the loop on features that are in progress and building out the content pipeline:
+
+- Merge open PRs for dashboard, study guide view, library, and file renaming
+- File upload pipeline via Garage (S3-compatible storage)
+- Course and study guide CRUD operations
+- Connecting frontend pages to live API data
+
+For the full sprint report with issue details, see the [Sprint 2 Review](/docs/sprint-reviews/sprint-2).

--- a/docs/docs/sprint-reviews/sprint-2.md
+++ b/docs/docs/sprint-reviews/sprint-2.md
@@ -4,6 +4,8 @@ sidebar_position: 2
 
 # Sprint 2 Report (03/01/26 – 04/04/26)
 
+[**Sprint demo video**](https://youtu.be/VIqZRLF_-vU)
+
 ## What's New (User Facing)
 
 - **Dashboard Redesign** — Dashboard redesign with metrics cards, recent study guides list, and activity history sidebar

--- a/docs/docs/sprint-reviews/sprint-2.md
+++ b/docs/docs/sprint-reviews/sprint-2.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 2
+---
+
+# Sprint 2 Report (03/02/26 – 04/04/26)
+
+[**Sprint demo video**](TODO)
+
+## What's New (User Facing)
+
+- **File Deletion** — Users can now delete files they own, with soft-delete support so files can be recovered if needed
+- **File Renaming** — Users can rename their uploaded files via the updated file management interface
+- **Study Guide View** — New dedicated page for viewing study guides with feature components for an improved reading experience
+- **Dashboard Redesign** — Redesigned authenticated dashboard with statistics cards (total study guides, completed quizzes, study streak), activity timeline, and recent study guide viewer
+- **Resource Library UI** — New library interface for browsing and discovering shared resources
+
+## Work Summary (Developer Facing)
+
+This sprint focused on building out core CRUD operations and user-facing pages on top of the foundation established in Sprint 1.
+
+On the backend, we implemented the DELETE endpoint for files with an asynchronous worker flow — deletion requests are queued and processed by a background worker, keeping the API responsive. The file repository was updated with soft-delete support so records are marked as deleted rather than permanently removed. We also added a PATCH endpoint for updating file metadata (renaming). A major infrastructure improvement was migrating the API documentation from manually maintained files to auto-generated content using OpenAPI specs, which keeps docs in sync with the actual API surface.
+
+On the frontend, significant progress was made on three key pages: the authenticated dashboard with real UI components (stat cards, activity timeline, recent study guides), the study guide view page, and the resource library. These pages are still being connected to live data but the UI and interaction patterns are in place.
+
+CI/CD was improved by scoping temporary script directories to individual workflow runs, preventing conflicts in parallel builds. Backend Go source code documentation was automated, reducing manual upkeep.
+
+## Completed Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#48](https://github.com/Ask-Atlas/AskAtlas/issues/48) | API - DELETE /api/files/:id |
+| [PR #52](https://github.com/Ask-Atlas/AskAtlas/pull/52) | Migrate API service to OpenAPI |
+| [PR #54](https://github.com/Ask-Atlas/AskAtlas/pull/54) | CI: scope temporary script directories to prevent conflicts |
+| [PR #56](https://github.com/Ask-Atlas/AskAtlas/pull/56) | Automate backend Go API documentation |
+
+## In Progress
+
+| Issue | PR | Description |
+|-------|-----|-------------|
+| [#6](https://github.com/Ask-Atlas/AskAtlas/issues/6) / [#7](https://github.com/Ask-Atlas/AskAtlas/issues/7) | [#57](https://github.com/Ask-Atlas/AskAtlas/pull/57) | Dashboard UI/UX design and implementation |
+| [#15](https://github.com/Ask-Atlas/AskAtlas/issues/15) | [#62](https://github.com/Ask-Atlas/AskAtlas/pull/62) | Study guide view page and feature components |
+| [#61](https://github.com/Ask-Atlas/AskAtlas/issues/61) | [#63](https://github.com/Ask-Atlas/AskAtlas/pull/63) | API - PATCH /files/{file_id} (update file metadata) |
+| [#19](https://github.com/Ask-Atlas/AskAtlas/issues/19) | [#64](https://github.com/Ask-Atlas/AskAtlas/pull/64) | Library UI/UX design |
+
+## Planned for Future Sprints
+
+| Issue | Description |
+|-------|-------------|
+| [#60](https://github.com/Ask-Atlas/AskAtlas/issues/60) | API - POST /api/files (create file reference + presigned upload) |
+| [#47](https://github.com/Ask-Atlas/AskAtlas/issues/47) | API - POST/DELETE /api/files/{file_id}/grants (manage file grants) |
+| [#45](https://github.com/Ask-Atlas/AskAtlas/issues/45) | Migration - Course & Study Guide Join Tables |
+| [#17](https://github.com/Ask-Atlas/AskAtlas/issues/17) | CRUD for library resources |
+| [#14](https://github.com/Ask-Atlas/AskAtlas/issues/14) | CRUD for Quizzes |
+| [#13](https://github.com/Ask-Atlas/AskAtlas/issues/13) | Scrape Wazzu for Courses |
+| [#12](https://github.com/Ask-Atlas/AskAtlas/issues/12) | CRUD for study guides |
+| [#11](https://github.com/Ask-Atlas/AskAtlas/issues/11) | Scrape Wazzu for courses |
+| [#10](https://github.com/Ask-Atlas/AskAtlas/issues/10) | CRUD for Courses |
+| [#9](https://github.com/Ask-Atlas/AskAtlas/issues/9) | CRUD Operations API Users |
+
+## Retrospective
+
+### What went well
+- Established async worker pattern for file deletion — sets a reusable pattern for future background processing
+- Automated API documentation keeps docs in sync without manual effort
+- Multiple frontend pages progressed in parallel across team members
+- OpenAPI migration gives us a single source of truth for API contracts
+
+### What we'd like to improve
+- Several PRs remain open at sprint end — need tighter scoping or earlier merges
+- Frontend pages need to be connected to real backend data sooner in the development cycle
+- More issues should have been formally tracked — some work (OpenAPI migration, CI fixes) was done as PRs without corresponding GitHub issues
+
+### Changes for next sprint
+- Set mid-sprint checkpoints to identify PRs at risk of not merging by sprint end
+- Prioritize connecting frontend pages to live API endpoints
+- Create GitHub issues before starting work, even for infrastructure improvements
+- Begin implementing file upload pipeline to complete the file management feature set

--- a/docs/docs/sprint-reviews/sprint-2.md
+++ b/docs/docs/sprint-reviews/sprint-2.md
@@ -2,76 +2,78 @@
 sidebar_position: 2
 ---
 
-# Sprint 2 Report (03/02/26 – 04/04/26)
-
-[**Sprint demo video**](TODO)
+# Sprint 2 Report (03/01/26 – 04/04/26)
 
 ## What's New (User Facing)
 
-- **File Deletion** — Users can now delete files they own, with soft-delete support so files can be recovered if needed
-- **File Renaming** — Users can rename their uploaded files via the updated file management interface
-- **Study Guide View** — New dedicated page for viewing study guides with feature components for an improved reading experience
-- **Dashboard Redesign** — Redesigned authenticated dashboard with statistics cards (total study guides, completed quizzes, study streak), activity timeline, and recent study guide viewer
-- **Resource Library UI** — New library interface for browsing and discovering shared resources
+- **Dashboard Redesign** — Dashboard redesign with metrics cards, recent study guides list, and activity history sidebar
+- **Study Guide View** — Study Guide View page displaying guide details, linked quizzes, and referenced resources
+- **Resource Library** — Library page with document upload, drag-and-drop file management, and list/grid view toggle
+- **File Renaming** — File rename capability allowing users to update document names
 
 ## Work Summary (Developer Facing)
 
-This sprint focused on building out core CRUD operations and user-facing pages on top of the foundation established in Sprint 1.
+This sprint focused on building out the core user-facing features of AskAtlas now that the foundational infrastructure from Sprint 1 was in place. Luca led frontend efforts, delivering both the redesigned dashboard and the library UI, which includes drag-and-drop uploads, document previews, and course filtering. Nathaniel completed the study guide view page, implementing a dynamic route with mock data standing in until the study guide API is ready. David contributed on the backend with a new PATCH endpoint for renaming files, complete with input validation, ownership checks, and full test coverage. All four pieces of work are in review via open pull requests and are pending final merge. A recurring theme this sprint was intentional use of mock data on the frontend while backend endpoints are still being developed, which allowed UI work to move forward in parallel without blocking on API availability.
 
-On the backend, we implemented the DELETE endpoint for files with an asynchronous worker flow — deletion requests are queued and processed by a background worker, keeping the API responsive. The file repository was updated with soft-delete support so records are marked as deleted rather than permanently removed. We also added a PATCH endpoint for updating file metadata (renaming). A major infrastructure improvement was migrating the API documentation from manually maintained files to auto-generated content using OpenAPI specs, which keeps docs in sync with the actual API surface.
+## Unfinished Work
 
-On the frontend, significant progress was made on three key pages: the authenticated dashboard with real UI components (stat cards, activity timeline, recent study guides), the study guide view page, and the resource library. These pages are still being connected to live data but the UI and interaction patterns are in place.
+No issues that were actively worked on this sprint were left incomplete. The open pull requests represent finished work currently under code review, not abandoned work. Several backlog issues remain unstarted and have been carried into future sprints as the team continues to prioritize core MVP features.
 
-CI/CD was improved by scoping temporary script directories to individual workflow runs, preventing conflicts in parallel builds. Backend Go source code documentation was automated, reducing manual upkeep.
-
-## Completed Issues
+## Completed Issues/User Stories
 
 | Issue | Description |
 |-------|-------------|
-| [#48](https://github.com/Ask-Atlas/AskAtlas/issues/48) | API - DELETE /api/files/:id |
-| [PR #52](https://github.com/Ask-Atlas/AskAtlas/pull/52) | Migrate API service to OpenAPI |
-| [PR #54](https://github.com/Ask-Atlas/AskAtlas/pull/54) | CI: scope temporary script directories to prevent conflicts |
-| [PR #56](https://github.com/Ask-Atlas/AskAtlas/pull/56) | Automate backend Go API documentation |
+| [#6](https://github.com/Ask-Atlas/AskAtlas/issues/6) | UI/UX design for the dashboard |
+| [#15](https://github.com/Ask-Atlas/AskAtlas/issues/15) | Design and implement the UI/UX for the Study Guide View |
+| [#19](https://github.com/Ask-Atlas/AskAtlas/issues/19) | UI/UX design for the library |
+| [#61](https://github.com/Ask-Atlas/AskAtlas/issues/61) | API - PATCH /api/files/{file_id} (update file metadata) |
 
-## In Progress
+## Incomplete Issues/User Stories
 
-| Issue | PR | Description |
-|-------|-----|-------------|
-| [#6](https://github.com/Ask-Atlas/AskAtlas/issues/6) / [#7](https://github.com/Ask-Atlas/AskAtlas/issues/7) | [#57](https://github.com/Ask-Atlas/AskAtlas/pull/57) | Dashboard UI/UX design and implementation |
-| [#15](https://github.com/Ask-Atlas/AskAtlas/issues/15) | [#62](https://github.com/Ask-Atlas/AskAtlas/pull/62) | Study guide view page and feature components |
-| [#61](https://github.com/Ask-Atlas/AskAtlas/issues/61) | [#63](https://github.com/Ask-Atlas/AskAtlas/pull/63) | API - PATCH /files/{file_id} (update file metadata) |
-| [#19](https://github.com/Ask-Atlas/AskAtlas/issues/19) | [#64](https://github.com/Ask-Atlas/AskAtlas/pull/64) | Library UI/UX design |
+| Issue | Reason |
+|-------|--------|
+| [#48](https://github.com/Ask-Atlas/AskAtlas/issues/48) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
+| [#47](https://github.com/Ask-Atlas/AskAtlas/issues/47) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
+| [#45](https://github.com/Ask-Atlas/AskAtlas/issues/45) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
+| [#17](https://github.com/Ask-Atlas/AskAtlas/issues/17) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
+| [#14](https://github.com/Ask-Atlas/AskAtlas/issues/14) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
+| [#13](https://github.com/Ask-Atlas/AskAtlas/issues/13) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
+| [#12](https://github.com/Ask-Atlas/AskAtlas/issues/12) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
+| [#11](https://github.com/Ask-Atlas/AskAtlas/issues/11) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
+| [#10](https://github.com/Ask-Atlas/AskAtlas/issues/10) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
+| [#9](https://github.com/Ask-Atlas/AskAtlas/issues/9) | We prioritized core UI features this sprint and plan to address this in Sprint 3. |
 
-## Planned for Future Sprints
+## Code Files for Review
 
-| Issue | Description |
-|-------|-------------|
-| [#60](https://github.com/Ask-Atlas/AskAtlas/issues/60) | API - POST /api/files (create file reference + presigned upload) |
-| [#47](https://github.com/Ask-Atlas/AskAtlas/issues/47) | API - POST/DELETE /api/files/{file_id}/grants (manage file grants) |
-| [#45](https://github.com/Ask-Atlas/AskAtlas/issues/45) | Migration - Course & Study Guide Join Tables |
-| [#17](https://github.com/Ask-Atlas/AskAtlas/issues/17) | CRUD for library resources |
-| [#14](https://github.com/Ask-Atlas/AskAtlas/issues/14) | CRUD for Quizzes |
-| [#13](https://github.com/Ask-Atlas/AskAtlas/issues/13) | Scrape Wazzu for Courses |
-| [#12](https://github.com/Ask-Atlas/AskAtlas/issues/12) | CRUD for study guides |
-| [#11](https://github.com/Ask-Atlas/AskAtlas/issues/11) | Scrape Wazzu for courses |
-| [#10](https://github.com/Ask-Atlas/AskAtlas/issues/10) | CRUD for Courses |
-| [#9](https://github.com/Ask-Atlas/AskAtlas/issues/9) | CRUD Operations API Users |
+Please review the following code files, which were actively developed during this sprint, for quality:
+
+| File | Description |
+|------|-------------|
+| `home/page.tsx` | Redesigned dashboard page with metrics, study guide list, and activity sidebar |
+| `study-guide-view.tsx` | Study guide view feature component |
+| `resources/page.tsx` | Library document management page |
+| `resources/upload/page.tsx` | File upload hub with drag-and-drop |
+| `files/service.go` | File rename service with validation and ownership checks |
 
 ## Retrospective
 
 ### What went well
-- Established async worker pattern for file deletion — sets a reusable pattern for future background processing
-- Automated API documentation keeps docs in sync without manual effort
-- Multiple frontend pages progressed in parallel across team members
-- OpenAPI migration gives us a single source of truth for API contracts
+- Parallel development between frontend UI and backend API worked well this sprint — UI work wasn't blocked waiting on endpoints
+- Strong individual ownership over features made progress clear and reduced coordination overhead
+- David's backend PR came in with thorough test coverage and clean validation logic from the start
+- The team had a clearer sense of scope going into this sprint compared to Sprint 1
 
 ### What we'd like to improve
-- Several PRs remain open at sprint end — need tighter scoping or earlier merges
-- Frontend pages need to be connected to real backend data sooner in the development cycle
-- More issues should have been formally tracked — some work (OpenAPI migration, CI fixes) was done as PRs without corresponding GitHub issues
+- PRs should be opened and reviewed earlier in the sprint rather than clustering near the deadline
+- Some frontend components still have mock data and TODOs that need to be tracked so they don't get forgotten
+- CI failures on some PRs (formatting, typecheck) should be caught locally before pushing
 
 ### Changes for next sprint
-- Set mid-sprint checkpoints to identify PRs at risk of not merging by sprint end
-- Prioritize connecting frontend pages to live API endpoints
-- Create GitHub issues before starting work, even for infrastructure improvements
-- Begin implementing file upload pipeline to complete the file management feature set
+- Begin wiring frontend components to real backend endpoints as API coverage grows
+- Address code review feedback on open PRs before opening new ones
+- Run linters and formatters locally as a habit before pushing to cut down on avoidable CI failures
+- Begin tackling CRUD backlog issues now that UI foundations are in place
+
+## Sprint Demo Video
+
+[Link TBD]


### PR DESCRIPTION
Add sprint review page covering completed work (file deletion API, OpenAPI migration, automated docs, CI improvements) and in-progress items (dashboard, study guide view, library UI, file renaming). Include corresponding blog post recap.

## Description

<!-- Brief summary of what this PR does and why. Reference the issue it closes. -->

Closes #

---

## Type of change

- [ ] New feature (non-breaking)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / chore

---

## Changes

<!-- Group changes by area (e.g., Auth, Files domain, Infrastructure). Be specific about what was added, modified, or removed. -->

---

## How has this been tested?

<!-- Describe the tests you ran. Include unit, integration, and/or E2E tests as applicable. -->

---

## Checklist

- [ ] Self-reviewed code
- [ ] Added/updated tests
- [ ] No new warnings introduced
- [ ] `go mod tidy` / `pnpm install` verified (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced dashboard redesign (metrics cards, recent guides, activity sidebar)
  * Study guide view with linked quizzes and referenced resources
  * Resource library: uploads with drag-and-drop, file management, list/grid toggle
  * File renaming with validation

* **Documentation**
  * Published Sprint 2 recap blog post
  * Added Sprint 2 review page summarizing scope, status, and next steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->