### PR TITLE
docs: remove redundant TBD video section from Sprint 2 report

### DIFF
--- a/docs/docs/sprint-reviews/sprint-2.md
+++ b/docs/docs/sprint-reviews/sprint-2.md
@@ -75,7 +75,3 @@ Please review the following code files, which were actively developed during thi
 - Address code review feedback on open PRs before opening new ones
 - Run linters and formatters locally as a habit before pushing to cut down on avoidable CI failures
 - Begin tackling CRUD backlog issues now that UI foundations are in place
-
-## Sprint Demo Video
-
-[Link TBD]


### PR DESCRIPTION
## Summary
- Removes the trailing "Sprint Demo Video / Link TBD" section since the video link is already at the top of the report

## Test plan
- [ ] Verify Sprint 2 report renders correctly with video link at top and no TBD section at bottom