### PR TITLE
chore(sessions): address ASK-128 post-merge review nits

### DIFF
--- a/api/db/queries/practice_sessions.sql
+++ b/api/db/queries/practice_sessions.sql
@@ -34,8 +34,15 @@ SELECT EXISTS (
 
 -- name: DeleteStaleIncompleteSessions :exec
 -- Hard-deletes this user's incomplete session for this quiz when it
--- has been sitting around for more than 7 days. CASCADE deletes the
--- attached practice_session_questions and practice_answers rows.
+-- has been sitting around longer than the caller-supplied stale
+-- threshold. CASCADE deletes the attached practice_session_questions
+-- and practice_answers rows.
+--
+-- The threshold is a Go-side constant (sessions.StaleSessionAge,
+-- currently 7 days) passed in as seconds so the policy lives in
+-- exactly one place. Multiplying by `interval '1 second'` lets us
+-- pass a plain integer instead of a Postgres interval value, which
+-- keeps the sqlc-generated Go signature simple.
 --
 -- Scoped per (user_id, quiz_id): we don't want a global cleanup job
 -- here -- the spec wants stale-cleanup to run on the start-session
@@ -51,7 +58,7 @@ DELETE FROM practice_sessions
 WHERE user_id = sqlc.arg(user_id)::uuid
   AND quiz_id = sqlc.arg(quiz_id)::uuid
   AND completed_at IS NULL
-  AND started_at < now() - interval '7 days';
+  AND started_at < now() - (sqlc.arg(stale_threshold_seconds)::bigint * interval '1 second');
 
 -- name: FindIncompleteSession :one
 -- Resume probe -- returns this user's current in-progress session for

--- a/api/internal/db/practice_sessions.sql.go
+++ b/api/internal/db/practice_sessions.sql.go
@@ -59,17 +59,25 @@ DELETE FROM practice_sessions
 WHERE user_id = $1::uuid
   AND quiz_id = $2::uuid
   AND completed_at IS NULL
-  AND started_at < now() - interval '7 days'
+  AND started_at < now() - ($3::bigint * interval '1 second')
 `
 
 type DeleteStaleIncompleteSessionsParams struct {
-	UserID pgtype.UUID `json:"user_id"`
-	QuizID pgtype.UUID `json:"quiz_id"`
+	UserID                pgtype.UUID `json:"user_id"`
+	QuizID                pgtype.UUID `json:"quiz_id"`
+	StaleThresholdSeconds int64       `json:"stale_threshold_seconds"`
 }
 
 // Hard-deletes this user's incomplete session for this quiz when it
-// has been sitting around for more than 7 days. CASCADE deletes the
-// attached practice_session_questions and practice_answers rows.
+// has been sitting around longer than the caller-supplied stale
+// threshold. CASCADE deletes the attached practice_session_questions
+// and practice_answers rows.
+//
+// The threshold is a Go-side constant (sessions.StaleSessionAge,
+// currently 7 days) passed in as seconds so the policy lives in
+// exactly one place. Multiplying by `interval '1 second'` lets us
+// pass a plain integer instead of a Postgres interval value, which
+// keeps the sqlc-generated Go signature simple.
 //
 // Scoped per (user_id, quiz_id): we don't want a global cleanup job
 // here -- the spec wants stale-cleanup to run on the start-session
@@ -82,7 +90,7 @@ type DeleteStaleIncompleteSessionsParams struct {
 // can match the WHERE clause, so DELETE is a no-op when there's no
 // stale session, and a single-row DELETE otherwise.
 func (q *Queries) DeleteStaleIncompleteSessions(ctx context.Context, arg DeleteStaleIncompleteSessionsParams) error {
-	_, err := q.db.Exec(ctx, deleteStaleIncompleteSessions, arg.UserID, arg.QuizID)
+	_, err := q.db.Exec(ctx, deleteStaleIncompleteSessions, arg.UserID, arg.QuizID, arg.StaleThresholdSeconds)
 	return err
 }
 

--- a/api/internal/db/querier.go
+++ b/api/internal/db/querier.go
@@ -71,8 +71,15 @@ type Querier interface {
 	// already-detached races (0 rows -> 404) vs success (1 row -> nil).
 	DeleteGuideResource(ctx context.Context, arg DeleteGuideResourceParams) (int64, error)
 	// Hard-deletes this user's incomplete session for this quiz when it
-	// has been sitting around for more than 7 days. CASCADE deletes the
-	// attached practice_session_questions and practice_answers rows.
+	// has been sitting around longer than the caller-supplied stale
+	// threshold. CASCADE deletes the attached practice_session_questions
+	// and practice_answers rows.
+	//
+	// The threshold is a Go-side constant (sessions.StaleSessionAge,
+	// currently 7 days) passed in as seconds so the policy lives in
+	// exactly one place. Multiplying by `interval '1 second'` lets us
+	// pass a plain integer instead of a Postgres interval value, which
+	// keeps the sqlc-generated Go signature simple.
 	//
 	// Scoped per (user_id, quiz_id): we don't want a global cleanup job
 	// here -- the spec wants stale-cleanup to run on the start-session

--- a/api/internal/sessions/params.go
+++ b/api/internal/sessions/params.go
@@ -1,6 +1,22 @@
 package sessions
 
-import "github.com/google/uuid"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// StaleSessionAge is the cutoff for an in-progress practice session
+// to be considered abandoned and eligible for hard-delete on the
+// next StartSession call (ASK-128 spec AC6: "stale incomplete
+// session (started_at > 7 days ago) -> cleaned up + fresh 201").
+//
+// This is the Single Source of Truth for the threshold. The
+// DeleteStaleIncompleteSessions sqlc query takes the value in
+// seconds via stale_threshold_seconds and multiplies by
+// `interval '1 second'` server-side -- so changing this constant
+// is the only edit required to update the policy.
+const StaleSessionAge = 7 * 24 * time.Hour
 
 // StartSessionParams is the input to Service.StartSession (ASK-128).
 // UserID is taken from the JWT in the handler -- the spec does not

--- a/api/internal/sessions/service.go
+++ b/api/internal/sessions/service.go
@@ -100,8 +100,9 @@ func (s *Service) StartSession(ctx context.Context, p StartSessionParams) (Start
 	}
 
 	if err := s.repo.DeleteStaleIncompleteSessions(ctx, db.DeleteStaleIncompleteSessionsParams{
-		UserID: userPgxID,
-		QuizID: quizPgxID,
+		UserID:                userPgxID,
+		QuizID:                quizPgxID,
+		StaleThresholdSeconds: int64(StaleSessionAge.Seconds()),
 	}); err != nil {
 		return StartSessionResult{}, fmt.Errorf("StartSession: stale cleanup: %w", err)
 	}

--- a/api/internal/sessions/service_test.go
+++ b/api/internal/sessions/service_test.go
@@ -412,3 +412,53 @@ func TestStartSession_NullableAnswerFields(t *testing.T) {
 	assert.Nil(t, a.IsCorrect, "NULL is_correct must surface as nil pointer")
 	assert.False(t, a.Verified, "verified flag must round-trip")
 }
+
+// TestStartSession_StaleCleanupOrdering verifies the AC6 contract
+// at the call-sequence level: DeleteStaleIncompleteSessions MUST
+// fire before FindIncompleteSession (so a previously-stale session
+// is hard-deleted before the resume probe sees it). When the stale
+// row is gone, FindIncompleteSession returns sql.ErrNoRows and
+// the service takes the create branch -> 201 (not 200 resume of
+// a stale session).
+//
+// The mock.InOrder expectations would fail if the service ever
+// reorders the cleanup vs the resume probe (e.g., probes first
+// then "cleans up" the resumed session -- which would be wrong).
+func TestStartSession_StaleCleanupOrdering(t *testing.T) {
+	repo := mock_sessions.NewMockRepository(t)
+
+	liveCall := repo.EXPECT().CheckQuizLiveForSession(mock.Anything, mock.Anything).Return(true, nil)
+	cleanupCall := repo.EXPECT().DeleteStaleIncompleteSessions(mock.Anything, mock.MatchedBy(func(arg db.DeleteStaleIncompleteSessionsParams) bool {
+		// Verify the StaleSessionAge constant flows through as the
+		// expected number of seconds (7 days = 604800s).
+		return arg.StaleThresholdSeconds == int64(sessions.StaleSessionAge.Seconds())
+	})).Return(nil)
+	probeCall := repo.EXPECT().FindIncompleteSession(mock.Anything, mock.Anything).
+		Return(db.FindIncompleteSessionRow{}, sql.ErrNoRows)
+
+	// Stale was cleaned -> probe finds nothing -> create path runs.
+	inTxRunsFn(repo)
+	insertCall := repo.EXPECT().InsertPracticeSessionIfAbsent(mock.Anything, mock.Anything).
+		Return(db.InsertPracticeSessionIfAbsentRow{
+			ID:             utils.UUID(uuid.New()),
+			QuizID:         utils.UUID(uuid.New()),
+			StartedAt:      pgtype.Timestamptz{Time: fixtureTime, Valid: true},
+			TotalQuestions: 0,
+		}, nil)
+	snapshotCall := repo.EXPECT().SnapshotQuizQuestionsAndUpdateCount(mock.Anything, mock.Anything).
+		Return(int32(2), nil)
+
+	mock.InOrder(
+		liveCall.Call,
+		cleanupCall.Call,
+		probeCall.Call,
+		insertCall.Call,
+		snapshotCall.Call,
+	)
+
+	svc := sessions.NewService(repo)
+	got, err := svc.StartSession(context.Background(), validParams(t))
+	require.NoError(t, err)
+	assert.True(t, got.Created, "stale-cleanup -> empty probe -> create path must yield 201")
+	assert.Equal(t, int32(2), got.Session.TotalQuestions, "snapshot CTE return value must flow through")
+}


### PR DESCRIPTION
## Summary
Two LOW-severity follow-ups from the post-hoc /code-review of PR #153:

1. **Extract \`StaleSessionAge\` to a Go-side constant** so the 7-day stale-session policy lives in exactly one place (\`api/internal/sessions/params.go\`). The SQL query takes the value in seconds via \`stale_threshold_seconds\` and multiplies by \`interval '1 second'\` server-side. Identical runtime behavior; policy edits are now a one-line change.
2. **Add \`TestStartSession_StaleCleanupOrdering\`** using \`mock.InOrder\` to pin the \`live -> cleanup -> probe -> insert -> snapshot\` sequence. Catches a future regression where the resume probe ever fires before stale-cleanup (which would resume a session the spec wants hard-deleted, AC6).

Skipped findings:
- **#3** StartSession function length is mostly docstring + linear flow; splitting hurts readability.
- **#4** Race re-fetch 500 is defensible per spec; existing code comment already covers the rationale.

No behavior change visible to API callers.

## Test plan
- [x] Local /code-review on the diff (0 findings)
- [x] \`go test -race ./...\` green locally
- [ ] dev deploy
- [ ] stage deploy
- [ ] No staging matrix needed (no behavior change; the prior ASK-128 matrix verified end-to-end resume/create paths)