### PR TITLE
refactor(apperrors): adopt symbolic status codes (ASK-110)

### DIFF
--- a/api/e2e/tests/contracts.spec.ts
+++ b/api/e2e/tests/contracts.spec.ts
@@ -79,7 +79,7 @@ test.describe("API Contracts & Error Handling", () => {
       const body = await response.json();
 
       expect(body).toHaveProperty("code", 404);
-      expect(body).toHaveProperty("status", "Not Found");
+      expect(body).toHaveProperty("status", "NOT_FOUND");
       expect(body).toHaveProperty("message");
       expect(typeof body.message).toBe("string");
     });
@@ -93,7 +93,7 @@ test.describe("API Contracts & Error Handling", () => {
       const body = await response.json();
 
       expect(body).toHaveProperty("code", 400);
-      expect(body).toHaveProperty("status", "Bad Request");
+      expect(body).toHaveProperty("status", "VALIDATION_ERROR");
       expect(body).toHaveProperty("message");
       expect(typeof body.message).toBe("string");
       expect(body).toHaveProperty("details");
@@ -146,7 +146,7 @@ test.describe("API Contracts & Error Handling", () => {
       const body = await response.json();
 
       expect(body).toHaveProperty("code", 400);
-      expect(body).toHaveProperty("status", "Bad Request");
+      expect(body).toHaveProperty("status", "VALIDATION_ERROR");
       expect(body).toHaveProperty("message");
       expect(typeof body.message).toBe("string");
     });

--- a/api/e2e/tests/files.spec.ts
+++ b/api/e2e/tests/files.spec.ts
@@ -63,7 +63,7 @@ test.describe("Files API", () => {
     expect(response.status()).toBe(400);
     const body = await response.json();
     expect(body).toHaveProperty("code", 400);
-    expect(body).toHaveProperty("status", "Bad Request");
+    expect(body).toHaveProperty("status", "VALIDATION_ERROR");
     expect(body.details).toHaveProperty("scope");
     // kin-openapi enum violation message format. Assert every allowed
     // value appears in the error so the API stays honest about the full

--- a/api/e2e/tests/sessions.spec.ts
+++ b/api/e2e/tests/sessions.spec.ts
@@ -139,7 +139,7 @@ test.describe("Sessions API (ASK-149 list)", () => {
     expect(resp.status()).toBe(404);
     const body = await resp.json();
     expect(body).toHaveProperty("code", 404);
-    expect(body).toHaveProperty("status", "Not Found");
+    expect(body).toHaveProperty("status", "NOT_FOUND");
   });
 
   // ---------- Happy path (requires seed data) ----------

--- a/api/internal/courses/service.go
+++ b/api/internal/courses/service.go
@@ -425,7 +425,7 @@ func (s *Service) JoinSection(ctx context.Context, p JoinSectionParams) (Members
 		if errors.Is(err, sql.ErrNoRows) {
 			return Membership{}, &apperrors.AppError{
 				Code:    http.StatusConflict,
-				Status:  "Conflict",
+				Status:  apperrors.StatusConflict,
 				Message: "Already a member of this section",
 			}
 		}

--- a/api/internal/files/service.go
+++ b/api/internal/files/service.go
@@ -541,7 +541,7 @@ func (s *Service) validateGranteeExists(ctx context.Context, granteeType string,
 		// AppError converter in the handler.
 		return &apperrors.AppError{
 			Code:    500,
-			Status:  "Internal Server Error",
+			Status:  apperrors.StatusInternalError,
 			Message: "Something went wrong",
 			Cause:   probeErr,
 		}

--- a/api/internal/handlers/courses_test.go
+++ b/api/internal/handlers/courses_test.go
@@ -436,7 +436,7 @@ func TestCoursesHandler_JoinSection_AlreadyMember(t *testing.T) {
 		JoinSection(mock.Anything, mock.Anything).
 		Return(courses.Membership{}, &apperrors.AppError{
 			Code:    http.StatusConflict,
-			Status:  "Conflict",
+			Status:  apperrors.StatusConflict,
 			Message: "Already a member of this section",
 		})
 

--- a/api/internal/handlers/studyguides_test.go
+++ b/api/internal/handlers/studyguides_test.go
@@ -1083,7 +1083,7 @@ func TestStudyGuidesHandler_Recommend_Forbidden_403(t *testing.T) {
 		RecommendStudyGuide(mock.Anything, mock.Anything).
 		Return(studyguides.Recommendation{}, &apperrors.AppError{
 			Code:    http.StatusForbidden,
-			Status:  "Forbidden",
+			Status:  apperrors.StatusForbidden,
 			Message: "Only instructors and TAs can recommend study guides",
 		})
 
@@ -1121,7 +1121,7 @@ func TestStudyGuidesHandler_Recommend_Conflict_409(t *testing.T) {
 		RecommendStudyGuide(mock.Anything, mock.Anything).
 		Return(studyguides.Recommendation{}, &apperrors.AppError{
 			Code:    http.StatusConflict,
-			Status:  "Conflict",
+			Status:  apperrors.StatusConflict,
 			Message: "You have already recommended this study guide",
 		})
 
@@ -1202,7 +1202,7 @@ func TestStudyGuidesHandler_RemoveRecommendation_Forbidden_403(t *testing.T) {
 		RemoveRecommendation(mock.Anything, mock.Anything).
 		Return(&apperrors.AppError{
 			Code:    http.StatusForbidden,
-			Status:  "Forbidden",
+			Status:  apperrors.StatusForbidden,
 			Message: "Only instructors and TAs can manage recommendations",
 		})
 
@@ -1565,7 +1565,7 @@ func TestStudyGuidesHandler_Attach_ServiceConflict_409(t *testing.T) {
 		AttachResource(mock.Anything, mock.Anything).
 		Return(studyguides.Resource{}, &apperrors.AppError{
 			Code:    http.StatusConflict,
-			Status:  "Conflict",
+			Status:  apperrors.StatusConflict,
 			Message: "This URL is already attached to this study guide",
 		})
 
@@ -1768,7 +1768,7 @@ func TestStudyGuidesHandler_AttachFile_Forbidden_403(t *testing.T) {
 	mockSvc.EXPECT().
 		AttachFile(mock.Anything, mock.Anything).
 		Return(studyguides.FileAttachment{}, &apperrors.AppError{
-			Code: http.StatusForbidden, Status: "Forbidden",
+			Code: http.StatusForbidden, Status: apperrors.StatusForbidden,
 			Message: "You can only attach files you own",
 		})
 
@@ -1786,7 +1786,7 @@ func TestStudyGuidesHandler_AttachFile_Conflict_409(t *testing.T) {
 	mockSvc.EXPECT().
 		AttachFile(mock.Anything, mock.Anything).
 		Return(studyguides.FileAttachment{}, &apperrors.AppError{
-			Code: http.StatusConflict, Status: "Conflict",
+			Code: http.StatusConflict, Status: apperrors.StatusConflict,
 			Message: "File is already attached to this study guide",
 		})
 

--- a/api/internal/studyguides/service_write.go
+++ b/api/internal/studyguides/service_write.go
@@ -315,7 +315,7 @@ func (s *Service) RecommendStudyGuide(ctx context.Context, p RecommendStudyGuide
 	if !gate.HasRole {
 		return Recommendation{}, &apperrors.AppError{
 			Code:    http.StatusForbidden,
-			Status:  "Forbidden",
+			Status:  apperrors.StatusForbidden,
 			Message: "Only instructors and TAs can recommend study guides",
 		}
 	}
@@ -328,7 +328,7 @@ func (s *Service) RecommendStudyGuide(ctx context.Context, p RecommendStudyGuide
 		if errors.Is(err, sql.ErrNoRows) {
 			return Recommendation{}, &apperrors.AppError{
 				Code:    http.StatusConflict,
-				Status:  "Conflict",
+				Status:  apperrors.StatusConflict,
 				Message: "You have already recommended this study guide",
 			}
 		}
@@ -372,7 +372,7 @@ func (s *Service) RemoveRecommendation(ctx context.Context, p RemoveRecommendati
 	if !gate.HasRole {
 		return &apperrors.AppError{
 			Code:    http.StatusForbidden,
-			Status:  "Forbidden",
+			Status:  apperrors.StatusForbidden,
 			Message: "Only instructors and TAs can manage recommendations",
 		}
 	}
@@ -651,7 +651,7 @@ func (s *Service) AttachResource(ctx context.Context, p AttachResourceParams) (R
 		if dup {
 			return &apperrors.AppError{
 				Code:    http.StatusConflict,
-				Status:  "Conflict",
+				Status:  apperrors.StatusConflict,
 				Message: "This URL is already attached to this study guide",
 			}
 		}
@@ -817,7 +817,7 @@ func (s *Service) AttachFile(ctx context.Context, p AttachFileParams) (FileAttac
 		if ownerID != p.AttacherID {
 			return &apperrors.AppError{
 				Code:    http.StatusForbidden,
-				Status:  "Forbidden",
+				Status:  apperrors.StatusForbidden,
 				Message: "You can only attach files you own",
 			}
 		}
@@ -840,7 +840,7 @@ func (s *Service) AttachFile(ctx context.Context, p AttachFileParams) (FileAttac
 			if errors.Is(err, sql.ErrNoRows) {
 				return &apperrors.AppError{
 					Code:    http.StatusConflict,
-					Status:  "Conflict",
+					Status:  apperrors.StatusConflict,
 					Message: "File is already attached to this study guide",
 				}
 			}

--- a/api/pkg/apperrors/apperrors.go
+++ b/api/pkg/apperrors/apperrors.go
@@ -1,14 +1,57 @@
 // Package apperrors defines standard application-level errors and HTTP mappings.
 // It provides a unified way to represent, handle, and return errors across the API.
+//
+// Status strings are SYMBOLIC (ASK-110): `VALIDATION_ERROR`,
+// `NOT_FOUND`, etc. -- stable machine-readable identifiers rather
+// than the HTTP phrase (`Bad Request`, `Not Found`). The integer
+// `code` field is the canonical HTTP status code and is unchanged.
 package apperrors
 
 import (
-	"cmp"
 	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
 )
+
+// Symbolic status strings shared across constructors + the
+// RespondWithError / ToHTTPError fallback. Kept as named constants
+// so a typo in a call site is a compile-time error rather than a
+// silent wire-contract regression.
+const (
+	StatusValidationError = "VALIDATION_ERROR"
+	StatusUnauthorized    = "UNAUTHORIZED"
+	StatusForbidden       = "FORBIDDEN"
+	StatusNotFound        = "NOT_FOUND"
+	StatusConflict        = "CONFLICT"
+	StatusInternalError   = "INTERNAL_ERROR"
+	StatusUnknownError    = "UNKNOWN_ERROR"
+)
+
+// statusCodeMap resolves an HTTP code to the symbolic status string.
+// Used as the fallback inside RespondWithError + ToHTTPError for
+// AppErrors built without a Status value (bare literals, third-
+// party code that surfaces only an integer code, etc.). An
+// unrecognised code falls through to "UNKNOWN_ERROR" so a wire
+// consumer never sees an empty string.
+var statusCodeMap = map[int]string{
+	http.StatusBadRequest:          StatusValidationError,
+	http.StatusUnauthorized:        StatusUnauthorized,
+	http.StatusForbidden:           StatusForbidden,
+	http.StatusNotFound:            StatusNotFound,
+	http.StatusConflict:            StatusConflict,
+	http.StatusInternalServerError: StatusInternalError,
+}
+
+// statusForCode maps an HTTP status code onto its symbolic status
+// string. Returns StatusUnknownError for codes not in the map so
+// callers never surface an empty Status to the wire.
+func statusForCode(code int) string {
+	if s, ok := statusCodeMap[code]; ok {
+		return s
+	}
+	return StatusUnknownError
+}
 
 // Standard predefined application errors.
 var (
@@ -39,40 +82,50 @@ func (e *AppError) Unwrap() error {
 	return e.Cause
 }
 
-// NewBadRequest creates an AppError with an HTTP 400 Bad Request status.
+// NewBadRequest creates an AppError with an HTTP 400 status. The
+// symbolic Status is VALIDATION_ERROR -- every 400 the API emits
+// is a request-validation failure (malformed body, bad query
+// param, enum violation).
 func NewBadRequest(message string, details map[string]string) *AppError {
-	return &AppError{Code: http.StatusBadRequest, Status: "Bad Request", Message: message, Details: details}
+	return &AppError{Code: http.StatusBadRequest, Status: StatusValidationError, Message: message, Details: details}
 }
 
-// NewNotFound creates an AppError with an HTTP 404 Not Found status.
+// NewNotFound creates an AppError with an HTTP 404 status and the
+// symbolic Status NOT_FOUND.
 func NewNotFound(message string) *AppError {
-	return &AppError{Code: http.StatusNotFound, Status: "Not Found", Message: message}
+	return &AppError{Code: http.StatusNotFound, Status: StatusNotFound, Message: message}
 }
 
-// NewUnauthorized creates an AppError with an HTTP 401 Unauthorized status.
+// NewUnauthorized creates an AppError with an HTTP 401 status and
+// the symbolic Status UNAUTHORIZED.
 func NewUnauthorized() *AppError {
-	return &AppError{Code: http.StatusUnauthorized, Status: "Unauthorized", Message: "Authentication required"}
+	return &AppError{Code: http.StatusUnauthorized, Status: StatusUnauthorized, Message: "Authentication required"}
 }
 
-// NewForbidden creates an AppError with an HTTP 403 Forbidden status.
+// NewForbidden creates an AppError with an HTTP 403 status and the
+// symbolic Status FORBIDDEN.
 func NewForbidden() *AppError {
-	return &AppError{Code: http.StatusForbidden, Status: "Forbidden", Message: "You do not have permission"}
+	return &AppError{Code: http.StatusForbidden, Status: StatusForbidden, Message: "You do not have permission"}
 }
 
-// NewConflict creates an AppError with an HTTP 409 Conflict status.
-// First introduced for ASK-137 (SubmitAnswer on a completed
-// session); reusable for any resource-state conflict (e.g. trying
-// to vote twice, recommend the same guide twice).
+// NewConflict creates an AppError with an HTTP 409 status and the
+// symbolic Status CONFLICT. First introduced for ASK-137
+// (SubmitAnswer on a completed session); reusable for any
+// resource-state conflict (e.g. trying to vote twice, recommend
+// the same guide twice, duplicate file grant).
 func NewConflict(message string) *AppError {
-	return &AppError{Code: http.StatusConflict, Status: "Conflict", Message: message}
+	return &AppError{Code: http.StatusConflict, Status: StatusConflict, Message: message}
 }
 
-// NewInternalError creates an AppError with an HTTP 500 Internal Server Error status.
+// NewInternalError creates an AppError with an HTTP 500 status and
+// the symbolic Status INTERNAL_ERROR.
 func NewInternalError() *AppError {
-	return &AppError{Code: http.StatusInternalServerError, Status: "Internal Server Error", Message: "Something went wrong"}
+	return &AppError{Code: http.StatusInternalServerError, Status: StatusInternalError, Message: "Something went wrong"}
 }
 
-// ToHTTPError maps a sentinel error or existing AppError to an AppError
+// ToHTTPError maps a sentinel error or existing AppError to an AppError.
+// AppErrors missing a Status value (legacy inline struct literals,
+// third-party code) get the symbolic status looked up from their Code.
 func ToHTTPError(err error) *AppError {
 	if appErr := (*AppError)(nil); errors.As(err, &appErr) {
 		if appErr == nil {
@@ -81,7 +134,9 @@ func ToHTTPError(err error) *AppError {
 		if appErr.Code < 100 || appErr.Code > 999 {
 			appErr.Code = http.StatusInternalServerError
 		}
-		appErr.Status = cmp.Or(appErr.Status, http.StatusText(appErr.Code))
+		if appErr.Status == "" {
+			appErr.Status = statusForCode(appErr.Code)
+		}
 		return appErr
 	}
 
@@ -89,7 +144,7 @@ func ToHTTPError(err error) *AppError {
 	case errors.Is(err, ErrNotFound):
 		return NewNotFound("Resource not found")
 	case errors.Is(err, ErrConflict):
-		return &AppError{Code: http.StatusConflict, Status: "Conflict", Message: "Resource already exists"}
+		return NewConflict("Resource already exists")
 	case errors.Is(err, ErrInvalidInput):
 		return NewBadRequest(err.Error(), nil)
 	case errors.Is(err, ErrUnauthorized):
@@ -102,13 +157,18 @@ func ToHTTPError(err error) *AppError {
 }
 
 // RespondWithError writes the given AppError as a JSON response to the client.
+// If Status is empty, fall back to the symbolic status for the Code so
+// no wire response ever ships with a blank `status` field.
 func RespondWithError(w http.ResponseWriter, appErr *AppError) {
 	if appErr == nil {
 		appErr = NewInternalError()
 	}
 	if appErr.Code < 100 || appErr.Code > 999 {
 		appErr.Code = http.StatusInternalServerError
-		appErr.Status = http.StatusText(http.StatusInternalServerError)
+		appErr.Status = StatusInternalError
+	}
+	if appErr.Status == "" {
+		appErr.Status = statusForCode(appErr.Code)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api/pkg/apperrors/apperrors_test.go
+++ b/api/pkg/apperrors/apperrors_test.go
@@ -62,3 +62,92 @@ func TestToHTTPError(t *testing.T) {
 		})
 	}
 }
+
+// TestSymbolicStatusCodes pins the wire `status` string each
+// constructor emits (ASK-110). This is a contract test -- the
+// frontend reads the `status` field to drive error-boundary UI, so
+// a regression to the old HTTP-phrase strings ("Bad Request",
+// "Not Found", etc.) would break that surface silently. The
+// explicit string literals here are the source of truth for the
+// wire format; every new test + service callsite should match.
+func TestSymbolicStatusCodes(t *testing.T) {
+	t.Run("NewBadRequest emits VALIDATION_ERROR", func(t *testing.T) {
+		if got := apperrors.NewBadRequest("x", nil).Status; got != "VALIDATION_ERROR" {
+			t.Errorf("Status = %q, want VALIDATION_ERROR", got)
+		}
+	})
+	t.Run("NewNotFound emits NOT_FOUND", func(t *testing.T) {
+		if got := apperrors.NewNotFound("x").Status; got != "NOT_FOUND" {
+			t.Errorf("Status = %q, want NOT_FOUND", got)
+		}
+	})
+	t.Run("NewUnauthorized emits UNAUTHORIZED", func(t *testing.T) {
+		if got := apperrors.NewUnauthorized().Status; got != "UNAUTHORIZED" {
+			t.Errorf("Status = %q, want UNAUTHORIZED", got)
+		}
+	})
+	t.Run("NewForbidden emits FORBIDDEN", func(t *testing.T) {
+		if got := apperrors.NewForbidden().Status; got != "FORBIDDEN" {
+			t.Errorf("Status = %q, want FORBIDDEN", got)
+		}
+	})
+	t.Run("NewConflict emits CONFLICT", func(t *testing.T) {
+		if got := apperrors.NewConflict("x").Status; got != "CONFLICT" {
+			t.Errorf("Status = %q, want CONFLICT", got)
+		}
+	})
+	t.Run("NewInternalError emits INTERNAL_ERROR", func(t *testing.T) {
+		if got := apperrors.NewInternalError().Status; got != "INTERNAL_ERROR" {
+			t.Errorf("Status = %q, want INTERNAL_ERROR", got)
+		}
+	})
+	// Sentinel-path tests -- ToHTTPError on a wrapped sentinel must
+	// produce the same symbolic status as the matching constructor.
+	t.Run("ToHTTPError(ErrNotFound) -> NOT_FOUND", func(t *testing.T) {
+		if got := apperrors.ToHTTPError(apperrors.ErrNotFound).Status; got != "NOT_FOUND" {
+			t.Errorf("Status = %q, want NOT_FOUND", got)
+		}
+	})
+	t.Run("ToHTTPError(ErrConflict) -> CONFLICT", func(t *testing.T) {
+		if got := apperrors.ToHTTPError(apperrors.ErrConflict).Status; got != "CONFLICT" {
+			t.Errorf("Status = %q, want CONFLICT", got)
+		}
+	})
+	t.Run("ToHTTPError(unknown) -> INTERNAL_ERROR", func(t *testing.T) {
+		if got := apperrors.ToHTTPError(errors.New("mystery")).Status; got != "INTERNAL_ERROR" {
+			t.Errorf("Status = %q, want INTERNAL_ERROR", got)
+		}
+	})
+}
+
+// TestStatusForCodeFallback covers the fallback for AppErrors built
+// without a Status value. A bare `&AppError{Code: 404}` must emit
+// "NOT_FOUND" on the wire via the statusCodeMap lookup; an
+// unrecognised code must fall through to "UNKNOWN_ERROR" so no
+// wire consumer ever sees an empty Status.
+func TestStatusForCodeFallback(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		want string
+	}{
+		{"400 -> VALIDATION_ERROR", http.StatusBadRequest, "VALIDATION_ERROR"},
+		{"401 -> UNAUTHORIZED", http.StatusUnauthorized, "UNAUTHORIZED"},
+		{"403 -> FORBIDDEN", http.StatusForbidden, "FORBIDDEN"},
+		{"404 -> NOT_FOUND", http.StatusNotFound, "NOT_FOUND"},
+		{"409 -> CONFLICT", http.StatusConflict, "CONFLICT"},
+		{"500 -> INTERNAL_ERROR", http.StatusInternalServerError, "INTERNAL_ERROR"},
+		{"418 -> UNKNOWN_ERROR", http.StatusTeapot, "UNKNOWN_ERROR"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Bare AppError with no Status -- ToHTTPError's
+			// `if appErr.Status == ""` branch fills it from
+			// statusForCode.
+			got := apperrors.ToHTTPError(&apperrors.AppError{Code: c.code})
+			if got.Status != c.want {
+				t.Errorf("Status = %q, want %q", got.Status, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Flip the wire \`status\` field from HTTP phrases (\`Bad Request\`, \`Not Found\`, etc.) to stable symbolic identifiers (\`VALIDATION_ERROR\`, \`NOT_FOUND\`, etc.) so machine consumers (frontend error boundaries, telemetry) can key off a value that won't drift with HTTP text updates.

The integer \`code\` field is unchanged — this is a pure wire-format tweak, not a status-code semantic change.

## Changes

| Constructor | Before | After |
|---|---|---|
| \`NewBadRequest\` | \`"Bad Request"\` | \`"VALIDATION_ERROR"\` |
| \`NewUnauthorized\` | \`"Unauthorized"\` | \`"UNAUTHORIZED"\` |
| \`NewForbidden\` | \`"Forbidden"\` | \`"FORBIDDEN"\` |
| \`NewNotFound\` | \`"Not Found"\` | \`"NOT_FOUND"\` |
| \`NewConflict\` | \`"Conflict"\` | \`"CONFLICT"\` |
| \`NewInternalError\` | \`"Internal Server Error"\` | \`"INTERNAL_ERROR"\` |

- 7 new exported named constants + \`statusCodeMap\` + \`statusForCode\` helper
- Fallback: a bare \`&AppError{Code: 404}\` now surfaces \`"NOT_FOUND"\` via the map; unrecognised codes fall through to \`"UNKNOWN_ERROR"\` so the wire is never empty
- 8 inline struct-literal call sites across \`studyguides/service_write.go\`, \`courses/service.go\`, \`files/service.go\` updated to use the named constants
- 2 handler test files, 3 e2e spec files updated
- 16 new sub-tests pin the wire contract in \`apperrors_test.go\`

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go test -race ./...\` (16 packages green)
- [x] \`make lint\` clean
- [x] 16 new contract tests for symbolic status + statusForCode fallback (including 418 → UNKNOWN_ERROR edge case)
- [x] Existing handler + service tests updated to match new Status values
- [x] E2E assertions flipped to new symbolic strings
- [ ] Dev/stage deploys green

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized error response status identifiers across the API (e.g., `NOT_FOUND`, `VALIDATION_ERROR`, `CONFLICT`, `INTERNAL_ERROR`) for consistent error handling.

* **Tests**
  * Updated test assertions to verify standardized error status values in API responses.

* **Chores**
  * Introduced symbolic status constants and unified error representation throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->