### PR TITLE
test(api/e2e): align files.spec assertions with current API contract

### DIFF
--- a/api/e2e/tests/files.spec.ts
+++ b/api/e2e/tests/files.spec.ts
@@ -24,11 +24,14 @@ test.describe("Files API", () => {
     expect(body).toHaveProperty("files");
     expect(body).toHaveProperty("has_more");
     expect(typeof body.has_more).toBe("boolean");
-    // next_cursor is nullable + not required in the OpenAPI spec, so it
-    // may be omitted from JSON when there is no next page. When present,
-    // it must be a string (or null per the nullable schema).
-    if ("next_cursor" in body && body.next_cursor !== null) {
+    // next_cursor is logically tied to has_more: when has_more is true,
+    // a string cursor MUST be present; when false, it must be null or
+    // omitted entirely (oapi-codegen drops nullable + non-required *string
+    // via omitempty when nil).
+    if (body.has_more) {
       expect(typeof body.next_cursor).toBe("string");
+    } else {
+      expect(body.next_cursor ?? null).toBeNull();
     }
     expect(Array.isArray(body.files)).toBeTruthy();
 
@@ -62,9 +65,13 @@ test.describe("Files API", () => {
     expect(body).toHaveProperty("code", 400);
     expect(body).toHaveProperty("status", "Bad Request");
     expect(body.details).toHaveProperty("scope");
-    // kin-openapi enum violation message format.
+    // kin-openapi enum violation message format. Assert every allowed
+    // value appears in the error so the API stays honest about the full
+    // valid set, not just whichever one we sampled.
     expect(body.details.scope).toContain("is not one of the allowed values");
-    expect(body.details.scope).toContain("owned");
+    for (const v of ["owned", "course", "study_guide", "accessible"]) {
+      expect(body.details.scope).toContain(v);
+    }
   });
 
   for (const sortBy of VALID_SORTS) {
@@ -84,7 +91,9 @@ test.describe("Files API", () => {
     const body = await response.json();
     expect(body.details).toHaveProperty("sort_by");
     expect(body.details.sort_by).toContain("is not one of the allowed values");
-    expect(body.details.sort_by).toContain("updated_at");
+    for (const v of VALID_SORTS) {
+      expect(body.details.sort_by).toContain(v);
+    }
   });
 
   test("GET /files accepts valid sort_dir (asc/desc)", async ({ request }) => {
@@ -130,7 +139,9 @@ test.describe("Files API", () => {
     const body = await response.json();
     expect(body.details).toHaveProperty("status");
     expect(body.details.status).toContain("is not one of the allowed values");
-    expect(body.details.status).toContain("pending");
+    for (const v of VALID_STATUSES) {
+      expect(body.details.status).toContain(v);
+    }
   });
 
   test("GET /files rejects invalid mime_type", async ({ request }) => {

--- a/api/e2e/tests/files.spec.ts
+++ b/api/e2e/tests/files.spec.ts
@@ -23,7 +23,13 @@ test.describe("Files API", () => {
 
     expect(body).toHaveProperty("files");
     expect(body).toHaveProperty("has_more");
-    expect(body).toHaveProperty("next_cursor");
+    expect(typeof body.has_more).toBe("boolean");
+    // next_cursor is nullable + not required in the OpenAPI spec, so it
+    // may be omitted from JSON when there is no next page. When present,
+    // it must be a string (or null per the nullable schema).
+    if ("next_cursor" in body && body.next_cursor !== null) {
+      expect(typeof body.next_cursor).toBe("string");
+    }
     expect(Array.isArray(body.files)).toBeTruthy();
 
     if (body.files.length > 0) {
@@ -56,9 +62,9 @@ test.describe("Files API", () => {
     expect(body).toHaveProperty("code", 400);
     expect(body).toHaveProperty("status", "Bad Request");
     expect(body.details).toHaveProperty("scope");
-    expect(body.details.scope).toContain(
-      "must be one of: owned, course, study_guide, accessible",
-    );
+    // kin-openapi enum violation message format.
+    expect(body.details.scope).toContain("is not one of the allowed values");
+    expect(body.details.scope).toContain("owned");
   });
 
   for (const sortBy of VALID_SORTS) {
@@ -77,7 +83,8 @@ test.describe("Files API", () => {
     expect(response.status()).toBe(400);
     const body = await response.json();
     expect(body.details).toHaveProperty("sort_by");
-    expect(body.details.sort_by).toContain("must be one of: updated_at");
+    expect(body.details.sort_by).toContain("is not one of the allowed values");
+    expect(body.details.sort_by).toContain("updated_at");
   });
 
   test("GET /files accepts valid sort_dir (asc/desc)", async ({ request }) => {
@@ -99,7 +106,9 @@ test.describe("Files API", () => {
     expect(response.status()).toBe(400);
     const body = await response.json();
     expect(body.details).toHaveProperty("sort_dir");
-    expect(body.details.sort_dir).toContain("must be one of: asc, desc");
+    expect(body.details.sort_dir).toContain("is not one of the allowed values");
+    expect(body.details.sort_dir).toContain("asc");
+    expect(body.details.sort_dir).toContain("desc");
   });
 
   for (const status of VALID_STATUSES) {
@@ -120,9 +129,8 @@ test.describe("Files API", () => {
     expect(response.status()).toBe(400);
     const body = await response.json();
     expect(body.details).toHaveProperty("status");
-    expect(body.details.status).toContain(
-      "must be one of: pending, complete, failed",
-    );
+    expect(body.details.status).toContain("is not one of the allowed values");
+    expect(body.details.status).toContain("pending");
   });
 
   test("GET /files rejects invalid mime_type", async ({ request }) => {


### PR DESCRIPTION
## Summary
- The 5 \`tests/files.spec.ts\` failures against staging were test-side, not API bugs.
- 4 of the 5 asserted on a \`\"must be one of: ...\"\` error wording the API never produced; the API uses \`kin-openapi\`'s \`openapi3filter\` which emits \`\"value is not one of the allowed values [...]\"\` (see [openapi3/schema.go:1185](https://github.com/getkin/kin-openapi/blob/v0.118.0/openapi3/schema.go#L1185), surfaced by [api/internal/api/errors.go:35](https://github.com/Ask-Atlas/AskAtlas/blob/main/api/internal/api/errors.go#L35)).
- The 5th expected \`next_cursor\` to always be present, but \`ListFilesResponse.next_cursor\` is \`nullable: true\` + not required → \`oapi-codegen\` emits \`omitempty\` and the field is dropped from JSON when there is no next page.

## Changes
- Invalid-enum assertions now match \`\"is not one of the allowed values\"\` plus a sample valid value (stable across array-formatting changes).
- Structure assertion checks \`next_cursor\` only when present, accepting both the omitted and \`null\` shapes the spec allows.

## Verification
Probed staging directly with curl to confirm the actual error envelopes:
- \`?scope=invalid_scope\` → \`details.scope: \"value is not one of the allowed values [\\\"owned\\\",\\\"course\\\",\\\"study_guide\\\",\\\"accessible\\\"]\"\`
- \`?sort_by=coolness\` → same format with the sort_by enum
- \`?sort_dir=sideways\` → same format with \`[\\\"asc\\\",\\\"desc\\\"]\`
- \`?status=kinda_done\` → same format with \`[\\\"pending\\\",\\\"complete\\\",\\\"failed\\\"]\`
- happy path → \`{\"files\":[],\"has_more\":false}\` (next_cursor omitted)

Then ran the full Playwright suite against \`api-staging.askatlas.study\`:
\`\`\`
27 passed, 3 skipped, 0 failed (5.2s)
\`\`\`

The 3 remaining skips are pre-existing \`test.skip()\` gates on staging having seeded files (none owned by the test user) — not regressions.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] Full \`npx playwright test\` against staging — 27/30 pass, 3 skipped (fixture-availability gates), 0 failed
- [ ] CI green on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced pagination response validation assertions for more explicit coupling between pagination flags.
  * Strengthened query parameter validation error assertions to ensure comprehensive coverage of allowed values for scope, sort, and status parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->