### PR TITLE
refactor(studyguides): adopt shared utils cursor helpers + dedupe package doc

### DIFF
--- a/api/internal/studyguides/service.go
+++ b/api/internal/studyguides/service.go
@@ -1,6 +1,6 @@
-// Package studyguides hosts the domain types, params, mappers, and
-// service logic for the study-guide surface. The service layer is
-// split across four files in this package:
+package studyguides
+
+// The service layer for this package is split across four files:
 //
 //   - service.go       (this file) -- Repository interface, Service
 //                                     struct, constructor.
@@ -12,10 +12,8 @@
 //                         CastVote, RemoveVote, RecommendStudyGuide,
 //                         RemoveRecommendation + write-side helpers.
 //
-// Keeping the read / list / write surfaces in separate files is purely
-// a maintenance split -- they all live on the same *Service and share
-// the same Repository interface. Tests stay in service_test.go.
-package studyguides
+// The canonical `// Package studyguides ...` doc comment lives in
+// model.go (Go expects exactly one package-level doc per package).
 
 import (
 	"context"

--- a/api/internal/studyguides/service_list.go
+++ b/api/internal/studyguides/service_list.go
@@ -181,40 +181,6 @@ func mapListRows[R any](rows []R, project func(R) sharedGuideRow) ([]StudyGuide,
 	return out, nil
 }
 
-// cursor pgtype helpers unwrap the pointer fields on Cursor into
-// pgtype values for the sqlc narg args. Return a zero (invalid)
-// pgtype when the cursor is absent or the relevant field is unset,
-// which is how the SQL predicates short-circuit to "no cursor applied".
-
-func cursorInt64(c *Cursor, field func(*Cursor) *int64) pgtype.Int8 {
-	if c == nil {
-		return pgtype.Int8{}
-	}
-	v := field(c)
-	if v == nil {
-		return pgtype.Int8{}
-	}
-	return pgtype.Int8{Int64: *v, Valid: true}
-}
-
-func cursorTimestamp(c *Cursor, field func(*Cursor) *time.Time) pgtype.Timestamptz {
-	if c == nil {
-		return pgtype.Timestamptz{}
-	}
-	v := field(c)
-	if v == nil {
-		return pgtype.Timestamptz{}
-	}
-	return pgtype.Timestamptz{Time: *v, Valid: true}
-}
-
-func cursorID(c *Cursor) pgtype.UUID {
-	if c == nil {
-		return pgtype.UUID{}
-	}
-	return utils.UUID(c.ID)
-}
-
 // Per-sort-variant query methods. Each builds the typed *Params struct,
 // calls the matching repository method, and projects the rows through
 // the shared mapper.
@@ -225,10 +191,10 @@ func (s *Service) queryScoreDesc(ctx context.Context, f dbFilters, limit int32) 
 		Q:               f.Q,
 		Tags:            f.Tags,
 		PageLimit:       limit,
-		CursorVoteScore: cursorInt64(f.Cursor, func(c *Cursor) *int64 { return c.VoteScore }),
-		CursorViewCount: cursorInt64(f.Cursor, func(c *Cursor) *int64 { return c.ViewCount }),
-		CursorUpdatedAt: cursorTimestamp(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
-		CursorID:        cursorID(f.Cursor),
+		CursorVoteScore: utils.CursorInt8(f.Cursor, func(c *Cursor) *int64 { return c.VoteScore }),
+		CursorViewCount: utils.CursorInt8(f.Cursor, func(c *Cursor) *int64 { return c.ViewCount }),
+		CursorUpdatedAt: utils.CursorTimestamptz(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
+		CursorID:        utils.CursorUUID(f.Cursor, func(c *Cursor) [16]byte { return c.ID }),
 	})
 	if err != nil {
 		return nil, err
@@ -242,10 +208,10 @@ func (s *Service) queryScoreAsc(ctx context.Context, f dbFilters, limit int32) (
 		Q:               f.Q,
 		Tags:            f.Tags,
 		PageLimit:       limit,
-		CursorVoteScore: cursorInt64(f.Cursor, func(c *Cursor) *int64 { return c.VoteScore }),
-		CursorViewCount: cursorInt64(f.Cursor, func(c *Cursor) *int64 { return c.ViewCount }),
-		CursorUpdatedAt: cursorTimestamp(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
-		CursorID:        cursorID(f.Cursor),
+		CursorVoteScore: utils.CursorInt8(f.Cursor, func(c *Cursor) *int64 { return c.VoteScore }),
+		CursorViewCount: utils.CursorInt8(f.Cursor, func(c *Cursor) *int64 { return c.ViewCount }),
+		CursorUpdatedAt: utils.CursorTimestamptz(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
+		CursorID:        utils.CursorUUID(f.Cursor, func(c *Cursor) [16]byte { return c.ID }),
 	})
 	if err != nil {
 		return nil, err
@@ -259,9 +225,9 @@ func (s *Service) queryViewsDesc(ctx context.Context, f dbFilters, limit int32) 
 		Q:               f.Q,
 		Tags:            f.Tags,
 		PageLimit:       limit,
-		CursorViewCount: cursorInt64(f.Cursor, func(c *Cursor) *int64 { return c.ViewCount }),
-		CursorUpdatedAt: cursorTimestamp(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
-		CursorID:        cursorID(f.Cursor),
+		CursorViewCount: utils.CursorInt8(f.Cursor, func(c *Cursor) *int64 { return c.ViewCount }),
+		CursorUpdatedAt: utils.CursorTimestamptz(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
+		CursorID:        utils.CursorUUID(f.Cursor, func(c *Cursor) [16]byte { return c.ID }),
 	})
 	if err != nil {
 		return nil, err
@@ -275,9 +241,9 @@ func (s *Service) queryViewsAsc(ctx context.Context, f dbFilters, limit int32) (
 		Q:               f.Q,
 		Tags:            f.Tags,
 		PageLimit:       limit,
-		CursorViewCount: cursorInt64(f.Cursor, func(c *Cursor) *int64 { return c.ViewCount }),
-		CursorUpdatedAt: cursorTimestamp(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
-		CursorID:        cursorID(f.Cursor),
+		CursorViewCount: utils.CursorInt8(f.Cursor, func(c *Cursor) *int64 { return c.ViewCount }),
+		CursorUpdatedAt: utils.CursorTimestamptz(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
+		CursorID:        utils.CursorUUID(f.Cursor, func(c *Cursor) [16]byte { return c.ID }),
 	})
 	if err != nil {
 		return nil, err
@@ -291,8 +257,8 @@ func (s *Service) queryNewestDesc(ctx context.Context, f dbFilters, limit int32)
 		Q:               f.Q,
 		Tags:            f.Tags,
 		PageLimit:       limit,
-		CursorCreatedAt: cursorTimestamp(f.Cursor, func(c *Cursor) *time.Time { return c.CreatedAt }),
-		CursorID:        cursorID(f.Cursor),
+		CursorCreatedAt: utils.CursorTimestamptz(f.Cursor, func(c *Cursor) *time.Time { return c.CreatedAt }),
+		CursorID:        utils.CursorUUID(f.Cursor, func(c *Cursor) [16]byte { return c.ID }),
 	})
 	if err != nil {
 		return nil, err
@@ -306,8 +272,8 @@ func (s *Service) queryNewestAsc(ctx context.Context, f dbFilters, limit int32) 
 		Q:               f.Q,
 		Tags:            f.Tags,
 		PageLimit:       limit,
-		CursorCreatedAt: cursorTimestamp(f.Cursor, func(c *Cursor) *time.Time { return c.CreatedAt }),
-		CursorID:        cursorID(f.Cursor),
+		CursorCreatedAt: utils.CursorTimestamptz(f.Cursor, func(c *Cursor) *time.Time { return c.CreatedAt }),
+		CursorID:        utils.CursorUUID(f.Cursor, func(c *Cursor) [16]byte { return c.ID }),
 	})
 	if err != nil {
 		return nil, err
@@ -321,8 +287,8 @@ func (s *Service) queryUpdatedDesc(ctx context.Context, f dbFilters, limit int32
 		Q:               f.Q,
 		Tags:            f.Tags,
 		PageLimit:       limit,
-		CursorUpdatedAt: cursorTimestamp(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
-		CursorID:        cursorID(f.Cursor),
+		CursorUpdatedAt: utils.CursorTimestamptz(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
+		CursorID:        utils.CursorUUID(f.Cursor, func(c *Cursor) [16]byte { return c.ID }),
 	})
 	if err != nil {
 		return nil, err
@@ -336,8 +302,8 @@ func (s *Service) queryUpdatedAsc(ctx context.Context, f dbFilters, limit int32)
 		Q:               f.Q,
 		Tags:            f.Tags,
 		PageLimit:       limit,
-		CursorUpdatedAt: cursorTimestamp(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
-		CursorID:        cursorID(f.Cursor),
+		CursorUpdatedAt: utils.CursorTimestamptz(f.Cursor, func(c *Cursor) *time.Time { return c.UpdatedAt }),
+		CursorID:        utils.CursorUUID(f.Cursor, func(c *Cursor) [16]byte { return c.ID }),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Follow-up to [#141](https://github.com/Ask-Atlas/AskAtlas/pull/141) addressing two automated-review findings I missed in my own self-review:

### M1 (gemini-code-assist on #141)
`cursorInt64` / `cursorTimestamp` / `cursorID` in `service_list.go` were duplicates of the generic helpers in [`api/internal/utils/cursor.go`](api/internal/utils/cursor.go) (`utils.CursorInt8`, `utils.CursorTimestamptz`, `utils.CursorUUID`). Drop the locals; swap all 22 call sites across the 8 `query*` methods.

`utils.CursorUUID` is a `func(*C) [16]byte` generic, so the closure reads `c.ID` directly (`uuid.UUID` is `[16]byte` under the hood).

### Style (copilot on #141)
Both `service.go` and `model.go` opened with `// Package studyguides ...`. Go expects exactly one package-level doc comment per package. Demote `service.go`'s preamble from a `// Package` doc to a regular file-layout note that points at `model.go` as canonical.

## Why this should have been part of #141

Both findings were pre-existing duplicates I should have consolidated **during** the file split, not after. My self-review missed them. Posting a follow-up rather than amending so the history of (a) the split and (b) the dedupe stays separable.

## Test plan

- [ ] `go build ./...` — Pass locally
- [ ] `go vet ./...` — Pass locally
- [ ] `go test -race -count=1 ./internal/studyguides/... ./internal/handlers/...` — Pass locally
- [ ] CI 8/8 green
- [ ] dev + stage deploy green (branch policy requires it)