### PR TITLE
fix(handlers): reject malformed JSON on JoinSection + review nits

### DIFF
--- a/api/internal/courses/service.go
+++ b/api/internal/courses/service.go
@@ -398,6 +398,10 @@ func (s *Service) GetCourse(ctx context.Context, p GetCourseParams) (CourseDetai
 // SQL means a duplicate join surfaces as sql.ErrNoRows; we map that to a
 // tailored 409 AppError so the handler returns "Already a member of this
 // section" verbatim.
+//
+// We construct a typed *AppError instead of returning apperrors.ErrConflict
+// because the shared sentinel maps to the generic message "Resource already
+// exists" -- the spec for ASK-132 requires the more specific phrasing.
 func (s *Service) JoinSection(ctx context.Context, p JoinSectionParams) (Membership, error) {
 	if err := s.assertCourseAndSection(ctx, p.CourseID, p.SectionID); err != nil {
 		return Membership{}, err

--- a/api/internal/courses/service_test.go
+++ b/api/internal/courses/service_test.go
@@ -491,10 +491,10 @@ func TestDecodeCursor_BadInput(t *testing.T) {
 // JoinSection / LeaveSection (ASK-132 / ASK-138)
 // =====================================================================
 
-// expectAssertHelpers wires the two preflight existence probes used by
-// both JoinSection and LeaveSection. Pulling this out keeps the per-AC
-// tests focused on the case under test instead of repeating six lines of
-// repo wiring.
+// expectAssertOK wires the two preflight existence probes used by both
+// JoinSection and LeaveSection. Pulling this out keeps the per-AC tests
+// focused on the case under test instead of repeating six lines of repo
+// wiring.
 func expectAssertOK(repo *mock_courses.MockRepository, courseID, sectionID uuid.UUID) {
 	repo.EXPECT().
 		CourseExists(mock.Anything, utils.UUID(courseID)).
@@ -590,7 +590,13 @@ func TestService_JoinSection_CourseNotFound(t *testing.T) {
 	assert.Equal(t, "Course not found", appErr.Message)
 }
 
-func TestService_JoinSection_SectionNotFoundOrCrossCourse(t *testing.T) {
+// Covers ASK-132 AC #4 (section does not exist) and AC #5 (section
+// exists under a *different* course than the URL's course_id). Both
+// surface the same way at the repo seam: SectionInCourseExists returns
+// false. The 404 message is intentionally identical for both cases so
+// the URL path can't be used to probe for sections under unrelated
+// courses.
+func TestService_JoinSection_SectionNotFoundOrCrossCoursePath(t *testing.T) {
 	repo := mock_courses.NewMockRepository(t)
 
 	courseID := uuid.New()
@@ -618,10 +624,8 @@ func TestService_JoinSection_SectionNotFoundOrCrossCourse(t *testing.T) {
 
 func TestService_JoinSection_RepoErrorPropagates(t *testing.T) {
 	repo := mock_courses.NewMockRepository(t)
-	expectAssertOK(repo, uuid.Nil, uuid.Nil)
-	// Override the assert wiring to use Anything so the test does not over-couple to ID values.
-	// (mockery records all expectations; the explicit matchers above accept the zero IDs.)
-
+	repo.EXPECT().CourseExists(mock.Anything, mock.Anything).Return(true, nil)
+	repo.EXPECT().SectionInCourseExists(mock.Anything, mock.Anything).Return(true, nil)
 	repo.EXPECT().
 		JoinSection(mock.Anything, mock.Anything).
 		Return(db.CourseMember{}, errors.New("boom"))

--- a/api/internal/handlers/courses.go
+++ b/api/internal/handlers/courses.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -133,12 +135,19 @@ func (h *CoursesHandler) GetCourse(w http.ResponseWriter, r *http.Request, cours
 }
 
 // JoinSection handles POST /courses/{course_id}/sections/{section_id}/members.
-// The viewer joins the section as a 'student'. Any fields in the request
-// body are intentionally ignored; the role is enforced by the service +
-// SQL layer to prevent privilege escalation via {"role": "instructor"}.
+// The viewer joins the section as a 'student'. Any *fields* in the request
+// body are intentionally ignored -- the role is enforced by the service +
+// SQL layer to prevent privilege escalation via {"role": "instructor"} --
+// but malformed JSON is still rejected with 400 per the spec, so we
+// shallow-parse the body when one is provided.
 func (h *CoursesHandler) JoinSection(w http.ResponseWriter, r *http.Request, courseId openapi_types.UUID, sectionId openapi_types.UUID) {
 	viewerID, appErr := viewerIDFromContext(r)
 	if appErr != nil {
+		apperrors.RespondWithError(w, appErr)
+		return
+	}
+
+	if appErr := validateJoinSectionBody(r); appErr != nil {
 		apperrors.RespondWithError(w, appErr)
 		return
 	}
@@ -158,6 +167,30 @@ func (h *CoursesHandler) JoinSection(w http.ResponseWriter, r *http.Request, cou
 	}
 
 	respondJSON(w, http.StatusCreated, mapCourseMemberResponse(membership))
+}
+
+// validateJoinSectionBody enforces the ASK-132 input-validation contract
+// for the POST body: empty body / missing Content-Type / `{}` / unknown
+// fields are all accepted, but a non-empty body that does not parse as
+// JSON returns 400 VALIDATION_ERROR. We decode into an empty struct so
+// any *fields* present in valid JSON are silently dropped -- the role is
+// enforced by the SQL layer regardless.
+func validateJoinSectionBody(r *http.Request) *apperrors.AppError {
+	if r.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return apperrors.NewBadRequest("Invalid request body", nil)
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	var ignored struct{}
+	if err := json.Unmarshal(body, &ignored); err != nil {
+		return apperrors.NewBadRequest("Invalid request body", nil)
+	}
+	return nil
 }
 
 // LeaveSection handles DELETE /courses/{course_id}/sections/{section_id}/members/me.

--- a/api/internal/handlers/courses_test.go
+++ b/api/internal/handlers/courses_test.go
@@ -378,6 +378,53 @@ func TestCoursesHandler_JoinSection_IgnoresUnexpectedBodyFields(t *testing.T) {
 	assert.Equal(t, api.Student, resp.Role)
 }
 
+// Per ASK-132 input-validation table: malformed JSON in the body must
+// surface as 400 even though valid JSON with unexpected fields is
+// accepted. NewMockCourseService(t) would fail on an unexpected call,
+// proving the handler rejects before reaching the service.
+func TestCoursesHandler_JoinSection_MalformedJSONBody(t *testing.T) {
+	mockSvc := mock_handlers.NewMockCourseService(t)
+	h := handlers.NewCoursesHandler(mockSvc)
+
+	url := fmt.Sprintf("/courses/%s/sections/%s/members", uuid.NewString(), uuid.NewString())
+	body := strings.NewReader(`{invalid`)
+	req := authedRequestMethod(t, http.MethodPost, url, body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r := coursesTestRouter(t, h)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid request body")
+}
+
+// Empty body is the documented default and must succeed -- regression
+// guard for the malformed-JSON fix above so the body-decode path doesn't
+// accidentally reject the documented happy case.
+func TestCoursesHandler_JoinSection_EmptyBodyAccepted(t *testing.T) {
+	mockSvc := mock_handlers.NewMockCourseService(t)
+	h := handlers.NewCoursesHandler(mockSvc)
+
+	mockSvc.EXPECT().
+		JoinSection(mock.Anything, mock.Anything).
+		Return(courses.Membership{
+			UserID:    uuid.New(),
+			SectionID: uuid.New(),
+			Role:      courses.MemberRoleStudent,
+			JoinedAt:  time.Now().UTC(),
+		}, nil)
+
+	url := fmt.Sprintf("/courses/%s/sections/%s/members", uuid.NewString(), uuid.NewString())
+	req := authedRequestMethod(t, http.MethodPost, url, nil)
+	w := httptest.NewRecorder()
+
+	r := coursesTestRouter(t, h)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
 func TestCoursesHandler_JoinSection_AlreadyMember(t *testing.T) {
 	mockSvc := mock_handlers.NewMockCourseService(t)
 	h := handlers.NewCoursesHandler(mockSvc)


### PR DESCRIPTION
Follow-up to #132 addressing the medium + low findings from the self-review.

## Summary
- **Medium (fix)**: ASK-132's input-validation table lists *malformed JSON body → 400*. The original handler intentionally never decoded the body to keep the unknown-field-ignoring behavior, so \`{invalid\` was silently accepted as a no-op and returned 201. Adds a small \`validateJoinSectionBody\` helper that reads the body once, short-circuits empty/missing bodies, and runs \`json.Unmarshal\` into an empty struct so any *fields* are still ignored but a parse failure now yields 400. Two new handler tests pin the contract pair: \`MalformedJSONBody\` and \`EmptyBodyAccepted\`.
- **Low (cosmetic/clarity)**:
  - Fix the comment header on \`expectAssertOK\` (was \`expectAssertHelpers\`).
  - Drop the misleading "Override the assert wiring" comment in \`TestService_JoinSection_RepoErrorPropagates\` and replace the \`expectAssertOK(uuid.Nil, uuid.Nil)\` setup with explicit \`mock.Anything\` matchers matching the comment's intent.
  - Rename \`TestService_JoinSection_SectionNotFoundOrCrossCourse\` to \`*_CrossCoursePath\` and add a comment that explicitly references AC #4 (section absent) and AC #5 (section under wrong course).
  - Add a paragraph to \`JoinSection\`'s doc comment explaining why we hand-build a typed \`*AppError\` instead of returning \`apperrors.ErrConflict\` (the sentinel's generic message would lose the spec-mandated phrasing).

## Out of scope
- The 3-roundtrip → 1 CTE optimization. PK-indexed lookups make latency impact negligible at MVP scale; revisit only if join/leave become hot paths.

## Test plan
- [x] \`go test -race ./...\` green locally
- [x] \`make lint\` clean
- [ ] Dev + stage GitHub Actions deploys green
- [ ] Re-run the join/leave matrix on staging:
  - 201 join → 409 re-join → 204 leave → 404 re-leave (regression)
  - **NEW**: \`POST … -d '{invalid'\` returns 400 with "Invalid request body"
  - **NEW**: \`POST …\` with no body / empty body / Content-Type unset still returns 201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JoinSection endpoint now validates request body and returns HTTP 400 for malformed JSON while accepting empty bodies.

* **Tests**
  * Added tests for request body validation behavior in JoinSection endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->