### PR TITLE
chore(bruno): scaffold Bruno collection + generator from openapi

### DIFF
--- a/api/bruno/Courses/Check Membership.bru
+++ b/api/bruno/Courses/Check Membership.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Check Membership
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/courses/{{courseId}}/sections/{{sectionId}}/members/me
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Check the authenticated user's membership in a section
+
+  Powers the per-section Join/Leave button on the course detail
+  page. Always returns 200 -- non-membership is `enrolled: false`
+  with null role/joined_at, NOT 404, so the frontend can
+  distinguish "not enrolled" from "section does not exist".
+}

--- a/api/bruno/Courses/Create Study Guide.bru
+++ b/api/bruno/Courses/Create Study Guide.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Create Study Guide
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/api/courses/{{courseId}}/study-guides
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "content": "string",
+    "description": "string",
+    "tags": [
+      "string"
+    ],
+    "title": "string"
+  }
+}
+
+docs {
+  # Create a study guide for a course
+
+  Creates a new study guide. Any authenticated user can create a
+  guide for any course. The `creator_id` is taken from the JWT;
+  any value supplied in the request body is ignored.
+  
+  Tags are normalized server-side: each value is trimmed +
+  lowercased + deduplicated (case-insensitively). Empty tags
+  after trim are rejected with 400. Validation order on tags:
+  per-tag length cap first (50 chars), total count cap second
+  (20 tags), then normalize.
+  
+  Returns the full StudyGuideDetail shape on 201 -- empty
+  recommended_by/quizzes/resources/files arrays, vote_score=0,
+  view_count=0, user_vote=null, is_recommended=false. The
+  frontend can render the freshly-created guide without a
+  follow-up GET.
+}

--- a/api/bruno/Courses/Get Course.bru
+++ b/api/bruno/Courses/Get Course.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Course
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/courses/{{courseId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Get a course detail with embedded sections
+
+}

--- a/api/bruno/Courses/Join Section.bru
+++ b/api/bruno/Courses/Join Section.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Join Section
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/courses/{{courseId}}/sections/{{sectionId}}/members
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Join a section as the authenticated user
+
+  Adds the authenticated user as a `student` member of the given section.
+  The role is hardcoded to `student` regardless of any fields supplied in
+  the request body. `instructor` and `ta` roles are assigned only through
+  the seeding pipeline.
+}

--- a/api/bruno/Courses/Leave Section.bru
+++ b/api/bruno/Courses/Leave Section.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Leave Section
+  type: http
+  seq: 9
+}
+
+delete {
+  url: {{baseUrl}}/api/courses/{{courseId}}/sections/{{sectionId}}/members/me
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Leave a section as the authenticated user
+
+  Removes the authenticated user's membership from the given section.
+  The membership row is hard-deleted. Any role (`student`, `ta`,
+  `instructor`) can leave.
+}

--- a/api/bruno/Courses/List Course Sections.bru
+++ b/api/bruno/Courses/List Course Sections.bru
@@ -1,0 +1,45 @@
+meta {
+  name: List Course Sections
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/courses/{{courseId}}/sections
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~term: 
+}
+
+docs {
+  # List sections for a course
+
+  Returns every section attached to the given course, with a live
+  `member_count` and an optional exact-match `term` filter. Used
+  by the course detail page when the caller needs the dedicated
+  sections payload (with `course_id` + `created_at`) rather than
+  the slimmer inline sections embedded in `GET /courses/{id}`.
+  
+  Sorted by `term DESC, section_code ASC` (most-recent term first;
+  within a term, section codes ascend). No pagination -- a course
+  typically has fewer than 10 sections.
+  
+  404 dispatch: a missing course (no row matches `course_id`) is
+  a single 404 with "Course not found"; an existing course with
+  zero matching sections (filtered out by `term` or just empty)
+  returns 200 with `sections: []`. The two are intentionally
+  distinguishable so the frontend can show a "no sections in this
+  term" empty state vs a generic not-found page.
+  
+  Term filter:
+    * Exact match (no ILIKE, no trigram). Term values are
+      structured strings like "Spring 2026" so case-insensitive
+      matching would only mask typos, not real intent.
+    * Empty string is treated as "no filter" (defensive: a
+      client clearing the input shouldn't send an empty
+      string to the server, but if it does the server treats
+      it as if no filter was supplied).
+}

--- a/api/bruno/Courses/List Courses.bru
+++ b/api/bruno/Courses/List Courses.bru
@@ -1,0 +1,26 @@
+meta {
+  name: List Courses
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/courses
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~school_id: 
+  ~department: 
+  ~q: 
+  sort_by: department
+  sort_dir: asc
+  page_limit: 25
+  ~cursor: 
+}
+
+docs {
+  # List and search courses
+
+}

--- a/api/bruno/Courses/List Section Members.bru
+++ b/api/bruno/Courses/List Section Members.bru
@@ -1,0 +1,30 @@
+meta {
+  name: List Section Members
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/courses/{{courseId}}/sections/{{sectionId}}/members
+  body: none
+  auth: inherit
+}
+
+params:query {
+  role: student
+  limit: 25
+  ~cursor: 
+}
+
+docs {
+  # List the members of a course section
+
+  Returns the section roster with limited per-user info: user_id,
+  first_name, last_name, role, joined_at. Email and clerk_id are
+  intentionally NOT exposed -- this endpoint is reachable by any
+  authenticated user (course pages are public within the app), so
+  the payload is the privacy-floor for member identity.
+  
+  Sorted by `joined_at ASC` with a `(joined_at, user_id)` keyset
+  cursor as the tiebreaker for stable pagination across pages.
+}

--- a/api/bruno/Courses/List Study Guides.bru
+++ b/api/bruno/Courses/List Study Guides.bru
@@ -1,0 +1,31 @@
+meta {
+  name: List Study Guides
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/courses/{{courseId}}/study-guides
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~q: 
+  ~tag: 
+  sort_by: score
+  sort_dir: desc
+  page_limit: 25
+  ~cursor: 
+}
+
+docs {
+  # List study guides for a course
+
+  Returns the study guides for the given course as a paginated
+  list. Soft-deleted guides and guides whose creator has been
+  soft-deleted are excluded. Per-row aggregates (`vote_score`,
+  `is_recommended`, `quiz_count`) are computed inline. The full
+  `content` field is intentionally omitted -- it is only returned
+  by the get-by-id endpoint, keeping the list payload small.
+}

--- a/api/bruno/Files/Create File.bru
+++ b/api/bruno/Files/Create File.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Create File
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/files
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "mime_type": "image/jpeg",
+    "name": "string",
+    "s3_key": "string",
+    "size": 0
+  }
+}
+
+docs {
+  # Create a file metadata record (ASK-105)
+
+  Creates a file metadata record in `pending` status. Called
+  by the Next.js server as the first step of the upload flow,
+  BEFORE the client uploads to S3 via a presigned URL the
+  Next.js server generates separately. The Go API never
+  touches S3 for uploads -- it only manages metadata records.
+  A subsequent PATCH /api/files/{id} transitions the record
+  from `pending` to `complete` or `failed`.
+}

--- a/api/bruno/Files/Create Grant.bru
+++ b/api/bruno/Files/Create Grant.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Create Grant
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/files/{{fileId}}/grants
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "grantee_id": "00000000-0000-0000-0000-000000000000",
+    "grantee_type": "user",
+    "permission": "view"
+  }
+}
+
+docs {
+  # Grant a permission on a file (ASK-122)
+
+  Creates a new file_grants row scoped to (file_id, grantee_type,
+  grantee_id, permission). Only the file owner may create grants.
+  
+  The grantee_id is validated against the corresponding table:
+  users for grantee_type=user, courses for course, and study_guides
+  (filtered by deleted_at IS NULL) for study_guide. The public
+  sentinel UUID 00000000-0000-0000-0000-000000000000 is exempt
+  from the users lookup when grantee_type=user (represents
+  "public access").
+  
+  A duplicate grant returns 409 Conflict; this endpoint does NOT
+  upsert. Permission hierarchy (delete >= share >= view) is
+  enforced by the read-side queries, not here.
+}

--- a/api/bruno/Files/Delete File.bru
+++ b/api/bruno/Files/Delete File.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Delete File
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{baseUrl}}/api/files/{{fileId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Delete a file by ID
+
+}

--- a/api/bruno/Files/Get File.bru
+++ b/api/bruno/Files/Get File.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get File
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/files/{{fileId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Get a file by ID
+
+}

--- a/api/bruno/Files/Record File View.bru
+++ b/api/bruno/Files/Record File View.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Record File View
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/files/{{fileId}}/view
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Record a file view (ASK-134)
+
+  Records that the authenticated user opened/previewed this
+  file. Inserts an append-only row into `file_views` for
+  analytics, then upserts `file_last_viewed` so the recents
+  sidebar (GET /api/me/recents) reflects the new timestamp.
+  
+  Fire-and-forget from the client. Permission-less: any
+  authenticated user can record a view of any non-deleted file
+  -- access control is enforced when the file's contents are
+  actually read, not on the view event itself.
+  
+  Returns 204 No Content on success. Returns 404 when the file
+  is missing or in any deletion state, so dangling view rows
+  cannot accumulate.
+}

--- a/api/bruno/Files/Revoke Grant.bru
+++ b/api/bruno/Files/Revoke Grant.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Revoke Grant
+  type: http
+  seq: 8
+}
+
+delete {
+  url: {{baseUrl}}/api/files/{{fileId}}/grants
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "grantee_id": "00000000-0000-0000-0000-000000000000",
+    "grantee_type": "user",
+    "permission": "view"
+  }
+}
+
+docs {
+  # Revoke a permission on a file (ASK-125)
+
+  Removes the file_grants row matched by (file_id, grantee_type,
+  grantee_id, permission). Only the file owner may revoke.
+  Returns 204 when a row was deleted, 404 when no matching grant
+  exists. Each (grantee_type, grantee_id, permission) tuple is a
+  distinct grant -- revoking `view` does NOT cascade to `share`
+  or `delete`.
+}

--- a/api/bruno/Files/Toggle File Favorite.bru
+++ b/api/bruno/Files/Toggle File Favorite.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Toggle File Favorite
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/files/{{fileId}}/favorite
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Toggle the file favorite (ASK-130)
+
+  Toggles whether the authenticated user has favorited this file.
+  If not favorited, inserts a `file_favorites` row and returns
+  `{favorited: true, favorited_at: <NOW>}`. If already favorited,
+  deletes the row and returns `{favorited: false, favorited_at: null}`.
+  
+  Favoriting is intentionally permission-less: any authenticated
+  user can favorite any non-deleted file. This is a personal
+  bookmark, not an access-control action -- the favorites list
+  endpoint already filters down to files the viewer can see.
+}

--- a/api/bruno/Files/Update File.bru
+++ b/api/bruno/Files/Update File.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Update File
+  type: http
+  seq: 6
+}
+
+patch {
+  url: {{baseUrl}}/api/files/{{fileId}}
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "string",
+    "status": "complete"
+  }
+}
+
+docs {
+  # Update file metadata and status (ASK-113)
+
+  Updates file metadata (rename) and/or transitions the upload
+  status. Called by the Next.js server after the presigned-URL
+  upload completes (or fails) to move the record from `pending`
+  to `complete` or `failed`. Also supports standalone renaming
+  of any non-deleted file the caller owns.
+  
+  Both fields are optional but at least one must be provided.
+  
+  Status transitions are restricted: only `pending -> complete`
+  and `pending -> failed` are allowed. All other combinations
+  return 400 INVALID_TRANSITION.
+}

--- a/api/bruno/Me/List Dashboard.bru
+++ b/api/bruno/Me/List Dashboard.bru
@@ -1,0 +1,36 @@
+meta {
+  name: List Dashboard
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/me/dashboard
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Aggregated dashboard data for the authenticated user
+
+  Returns the home-page dashboard payload in a single response:
+  enrolled courses for the current term, recently updated study
+  guides the viewer created, practice stats + recent sessions,
+  and file totals + recent files.
+  
+  Each section is independent. A user with no enrollments,
+  no guides, no sessions, or no files gets zeros and empty
+  arrays in the relevant section -- the whole endpoint never
+  404s and never partially fails (a DB error in any one
+  section returns 500).
+  
+  Soft-deleted entities (study guides with `deleted_at`,
+  files in any deletion lifecycle) are excluded everywhere
+  they appear -- counts, lists, and aggregate sums.
+  
+  "Current term" resolution waterfall:
+    1. Active sections covering today (start_date <= today <= end_date).
+    2. Most recently ended term (end_date < today, ordered DESC).
+    3. Lexicographically latest term string (when no dates exist).
+  Returns null when the user has no enrollments at all.
+}

--- a/api/bruno/Me/List Favorites.bru
+++ b/api/bruno/Me/List Favorites.bru
@@ -1,0 +1,36 @@
+meta {
+  name: List Favorites
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/api/me/favorites
+  body: none
+  auth: inherit
+}
+
+params:query {
+  entity_type: file
+  limit: 25
+  ~cursor: 
+}
+
+docs {
+  # List the authenticated user's favorited items
+
+  Returns favorites across files, study guides, and courses for
+  the authenticated user, sorted by `favorited_at DESC`. Powers
+  the sidebar "Starred" section and the `/me/saved` page.
+  Supports filtering by entity type and offset-based pagination.
+  
+  Soft-deleted entities (files in any deletion lifecycle,
+  soft-deleted study guides) are excluded. Courses have no
+  soft-delete and are always eligible.
+  
+  The `cursor` is opaque -- callers must pass back the
+  `next_cursor` from the previous response verbatim. The wire
+  contract is opaque so a future migration to keyset
+  pagination is non-breaking. `next_cursor` is required and
+  nullable so it renders as explicit JSON null on the last page.
+}

--- a/api/bruno/Me/List Files.bru
+++ b/api/bruno/Me/List Files.bru
@@ -1,0 +1,33 @@
+meta {
+  name: List Files
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/me/files
+  body: none
+  auth: inherit
+}
+
+params:query {
+  scope: owned
+  status: complete
+  mime_type: image/jpeg
+  ~min_size: 
+  ~max_size: 
+  ~created_from: 
+  ~created_to: 
+  ~updated_from: 
+  ~updated_to: 
+  ~q: 
+  sort_by: updated_at
+  sort_dir: desc
+  page_limit: 25
+  ~cursor: 
+}
+
+docs {
+  # List files for the current user
+
+}

--- a/api/bruno/Me/List My Enrollments.bru
+++ b/api/bruno/Me/List My Enrollments.bru
@@ -1,0 +1,25 @@
+meta {
+  name: List My Enrollments
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/me/courses
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~term: 
+  role: student
+}
+
+docs {
+  # List the authenticated user's section enrollments
+
+  Returns every section the authenticated user is enrolled in, with
+  compact embedded course + school summaries. Sorted by `term DESC,
+  department ASC, number ASC`. Not paginated -- a user is typically
+  in 4-8 courses, and even outliers fit comfortably in one response.
+}

--- a/api/bruno/Me/List My Study Guides.bru
+++ b/api/bruno/Me/List My Study Guides.bru
@@ -1,0 +1,37 @@
+meta {
+  name: List My Study Guides
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/api/me/study-guides
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~course_id: 
+  sort_by: updated
+  limit: 25
+  ~cursor: 
+}
+
+docs {
+  # List study guides created by the authenticated user (ASK-131)
+
+  Returns study guides authored by the viewer as a paginated
+  list. Unlike the course-scoped list, this endpoint DOES
+  surface soft-deleted guides -- the response includes a
+  nullable `deleted_at` field so the owner can see (and
+  eventually restore) their own deleted content.
+  
+  Sort options: `updated` (default, updated_at DESC),
+  `newest` (created_at DESC), `title` (case-insensitive ASC).
+  Single direction per variant -- the endpoint does not
+  expose a `sort_dir` query param.
+  
+  Optional `course_id` filters to one course. A non-existent
+  course yields an empty array, not 404 (the filter just
+  yields no results).
+}

--- a/api/bruno/Me/List Recents.bru
+++ b/api/bruno/Me/List Recents.bru
@@ -1,0 +1,26 @@
+meta {
+  name: List Recents
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/api/me/recents
+  body: none
+  auth: inherit
+}
+
+params:query {
+  limit: 10
+}
+
+docs {
+  # List the authenticated user's most recently viewed items
+
+  Returns the most recently viewed items across files, study guides,
+  and courses for the authenticated user, merged and sorted by
+  `viewed_at DESC` and truncated to `limit`. Powers the "Recents"
+  section of the sidebar. Soft-deleted entities (files in a
+  deletion lifecycle, soft-deleted study guides) are excluded.
+  Courses have no soft-delete and are always eligible.
+}

--- a/api/bruno/Me/Toggle Course Favorite.bru
+++ b/api/bruno/Me/Toggle Course Favorite.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Toggle Course Favorite
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/me/courses/{{courseId}}/favorite
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Toggle the course favorite (ASK-157)
+
+  Toggles whether the authenticated user has favorited this
+  course. Same toggle semantics as the file favorite endpoint.
+  Permission-less: no enrollment check.
+}

--- a/api/bruno/Me/Toggle Study Guide Favorite.bru
+++ b/api/bruno/Me/Toggle Study Guide Favorite.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Toggle Study Guide Favorite
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/api/me/study-guides/{{studyGuideId}}/favorite
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Toggle the study guide favorite (ASK-156)
+
+  Toggles whether the authenticated user has favorited this
+  study guide. Same toggle semantics as the file favorite
+  endpoint -- inserts when missing, deletes when present.
+  Permission-less: no enrollment or ownership check.
+}

--- a/api/bruno/Quizzes/Add Quiz Question.bru
+++ b/api/bruno/Quizzes/Add Quiz Question.bru
@@ -1,0 +1,62 @@
+meta {
+  name: Add Quiz Question
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/quizzes/{{quizId}}/questions
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "correct_answer": null,
+    "feedback_correct": "string",
+    "feedback_incorrect": "string",
+    "hint": "string",
+    "options": [
+      {
+        "is_correct": false,
+        "text": "string"
+      }
+    ],
+    "question": "string",
+    "sort_order": 0,
+    "type": "multiple-choice"
+  }
+}
+
+docs {
+  # Add a question to an existing quiz
+
+  Appends a single question (with its answer options for MCQ, or
+  the auto-expanded True/False option pair for TF) to an
+  existing quiz. The validation rules are identical to the
+  per-question rules on POST /api/study-guides/{id}/quizzes --
+  same `type` enum, same per-type `correct_answer` typing, same
+  MCQ option counts and "exactly one correct" invariant.
+  
+  Authorization: creator-only. The authenticated user MUST be
+  `quizzes.creator_id`; any other authenticated user gets 403.
+  
+  Per-quiz cap: a quiz can hold at most 100 questions. The
+  count is taken inside the same transaction as the insert so
+  a concurrent add cannot push the quiz over the cap.
+  
+  `quizzes.updated_at` is refreshed on every successful add.
+  Active practice sessions are NOT affected -- the new
+  question is not retro-injected into existing
+  `practice_session_questions` snapshots; only sessions started
+  after the add will include it.
+  
+  404 covers BOTH the quiz being missing/soft-deleted AND the
+  parent study guide being soft-deleted (same convention as
+  PATCH /quizzes/{quiz_id}).
+  
+  Default `sort_order`: when omitted, defaults to the current
+  question count (so the new question lands at the end of the
+  existing sequence). An explicit value is honored verbatim --
+  callers may interleave with existing questions if they want.
+}

--- a/api/bruno/Quizzes/Delete Quiz Question.bru
+++ b/api/bruno/Quizzes/Delete Quiz Question.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Delete Quiz Question
+  type: http
+  seq: 8
+}
+
+delete {
+  url: {{baseUrl}}/api/quizzes/{{quizId}}/questions/{{questionId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Delete a question from a quiz (ASK-119)
+
+  Hard-delete one question from a quiz. The `quiz_answer_options`
+  for the question CASCADE-delete; references from
+  `practice_session_questions.question_id` and
+  `practice_answers.question_id` are SET NULL so historical
+  session data is preserved with a NULL question reference.
+  
+  A quiz must always carry at least 1 question; an attempt to
+  delete the last remaining question returns 400 with
+  `"quiz must have at least 1 question"`. The count check runs
+  inside the same transaction as the delete so two concurrent
+  deletes on a 2-question quiz can't both succeed.
+  
+  Authorization: creator-only. The authenticated user must be
+  `quizzes.creator_id`; any other authenticated user gets 403.
+  
+  404 covers all of: quiz missing/soft-deleted, parent study
+  guide soft-deleted, question missing, question belonging to a
+  different quiz.
+  
+  `quizzes.updated_at` is refreshed on every successful delete.
+}

--- a/api/bruno/Quizzes/Delete Quiz.bru
+++ b/api/bruno/Quizzes/Delete Quiz.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Delete Quiz
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{baseUrl}}/api/quizzes/{{quizId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Soft-delete a quiz
+
+  Soft-deletes the quiz by setting `deleted_at = now()` (the row
+  stays in the table; subsequent reads filter by `deleted_at IS
+  NULL` and treat the quiz as gone).
+  
+  Authorization: creator-only. The authenticated user MUST be
+  `quizzes.creator_id` for the action to proceed; any other
+  authenticated user gets 403.
+  
+  Idempotency: a second DELETE on an already-soft-deleted quiz
+  returns 404 (not 204). This is a deliberate choice -- a
+  duplicate DELETE that returned 204 would silently confirm a
+  destructive action and mask the "is this quiz still here?"
+  question the caller is actually asking. The 404 is also the
+  same response a non-creator would get for the same row, so
+  callers cannot distinguish "quiz was just deleted" from
+  "quiz never existed" or "you can't see this quiz" -- the
+  information-leak prevention covered by the unit tests.
+  
+  No cascade: practice sessions, questions, and answer options
+  are NOT touched. The quiz simply becomes invisible to the
+  list/detail endpoints. This preserves historical data for
+  completed sessions and matches the spec's "preserve practice
+  history" requirement.
+}

--- a/api/bruno/Quizzes/Get Quiz.bru
+++ b/api/bruno/Quizzes/Get Quiz.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Get Quiz
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/quizzes/{{quizId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Get a quiz with all questions and correct answers
+
+  Returns the full quiz payload — title, description, creator
+  (privacy floor: id + first_name + last_name only), and every
+  question with its options + per-type `correct_answer`. This is
+  the primary endpoint the practice player calls to render a
+  quiz.
+  
+  Correct answers are intentionally included on the wire --
+  AskAtlas is a study aid, not a proctored exam. Hiding answers
+  for protected questions (the `is_protected` column) is out of
+  scope for the MVP and tracked separately.
+  
+  Response shape per question type:
+    * `multiple-choice` -- `options` is a string array of option
+      text in `sort_order` ascending; `correct_answer` is the
+      text of the option whose `is_correct` flag is true.
+    * `true-false` -- `options` is omitted from the wire;
+      `correct_answer` is a boolean (resolved from the canonical
+      "True" option's `is_correct` flag).
+    * `freeform` -- `options` is omitted; `correct_answer` is
+      the `quiz_questions.reference_answer` string.
+  
+  Authorization: any authenticated user can fetch any quiz that
+  is live AND whose parent study guide is live. There is no
+  per-viewer access control beyond authentication.
+  
+  404 covers BOTH the quiz being missing/soft-deleted AND the
+  parent study guide being soft-deleted (matches the rest of
+  the quizzes surface).
+}

--- a/api/bruno/Quizzes/List Practice Sessions.bru
+++ b/api/bruno/Quizzes/List Practice Sessions.bru
@@ -1,0 +1,57 @@
+meta {
+  name: List Practice Sessions
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/quizzes/{{quizId}}/sessions
+  body: none
+  auth: inherit
+}
+
+params:query {
+  status: active
+  limit: 10
+  ~cursor: 
+}
+
+docs {
+  # List the authenticated user's practice sessions for a quiz
+
+  Returns the authenticated user's practice sessions for the
+  target quiz, sorted by `started_at DESC, id DESC`. Used by the
+  practice-history view to render past attempts and scores.
+  
+  Pagination: cursor-based keyset on `(started_at, id)`. Pass
+  the `next_cursor` from the previous response to fetch the
+  next page. `has_more` reports whether more pages exist beyond
+  the current one.
+  
+  Status filter: `active` returns only in-progress sessions
+  (`completed_at IS NULL`); `completed` returns only completed
+  sessions (`completed_at IS NOT NULL`); omitting the filter
+  returns both interleaved by `started_at DESC`.
+  
+  Score: for completed sessions, `score_percentage` is
+  `round((correct_answers / total_questions) * 100)` (same
+  formula as POST /sessions/{id}/complete and GET
+  /sessions/{id}). For in-progress sessions, `score_percentage`
+  is `null` because no final score exists yet.
+  
+  Authorization: scoped to the authenticated user. Sessions
+  belonging to other users on the same quiz are NEVER returned,
+  even if the requesting user is the quiz creator.
+  
+  Parent quiz lifecycle: a soft-deleted quiz, a quiz under a
+  soft-deleted study guide, and a missing quiz all return 404
+  (info-leak prevention -- the caller cannot distinguish them).
+  This is the OPPOSITE of GET /sessions/{id} (ASK-152), which
+  returns historical sessions for soft-deleted parents because
+  a single session read is anchored on the session id alone --
+  a list scoped to a quiz needs a live quiz to anchor on.
+  
+  Response shape: a compact summary per session (no `answers`
+  array). Use GET /api/sessions/{id} (ASK-152) to fetch full
+  detail including the chronological answer list.
+}

--- a/api/bruno/Quizzes/Replace Quiz Question.bru
+++ b/api/bruno/Quizzes/Replace Quiz Question.bru
@@ -1,0 +1,56 @@
+meta {
+  name: Replace Quiz Question
+  type: http
+  seq: 5
+}
+
+put {
+  url: {{baseUrl}}/api/quizzes/{{quizId}}/questions/{{questionId}}
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "correct_answer": null,
+    "feedback_correct": "string",
+    "feedback_incorrect": "string",
+    "hint": "string",
+    "options": [
+      {
+        "is_correct": false,
+        "text": "string"
+      }
+    ],
+    "question": "string",
+    "sort_order": 0,
+    "type": "multiple-choice"
+  }
+}
+
+docs {
+  # Replace a question in a quiz (ASK-108)
+
+  Full replacement of one question in a quiz. PUT semantics --
+  every field on the request body is required; unprovided fields
+  are NOT preserved. The validation rules are identical to a
+  single question on POST /api/study-guides/{id}/quizzes (same
+  type enum, per-type correct_answer typing, MCQ option counts,
+  exactly-one-correct invariant).
+  
+  The replacement runs in a single transaction:
+  delete-old-options -> update-question -> insert-new-options.
+  Type changes are allowed (MCQ -> TF -> freeform); the
+  per-type option set is rebuilt from scratch on every call.
+  
+  Authorization: creator-only. The authenticated user must be
+  `quizzes.creator_id`; any other authenticated user gets 403.
+  
+  404 covers BOTH the quiz being missing/soft-deleted, the
+  parent study guide being soft-deleted, the question being
+  absent, AND the question belonging to a different quiz.
+  
+  Existing `practice_answers` rows are NOT affected -- the
+  question_id reference persists across the replace, so
+  historical session data stays intact.
+}

--- a/api/bruno/Quizzes/Start Practice Session.bru
+++ b/api/bruno/Quizzes/Start Practice Session.bru
@@ -1,0 +1,65 @@
+meta {
+  name: Start Practice Session
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/quizzes/{{quizId}}/sessions
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Start a new practice session or resume an existing incomplete one
+
+  Returns the practice session for the authenticated user on the
+  target quiz. The status code distinguishes the two paths:
+  
+    * **201 Created** -- a new session was inserted. A snapshot
+      of the quiz's CURRENT questions is frozen into
+      `practice_session_questions` so subsequent edits to the
+      quiz (questions added or removed) do not affect this
+      session. `answers` is an empty array.
+    * **200 OK** -- an in-progress session already exists for
+      this user+quiz (`completed_at IS NULL`). The existing
+      row is returned along with all answers submitted so far.
+      No new snapshot is created.
+  
+  Stale-session cleanup: incomplete sessions whose `started_at`
+  is older than 7 days are hard-deleted before the resume check.
+  After cleanup, "no incomplete session" surfaces as 201
+  (fresh start) rather than 200 (resume) -- per spec AC6.
+  
+  Snapshot semantics: `total_questions` is the COUNT of
+  `quiz_questions` at session-start time. If a question is
+  deleted from the quiz LATER, the
+  `practice_session_questions.question_id` column is set to
+  NULL (ON DELETE SET NULL) but the row persists --
+  `total_questions` does not change. New questions added after
+  session start are NOT in the snapshot.
+  
+  Race protection: a partial unique index on
+  `practice_sessions(user_id, quiz_id) WHERE completed_at IS NULL`
+  guarantees at most one incomplete session per user+quiz at
+  the database level. Two simultaneous starts will both attempt
+  to insert; one wins, the other is detected via
+  `INSERT ... ON CONFLICT DO NOTHING RETURNING` and falls back
+  to the resume path (returning 200 with the winner's session).
+  
+  Authorization: any authenticated user can start a session on
+  any live quiz on a live study guide. There is no per-viewer
+  access control.
+  
+  Resumed-session question content: this endpoint returns
+  session state + answers only. The frontend fetches question
+  content separately via `GET /api/quizzes/{quiz_id}` (ASK-142).
+  
+  Response answer rows: `question_id`, `user_answer`, and
+  `is_correct` are all nullable on the wire. `question_id`
+  becomes NULL when the underlying question is hard-deleted
+  after the answer was submitted (ON DELETE SET NULL).
+  `user_answer` and `is_correct` are nullable to match the
+  schema, though in practice the submit-answer endpoint will
+  never write NULL values.
+}

--- a/api/bruno/Quizzes/Update Quiz.bru
+++ b/api/bruno/Quizzes/Update Quiz.bru
@@ -1,0 +1,46 @@
+meta {
+  name: Update Quiz
+  type: http
+  seq: 6
+}
+
+patch {
+  url: {{baseUrl}}/api/quizzes/{{quizId}}
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "description": "string",
+    "title": "string"
+  }
+}
+
+docs {
+  # Update a quiz's metadata (title and/or description)
+
+  Partial-update of the quiz's `title` and/or `description`.
+  Question-level edits flow through the per-question endpoints --
+  this PATCH only touches the quiz row.
+  
+  Authorization: creator-only. The authenticated user MUST be
+  `quizzes.creator_id`; any other authenticated user gets 403.
+  
+  Field semantics:
+    * Both fields are optional. An empty body `{}` is rejected
+      with 400 -- at least one field must be provided.
+    * `title` MUST be non-empty when provided (after trim) and
+      <=500 chars.
+    * `description` accepts JSON `null` to explicitly CLEAR
+      the existing value, a non-empty string to set the value
+      (max 2,000 chars after trim), and a whitespace-only
+      string is downgraded to a clear (NULL) since the column
+      should not store meaningless blank values. To leave the
+      current description untouched, OMIT the field entirely
+      from the request body.
+  
+  404 covers BOTH the quiz being missing/soft-deleted AND the
+  parent study guide being soft-deleted (per spec AC6).
+  `updated_at` is refreshed on every successful PATCH.
+}

--- a/api/bruno/README.md
+++ b/api/bruno/README.md
@@ -1,0 +1,83 @@
+# AskAtlas API — Bruno Collection
+
+A [Bruno](https://www.usebruno.com) collection covering every operation in
+`api/openapi.yaml`. Replaces the previous Postman workflow.
+
+## Layout
+
+```
+bruno/
+├── bruno.json               # collection manifest (auto-detected by Bruno)
+├── collection.bru           # collection-root auth block (bearer {{authToken}})
+├── README.md                # this file
+├── environments/
+│   ├── dev.bru              # baseUrl + authToken + path-param UUIDs for dev
+│   └── staging.bru          # same shape, pointed at staging
+├── Courses/                 # one folder per top-level path segment
+├── Files/
+├── Me/
+├── Quizzes/
+├── Schools/
+├── Sessions/
+└── Study Guides/
+```
+
+Each folder contains one `.bru` per operation. Folder grouping is the first
+non-variable segment of the OpenAPI path, so `/api/files/{id}` lands under
+`Files/` and `/api/me/recents` lands under `Me/`.
+
+## Quickstart
+
+1. Install Bruno (`brew install --cask bruno` or grab the app).
+2. `File → Open Collection` → point at `api/bruno/`.
+3. Pick the `dev` or `staging` environment from the dropdown.
+4. Paste a Clerk JWT into the `authToken` var (it's flagged secret so
+   it won't be printed in logs or committed accidentally).
+5. Send any request — bearer auth inherits from the collection root.
+
+### Grabbing a test JWT
+
+Clerk's dashboard under *Configure → Sessions → Tokens → Customize session
+token* exposes a long-lived testing JWT per environment. Use those values
+in `authToken`; they're already whitelisted against the matching API
+origin. Do not check real JWTs into git — the `vars:secret` block keeps
+them out of the file on save, but the `~authToken:` line is disabled by
+default so accidental commits land empty.
+
+## Regenerating
+
+`.bru` files (except `bruno.json`, `collection.bru`, and anything under
+`environments/`) are generated from `api/openapi.yaml` by
+`api/scripts/brunogen/main.go`. Re-run after any spec change:
+
+```sh
+make bruno
+```
+
+The generator:
+
+- wipes every subfolder except `environments/`
+- walks `paths` in sorted order, writes one `.bru` per operation
+- picks the first JSON example (or synthesizes one from the schema) for
+  request bodies
+- substitutes path params `{file_id}` → `{{fileId}}` (snake → camel) so
+  they bind to the env vars
+- renders `summary` + `description` into the `docs { }` block so each
+  request shows inline context
+
+Output is deterministic — re-running without spec changes produces zero
+diff.
+
+## Path parameters
+
+Every path-param UUID defaults to the NIL UUID
+(`00000000-0000-0000-0000-000000000000`) in both env files. An
+accidental send hits a deterministic 404 instead of mutating real data.
+Override individual vars in the env before sending requests that
+actually need to reach a row.
+
+## Adding an environment
+
+Copy `environments/dev.bru` to `environments/<name>.bru`, change
+`baseUrl`, keep the `vars:secret [ authToken ]` block. The generator
+leaves the `environments/` folder alone, so hand-edits stick.

--- a/api/bruno/Schools/Get School.bru
+++ b/api/bruno/Schools/Get School.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get School
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/schools/{{schoolId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Get a single school by ID
+
+}

--- a/api/bruno/Schools/List Schools.bru
+++ b/api/bruno/Schools/List Schools.bru
@@ -1,0 +1,22 @@
+meta {
+  name: List Schools
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/schools
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~q: 
+  page_limit: 25
+  ~cursor: 
+}
+
+docs {
+  # List and search schools
+
+}

--- a/api/bruno/Sessions/Abandon Practice Session.bru
+++ b/api/bruno/Sessions/Abandon Practice Session.bru
@@ -1,0 +1,55 @@
+meta {
+  name: Abandon Practice Session
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/api/sessions/{{sessionId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Hard-delete an in-progress practice session
+
+  Hard-deletes the session row and CASCADE-removes its
+  `practice_session_questions` snapshot rows and
+  `practice_answers` rows. Used by the practice player when a
+  user wants to start fresh on a quiz they previously started
+  but didn't finish.
+  
+  Only INCOMPLETE sessions (`completed_at IS NULL`) can be
+  abandoned. Completed sessions are historical records and
+  return 409. Deletion semantics are intentionally
+  asymmetric to GET /sessions/{id} (which returns historical
+  sessions even after parent soft-delete) -- a user
+  explicitly invoking DELETE on a completed session is
+  ambiguous enough to surface as an error rather than
+  silently destroy analytics data.
+  
+  Authorization: session-owner only (403 otherwise). 404
+  for missing sessions; the standard 404-beats-403 ordering
+  does NOT apply here because we have to load the row to
+  check ownership in the same locked SELECT, so we already
+  know the row exists by the time we'd return 403.
+  
+  Idempotency: NOT idempotent. A second DELETE on an
+  already-abandoned session returns 404, not 204. Callers
+  that want to "make sure it's gone" must tolerate 404 on
+  the second call.
+  
+  Race protection: SELECT FOR UPDATE on the session row
+  serializes against concurrent SubmitAnswer (ASK-137) and
+  CompleteSession (ASK-140). If the DELETE wins, a pending
+  SubmitAnswer either fails its own locked SELECT (404 from
+  sql.ErrNoRows on the gone row) or fails its insert with
+  an FK violation depending on commit timing -- both surface
+  as a clean error to the answer caller. If a concurrent
+  CompleteSession wins, our locked SELECT sees `completed_at`
+  set and we return 409.
+  
+  After abandoning, calling POST /quizzes/{quiz_id}/sessions
+  creates a fresh session (the partial unique index
+  previously held by the abandoned row is now free).
+}

--- a/api/bruno/Sessions/Complete Practice Session.bru
+++ b/api/bruno/Sessions/Complete Practice Session.bru
@@ -1,0 +1,48 @@
+meta {
+  name: Complete Practice Session
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/sessions/{{sessionId}}/complete
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Mark a practice session as completed and return the score
+
+  Sets the session's `completed_at = now()` and returns the
+  finalized session payload with a server-computed
+  `score_percentage`. Can be called even when not all questions
+  were answered (the user quit early) -- `total_questions`
+  stays at the snapshot value, `correct_answers` reflects
+  only the answers actually submitted.
+  
+  Score: `round((correct_answers / total_questions) * 100)`,
+  rounded to the nearest integer. When `total_questions` is 0
+  (theoretically unreachable -- create-quiz requires >=1 --
+  but the read-side defensively handles it), the score is 0
+  rather than a division-by-zero panic.
+  
+  Authorization: the session must belong to the
+  authenticated user (403 otherwise). Once completed, a
+  second call returns 409 -- this endpoint is NOT
+  idempotent. Callers that want to fetch a completed
+  session's state should use GET /api/sessions/{id}
+  (ASK-152, future).
+  
+  Race protection: SELECT FOR UPDATE on the session row
+  serializes against any concurrent SubmitAnswer (ASK-137).
+  If an answer commits first, it's counted in the final
+  score; if complete commits first, the answer call returns
+  409.
+  
+  Response shape: similar to PracticeSessionResponse but
+  without the `answers` array (callers can fetch them via
+  GET /api/sessions/{id}) and with the new
+  `score_percentage` field. `completed_at` is non-nullable
+  on this endpoint -- a successful response always carries
+  the freshly-set timestamp.
+}

--- a/api/bruno/Sessions/Get Practice Session.bru
+++ b/api/bruno/Sessions/Get Practice Session.bru
@@ -1,0 +1,49 @@
+meta {
+  name: Get Practice Session
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/sessions/{{sessionId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Get a practice session detail including all submitted answers
+
+  Returns the full session payload: metadata + all submitted
+  answers in chronological order. Used by the practice player
+  to render post-completion review and to restore in-progress
+  state on return visits (the start endpoint also returns the
+  same data on resume, so this endpoint exists primarily for
+  the post-complete results view).
+  
+  Response shape vs sibling sessions endpoints:
+    * Like PracticeSessionResponse (POST /quizzes/{id}/sessions):
+      includes id, quiz_id, started_at, completed_at,
+      total_questions, correct_answers, answers.
+    * Like CompletedSessionResponse (POST /sessions/{id}/complete):
+      includes a server-computed score_percentage.
+    * Unique to this endpoint: score_percentage is nullable
+      (null while the session is in-progress; set once the
+      user calls complete).
+  
+  Authorization: session-owner only (403 otherwise). 404 for
+  missing sessions.
+  
+  Historical preservation: a session whose parent quiz or
+  study guide has been soft-deleted is STILL returned --
+  sessions are append-only history that survives parent
+  deletion. This is opposite to the read endpoints on the
+  quizzes surface (which 404 on a deleted parent) because
+  sessions have a different lifecycle: once finalised, they
+  belong to the user, not the quiz.
+  
+  Answers with `question_id: null` (the underlying quiz
+  question was hard-deleted via ON DELETE SET NULL after the
+  answer was submitted) are INCLUDED in the response, not
+  filtered. The frontend should render those as orphaned
+  answer rows rather than silently dropping them.
+}

--- a/api/bruno/Sessions/Submit Practice Answer.bru
+++ b/api/bruno/Sessions/Submit Practice Answer.bru
@@ -1,0 +1,62 @@
+meta {
+  name: Submit Practice Answer
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/sessions/{{sessionId}}/answers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "question_id": "00000000-0000-0000-0000-000000000000",
+    "user_answer": "string"
+  }
+}
+
+docs {
+  # Submit an answer for one question in a practice session
+
+  Records the user's answer to a single question. The backend
+  determines correctness server-side -- the client does NOT
+  send `is_correct`. Per-type validation:
+  
+    * `multiple-choice` -- exact string match between
+      `user_answer` and the text of the option whose
+      `is_correct` flag is true. `verified: true`.
+    * `true-false` -- `user_answer` MUST be the lowercase
+      string `"true"` or `"false"`. The backend parses it
+      and compares against the canonical answer derived
+      from the "True" option's `is_correct` flag.
+      `verified: true`.
+    * `freeform` -- case-insensitive trimmed string compare
+      against `quiz_questions.reference_answer`. The
+      response carries `verified: false` because string-match
+      is not semantic validation.
+  
+  On a correct answer, the parent session's
+  `correct_answers` counter is incremented by 1 in the
+  same transaction as the insert.
+  
+  Authorization: the session must belong to the
+  authenticated user (403 otherwise). Sessions that have
+  already been completed reject submissions with 409 (the
+  SELECT FOR UPDATE on the session row serializes against
+  a concurrent complete-session call).
+  
+  Duplicate submission protection: the
+  `uq_practice_answers_session_question` unique constraint
+  catches the case where a question is answered twice in
+  the same session. The service surfaces the unique
+  violation as a typed 400 with details
+  `{"question_id": "already answered"}`.
+  
+  No auto-completion: even when this answer is the last
+  unanswered question in the snapshot, the session stays
+  in-progress until the client explicitly calls
+  `POST /api/sessions/{session_id}/complete` (ASK-140,
+  future).
+}

--- a/api/bruno/Study Guides/Attach File.bru
+++ b/api/bruno/Study Guides/Attach File.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Attach File
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/files/{{fileId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Attach a file to a study guide
+
+  Links an already-uploaded file to a study guide. The file must
+  be owned by the viewer (`files.user_id == JWT viewer`) and in
+  `status = 'complete'` with no deletion in progress.
+  
+  Authorization: only the file owner can attach. A user who does
+  not own the file gets 403 (regardless of whether they own the
+  guide -- the rule is "you can only put your own files on
+  guides", to prevent linking other users' private uploads).
+  
+  409 on duplicate -- the same `(file_id, study_guide_id)` pair
+  is already attached.
+}

--- a/api/bruno/Study Guides/Attach Resource.bru
+++ b/api/bruno/Study Guides/Attach Resource.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Attach Resource
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/resources
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "description": "string",
+    "title": "string",
+    "type": "link",
+    "url": "https://example.com"
+  }
+}
+
+docs {
+  # Attach an external resource to a study guide
+
+  Attaches a URL-based resource (link / video / article / pdf) to
+  a study guide. Resources are community-contributed -- any
+  authenticated user can attach.
+  
+  Resource reuse: a (creator_id, url) pair is unique in the
+  `resources` table. If the viewer has previously created a
+  resource row with the same URL (for any guide), the existing
+  row is reused via INSERT ... ON CONFLICT DO NOTHING + lookup;
+  the original title / description / type are preserved.
+  
+  Conflict detection: if ANY resource (regardless of creator)
+  with the same URL is already attached to this guide, returns
+  409 BEFORE the upsert -- avoids creating new resource rows
+  only to discard them on the join PK violation.
+  
+  Returns 201 with the (possibly-reused) resource row.
+}

--- a/api/bruno/Study Guides/Cast Study Guide Vote.bru
+++ b/api/bruno/Study Guides/Cast Study Guide Vote.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Cast Study Guide Vote
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/votes
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "vote": "up"
+  }
+}
+
+docs {
+  # Cast or change a vote on a study guide
+
+  Upserts the authenticated user's vote on the guide. Same-direction
+  re-submits are no-ops; opposite-direction submits flip the vote.
+  Returns the post-upsert `vote_score` so the UI can update without
+  a refetch. Soft-deleted guides return 404. Creators may vote on
+  their own guides (no self-vote restriction).
+}

--- a/api/bruno/Study Guides/Create Quiz.bru
+++ b/api/bruno/Study Guides/Create Quiz.bru
@@ -1,0 +1,66 @@
+meta {
+  name: Create Quiz
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/quizzes
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "description": "string",
+    "questions": [
+      {
+        "correct_answer": null,
+        "feedback_correct": "string",
+        "feedback_incorrect": "string",
+        "hint": "string",
+        "options": [
+          {
+            "is_correct": false,
+            "text": "string"
+          }
+        ],
+        "question": "string",
+        "sort_order": 0,
+        "type": "multiple-choice"
+      }
+    ],
+    "title": "string"
+  }
+}
+
+docs {
+  # Create a quiz attached to a study guide
+
+  Creates a new quiz with all of its questions and answer options
+  in a single atomic request. The frontend quiz builder submits the
+  entire quiz at once: if any question fails validation, nothing is
+  created (the entire write runs in one transaction).
+  
+  Authorization: any authenticated user can create a quiz on any
+  study guide. AskAtlas explicitly encourages collaborative quiz
+  contribution; ownership of the underlying guide is not required.
+  `creator_id` is set from the JWT and any value supplied in the
+  body is ignored.
+  
+  Per-question validation:
+    * `multiple-choice` -- 2-10 options. Each option has `text`
+      (1-500 chars) and `is_correct` (boolean). Exactly one option
+      must have `is_correct: true`. The request's `correct_answer`
+      field is ignored on MCQ.
+    * `true-false` -- `correct_answer` MUST be a boolean. The API
+      internally creates two `quiz_answer_options` rows (`True`
+      and `False`) with the matching `is_correct` flag.
+    * `freeform` -- `correct_answer` MUST be a non-empty string
+      (max 500 chars). Stored as `quiz_questions.reference_answer`.
+      No `quiz_answer_options` rows are created.
+  
+  The response mirrors GET /quizzes/{quiz_id} (future ticket) so
+  the frontend can render the freshly-created quiz without a
+  follow-up GET.
+}

--- a/api/bruno/Study Guides/Delete Study Guide.bru
+++ b/api/bruno/Study Guides/Delete Study Guide.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Delete Study Guide
+  type: http
+  seq: 9
+}
+
+delete {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Soft-delete a study guide
+
+  Soft-deletes the guide (`study_guides.deleted_at = now()`) and
+  cascades to all child quizzes (`quizzes.deleted_at = now()`)
+  atomically in a single transaction. Application-level cascade
+  (not DB CASCADE) so quizzes keep their own deleted_at lifecycle
+  for any future undelete workflow.
+  
+  Creator-only: 403 if the viewer is not the guide's creator. 404
+  for missing or already-deleted guides. Order of checks:
+    1. Fetch + lock guide row.
+    2. 404 if missing or deleted_at IS NOT NULL.
+    3. 403 if creator_id != viewer_id.
+    4. UPDATE guide + child quizzes, COMMIT.
+}

--- a/api/bruno/Study Guides/Detach File.bru
+++ b/api/bruno/Study Guides/Detach File.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Detach File
+  type: http
+  seq: 10
+}
+
+delete {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/files/{{fileId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Detach a file from a study guide
+
+  Removes the link between a file and a guide. Does NOT delete
+  the file itself -- a file may be attached to many guides /
+  courses.
+  
+  Dual-authz: viewer must be EITHER the file owner OR the
+  study guide creator. Broader than POST (which requires file
+  owner only) so a guide creator can curate their guide's
+  attached files without owning every file.
+  
+  404 covers both 'guide missing/deleted' and 'file not
+  attached to this guide'.
+}

--- a/api/bruno/Study Guides/Detach Resource.bru
+++ b/api/bruno/Study Guides/Detach Resource.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Detach Resource
+  type: http
+  seq: 12
+}
+
+delete {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/resources/{{resourceId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Detach a resource from a study guide
+
+  Removes the link between a resource and a guide. Does NOT
+  delete the resource itself -- a resource may be attached to
+  multiple guides + courses.
+  
+  Authorization: the guide's creator OR the user who attached
+  the resource (`attached_by` on the join row) can detach. The
+  resource's own creator (if different from both) cannot detach
+  when they didn't attach it here.
+  
+  404 covers both 'guide missing/deleted' and 'resource not
+  attached to this guide'.
+}

--- a/api/bruno/Study Guides/Get Study Guide.bru
+++ b/api/bruno/Study Guides/Get Study Guide.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Study Guide
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Get a study guide detail
+
+  Returns the full study-guide detail including `content`, the
+  authenticated user's own vote state (`user_vote`), the list of
+  recommenders, inline quizzes (with `question_count`), resources,
+  and attached files. Soft-deleted guides return 404.
+  
+  This endpoint is a pure read -- no view-counter increment, no
+  last-viewed upsert, no mutation of any kind. View tracking lives
+  on its own dedicated POST (future ticket, mirroring
+  POST /api/files/{file_id}/view in ASK-134) so GET stays safe
+  and idempotent per HTTP semantics.
+}

--- a/api/bruno/Study Guides/List Quizzes.bru
+++ b/api/bruno/Study Guides/List Quizzes.bru
@@ -1,0 +1,29 @@
+meta {
+  name: List Quizzes
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/quizzes
+  body: none
+  auth: inherit
+}
+
+docs {
+  # List quizzes attached to a study guide
+
+  Returns every non-soft-deleted quiz attached to the given study
+  guide, with the creator (privacy floor: id + first_name +
+  last_name only) and a server-computed `question_count`. Quizzes
+  are ordered by `created_at DESC` (newest first), with `id` as
+  the deterministic tiebreaker on identical timestamps.
+  
+  No pagination -- per the PRD, study guides typically host a
+  handful of quizzes (<10) and the practice page renders them all
+  in one go. Non-deleted-only by construction (no `include_deleted`
+  toggle); a soft-deleted quiz never surfaces.
+  
+  Returns 404 when the study guide does not exist OR is itself
+  soft-deleted, mirroring the studyguides surface convention.
+}

--- a/api/bruno/Study Guides/Recommend Study Guide.bru
+++ b/api/bruno/Study Guides/Recommend Study Guide.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Recommend Study Guide
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/recommendations
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Recommend a study guide
+
+  Records that the authenticated user (an instructor or TA in the
+  guide's course) recommends the guide. Recommendations contribute
+  to the `is_recommended` badge and the `recommended_by` list on
+  the guide detail.
+  
+  Authorization: viewer must hold the `instructor` or `ta` role in
+  AT LEAST ONE section of the guide's course. Holding a
+  non-elevated role (`student`) in some sections does NOT block
+  the action -- the rule is "any elevated role somewhere in the
+  course suffices".
+  
+  Returns 409 on duplicate (same viewer recommended this guide
+  before) -- recommendations are not idempotent because the
+  creation timestamp matters and re-recommending would silently
+  bump it.
+}

--- a/api/bruno/Study Guides/Remove Study Guide Recommendation.bru
+++ b/api/bruno/Study Guides/Remove Study Guide Recommendation.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Remove Study Guide Recommendation
+  type: http
+  seq: 11
+}
+
+delete {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/recommendations
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Remove the authenticated user's recommendation on a study guide
+
+  Hard-deletes the (viewer, guide) row in
+  `study_guide_recommendations`. Authorization mirrors the POST
+  side: viewer must currently hold instructor/TA in the guide's
+  course (a former TA who lost the role can't manage their old
+  recommendations -- the policy is "current elevated-role users
+  only").
+  
+  404 covers BOTH "guide missing/deleted" and "viewer never
+  recommended this guide" -- by design, since the desired end
+  state is "no recommendation from viewer", which is reached in
+  either case from the caller's point of view.
+}

--- a/api/bruno/Study Guides/Remove Study Guide Vote.bru
+++ b/api/bruno/Study Guides/Remove Study Guide Vote.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Remove Study Guide Vote
+  type: http
+  seq: 13
+}
+
+delete {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}/votes
+  body: none
+  auth: inherit
+}
+
+docs {
+  # Remove the authenticated user's vote on a study guide
+
+  Hard-deletes the row in `study_guide_votes` for the
+  (viewer, guide) pair, returning the user to a neutral state.
+  Returns 404 when the guide is missing/soft-deleted OR when the
+  viewer has no existing vote -- both surfaces are collapsed to
+  404 by design (the desired state is "no vote", which is reached
+  in either case from the caller's point of view).
+}

--- a/api/bruno/Study Guides/Update Study Guide.bru
+++ b/api/bruno/Study Guides/Update Study Guide.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Update Study Guide
+  type: http
+  seq: 8
+}
+
+patch {
+  url: {{baseUrl}}/api/study-guides/{{studyGuideId}}
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "content": "string",
+    "description": "string",
+    "tags": [
+      "string"
+    ],
+    "title": "string"
+  }
+}
+
+docs {
+  # Update a study guide
+
+  Partial update of any subset of `title`, `description`, `content`,
+  or `tags`. Only fields provided in the request body are touched;
+  absent fields preserve their current values. Tags, when provided,
+  are REPLACED entirely (no merge) and normalized server-side
+  (trim + lowercase + dedupe).
+  
+  Creator-only: 403 if the viewer is not the guide's creator. 404
+  for missing or already-deleted guides. Order of checks:
+    1. Validate the request body (per-field caps + at-least-one
+       field provided).
+    2. Fetch + lock guide row.
+    3. 404 if missing or deleted_at IS NOT NULL.
+    4. 403 if creator_id != viewer_id.
+    5. UPDATE only the provided fields, set updated_at = now(),
+       COMMIT.
+    6. Re-hydrate the full StudyGuideDetail (same shape as GET).
+}

--- a/api/bruno/bruno.json
+++ b/api/bruno/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "AskAtlas API",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/api/bruno/collection.bru
+++ b/api/bruno/collection.bru
@@ -1,0 +1,33 @@
+auth {
+  mode: bearer
+}
+
+auth:bearer {
+  token: {{authToken}}
+}
+
+docs {
+  # AskAtlas API -- Bruno Collection
+
+  Every request in this collection inherits the collection-level
+  bearer auth. Set `authToken` in the active environment to a Clerk
+  JWT; point `baseUrl` at the target API. The collection ships with
+  `dev` and `staging` environments; add a `local` file if you run
+  `make dev` against `http://localhost:8080`.
+
+  ## Regenerating
+
+  `.bru` files are generated from `api/openapi.yaml` by
+  `scripts/brunogen/main.go`. Re-run via `make bruno` after any spec
+  change. Hand-edits to generated files will be clobbered; add
+  long-form notes to this `collection.bru` docs block or to the
+  environment files instead.
+
+  ## Path parameters
+
+  Operations with path params surface them as collection variables
+  in the active environment (e.g. `fileId`, `studyGuideId`). Bruno
+  substitutes `{{fileId}}` at send time. Defaults to the NIL UUID
+  so a first-time run hits a deterministic 404 instead of
+  accidentally mutating live data.
+}

--- a/api/bruno/environments/dev.bru
+++ b/api/bruno/environments/dev.bru
@@ -1,0 +1,27 @@
+vars {
+  baseUrl: https://dev-api.askatlas.ai
+  ~authToken: REPLACE_ME_WITH_A_CLERK_DEV_JWT
+  fileId: 00000000-0000-0000-0000-000000000000
+  studyGuideId: 00000000-0000-0000-0000-000000000000
+  quizId: 00000000-0000-0000-0000-000000000000
+  questionId: 00000000-0000-0000-0000-000000000000
+  sessionId: 00000000-0000-0000-0000-000000000000
+  courseId: 00000000-0000-0000-0000-000000000000
+  schoolId: 00000000-0000-0000-0000-000000000000
+  resourceId: 00000000-0000-0000-0000-000000000000
+  sectionId: 00000000-0000-0000-0000-000000000000
+}
+
+vars:secret [
+  authToken
+]
+
+docs {
+  # Dev environment
+
+  Set `authToken` to a Clerk JWT valid against the dev tenant --
+  Bruno marks it secret so it won't leak into committed run reports.
+  Every path-param UUID defaults to NIL (00000000-...) so an
+  accidental send against a default variable hits 404, not a real
+  row.
+}

--- a/api/bruno/environments/staging.bru
+++ b/api/bruno/environments/staging.bru
@@ -1,0 +1,27 @@
+vars {
+  baseUrl: https://staging-api.askatlas.ai
+  ~authToken: REPLACE_ME_WITH_A_CLERK_STAGING_JWT
+  fileId: 00000000-0000-0000-0000-000000000000
+  studyGuideId: 00000000-0000-0000-0000-000000000000
+  quizId: 00000000-0000-0000-0000-000000000000
+  questionId: 00000000-0000-0000-0000-000000000000
+  sessionId: 00000000-0000-0000-0000-000000000000
+  courseId: 00000000-0000-0000-0000-000000000000
+  schoolId: 00000000-0000-0000-0000-000000000000
+  resourceId: 00000000-0000-0000-0000-000000000000
+  sectionId: 00000000-0000-0000-0000-000000000000
+}
+
+vars:secret [
+  authToken
+]
+
+docs {
+  # Staging environment
+
+  Set `authToken` to a Clerk JWT valid against the staging tenant.
+  Every path-param UUID defaults to NIL so an accidental send hits
+  404, not a real row. Use this env for smoke-testing PR branches
+  after `gh workflow run api-deployments.yml --ref <branch>
+  -f environment=stage`.
+}

--- a/api/makefile
+++ b/api/makefile
@@ -33,7 +33,7 @@ endef
 
 .PHONY: dev stage prod build install format format-check lint test tidy tidy-check \
 	sqlc/generate docker-build docker-run mockery seed seed-schools seed-courses \
-	seed-study-guides e2e generate-docs
+	seed-study-guides e2e generate-docs bruno
 
 dev:
 	infisical run --env=dev -- go run $(MAIN_PATH)
@@ -68,6 +68,16 @@ mockery:
 generate-api:
 	mkdir -p internal/api
 	go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0 -config oapi-codegen.yaml openapi.yaml
+
+## make bruno
+##
+## Regenerates the Bruno collection under bruno/ from openapi.yaml. Wipes
+## every subfolder except bruno/environments/ (which is hand-maintained)
+## and re-emits one .bru per operation, grouped by the first non-variable
+## path segment. Run after any openapi.yaml change so the Bruno sidebar
+## stays in sync. Safe to run repeatedly -- output is deterministic.
+bruno:
+	go run ./scripts/brunogen
 
 generate-docs:
 	rm -rf ../docs/docs/backend

--- a/api/scripts/brunogen/main.go
+++ b/api/scripts/brunogen/main.go
@@ -1,0 +1,558 @@
+// Command brunogen emits a Bruno (.bru) collection from openapi.yaml.
+//
+// One file per operation, grouped into folders by the first URL
+// segment (files/, me/, study-guides/, etc). Path params surface as
+// {{camelCaseName}} placeholders that resolve from the active
+// environment; query params surface in a params:query block with
+// their default value or an empty placeholder; JSON request bodies
+// get an example synthesized from the schema.
+//
+// Run via `make bruno` or `go run ./scripts/brunogen`. The
+// collection root (bruno/bruno.json, bruno/collection.bru,
+// bruno/environments/) is hand-maintained and never touched by
+// this tool; only the per-folder operation .bru files are written.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+const (
+	specPath       = "openapi.yaml"
+	collectionRoot = "bruno"
+)
+
+// methodOrder canonicalises the render order when an operation has
+// multiple methods on the same path (rare but possible -- the
+// detail routes on /study-guides/{id} have GET + PATCH + DELETE).
+var methodOrder = []string{"GET", "POST", "PUT", "PATCH", "DELETE"}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "brunogen:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromFile(specPath)
+	if err != nil {
+		return fmt.Errorf("load %s: %w", specPath, err)
+	}
+	if err := doc.Validate(loader.Context); err != nil {
+		return fmt.Errorf("validate %s: %w", specPath, err)
+	}
+
+	// Wipe every per-folder tree under collectionRoot on each run so
+	// stale .bru files from removed operations don't linger.
+	// Environment files + bruno.json + collection.bru are untouched
+	// (they live at the root, not inside operation folders).
+	if err := cleanGeneratedFolders(collectionRoot); err != nil {
+		return fmt.Errorf("clean: %w", err)
+	}
+
+	ops := collectOps(doc)
+	if err := writeOps(ops); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+
+	fmt.Printf("brunogen: wrote %d operations to %s/\n", len(ops), collectionRoot)
+	return nil
+}
+
+// operation is the flattened view brunogen actually renders from.
+type operation struct {
+	Folder   string
+	Seq      int
+	Name     string
+	FileName string
+	Method   string
+	Path     string
+	Summary  string
+	Desc     string
+	Query    []param
+	PathVars []string // camelCase names pre-substituted into URL
+	BodyJSON string   // empty when no JSON body
+	HasBody  bool
+}
+
+type param struct {
+	Name     string // wire name (snake_case, matches spec)
+	Default  string // first enum, default, or placeholder
+	Disabled bool   // render with `~key:` prefix (no default -> disabled)
+}
+
+// collectOps walks the doc and builds an operation slice sorted
+// first by folder, then by method order (GET, POST, ...), then by
+// path. Sequence numbers are assigned per folder in that final
+// order so Bruno's sidebar matches the render order deterministically.
+func collectOps(doc *openapi3.T) []operation {
+	var ops []operation
+	paths := doc.Paths.Map()
+	pathKeys := make([]string, 0, len(paths))
+	for p := range paths {
+		pathKeys = append(pathKeys, p)
+	}
+	sort.Strings(pathKeys)
+
+	for _, p := range pathKeys {
+		pi := paths[p]
+		for _, m := range methodOrder {
+			op := operationForMethod(pi, m)
+			if op == nil {
+				continue
+			}
+			ops = append(ops, buildOp(doc, p, m, op))
+		}
+	}
+
+	sort.SliceStable(ops, func(i, j int) bool {
+		if ops[i].Folder != ops[j].Folder {
+			return ops[i].Folder < ops[j].Folder
+		}
+		mi := methodOrderIndex(ops[i].Method)
+		mj := methodOrderIndex(ops[j].Method)
+		if mi != mj {
+			return mi < mj
+		}
+		return ops[i].Path < ops[j].Path
+	})
+
+	// Assign sequence numbers per folder.
+	seq := map[string]int{}
+	for i := range ops {
+		seq[ops[i].Folder]++
+		ops[i].Seq = seq[ops[i].Folder]
+	}
+	return ops
+}
+
+func operationForMethod(pi *openapi3.PathItem, method string) *openapi3.Operation {
+	switch method {
+	case "GET":
+		return pi.Get
+	case "POST":
+		return pi.Post
+	case "PUT":
+		return pi.Put
+	case "PATCH":
+		return pi.Patch
+	case "DELETE":
+		return pi.Delete
+	}
+	return nil
+}
+
+func methodOrderIndex(m string) int {
+	for i, v := range methodOrder {
+		if v == m {
+			return i
+		}
+	}
+	return len(methodOrder)
+}
+
+// buildOp pulls the renderable fields out of the spec types.
+func buildOp(_ *openapi3.T, path, method string, op *openapi3.Operation) operation {
+	folder := folderFor(path)
+	name := titleFromOperationID(op.OperationID)
+	fileName := name + ".bru"
+
+	out := operation{
+		Folder:   folder,
+		Name:     name,
+		FileName: fileName,
+		Method:   method,
+		Path:     path,
+		Summary:  op.Summary,
+		Desc:     strings.TrimSpace(op.Description),
+	}
+
+	// Path-param vars: `{file_id}` -> `{{fileId}}` in the URL, and
+	// the camelCase name gets added to PathVars for any per-request
+	// docs that want to enumerate them.
+	for _, pref := range op.Parameters {
+		if pref == nil || pref.Value == nil {
+			continue
+		}
+		p := pref.Value
+		switch p.In {
+		case openapi3.ParameterInPath:
+			out.PathVars = append(out.PathVars, snakeToCamel(p.Name))
+		case openapi3.ParameterInQuery:
+			out.Query = append(out.Query, queryParam(p))
+		}
+	}
+
+	// Request body: only JSON content is supported (the spec uses
+	// application/json exclusively). Synthesized example comes from
+	// schema.Example when provided, otherwise from a recursive
+	// walk that emits placeholder values by type.
+	if op.RequestBody != nil && op.RequestBody.Value != nil {
+		if m := op.RequestBody.Value.Content.Get("application/json"); m != nil {
+			body := pickJSONExample(m)
+			if body != "" {
+				out.HasBody = true
+				out.BodyJSON = body
+			}
+		}
+	}
+
+	return out
+}
+
+// folderFor groups operations into Bruno sidebar folders. The first
+// non-variable segment is the group name -- /files/{id}/grants goes
+// under "Files", /me/study-guides under "Me", etc. Folder names are
+// Title-Cased for readability in Bruno.
+func folderFor(path string) string {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	for _, p := range parts {
+		if p == "" || strings.HasPrefix(p, "{") {
+			continue
+		}
+		return toTitle(strings.ReplaceAll(p, "-", " "))
+	}
+	return "Misc"
+}
+
+// titleFromOperationID converts a PascalCase operationId ("ListFiles")
+// into a spaced title ("List Files") suitable for the Bruno meta
+// name + .bru filename.
+func titleFromOperationID(opID string) string {
+	if opID == "" {
+		return "Unnamed"
+	}
+	var b strings.Builder
+	for i, r := range opID {
+		if i > 0 && unicode.IsUpper(r) {
+			b.WriteByte(' ')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// toTitle lowercases then upper-cases the first rune of each word.
+// Used for folder names.
+func toTitle(s string) string {
+	words := strings.Fields(s)
+	for i, w := range words {
+		if w == "" {
+			continue
+		}
+		runes := []rune(strings.ToLower(w))
+		runes[0] = unicode.ToUpper(runes[0])
+		words[i] = string(runes)
+	}
+	return strings.Join(words, " ")
+}
+
+// snakeToCamel converts snake_case to camelCase for Bruno var names.
+// The spec uses snake_case path params (file_id); Bruno env vars are
+// conventionally camelCase (fileId).
+func snakeToCamel(s string) string {
+	parts := strings.Split(s, "_")
+	for i := 1; i < len(parts); i++ {
+		if parts[i] == "" {
+			continue
+		}
+		runes := []rune(parts[i])
+		runes[0] = unicode.ToUpper(runes[0])
+		parts[i] = string(runes)
+	}
+	return strings.Join(parts, "")
+}
+
+// queryParam extracts the Bruno render fields from an OpenAPI
+// parameter. When the schema declares a default or an enum, use the
+// first known-good value; otherwise emit the key as disabled so
+// Bruno shows it in the UI with an empty value rather than sending
+// a garbage query string on first open.
+func queryParam(p *openapi3.Parameter) param {
+	out := param{Name: p.Name, Disabled: true}
+	if p.Schema == nil || p.Schema.Value == nil {
+		return out
+	}
+	sv := p.Schema.Value
+	if sv.Default != nil {
+		out.Default = fmt.Sprintf("%v", sv.Default)
+		out.Disabled = false
+		return out
+	}
+	if len(sv.Enum) > 0 {
+		out.Default = fmt.Sprintf("%v", sv.Enum[0])
+		out.Disabled = false
+		return out
+	}
+	// Otherwise stay disabled with an empty value -- user fills in.
+	return out
+}
+
+// pickJSONExample chooses the best JSON body example for a
+// requestBody: the explicit example on the MediaType, the schema's
+// example, or a synthesized placeholder object walked from the
+// schema. Returned string is a valid JSON document, ready to drop
+// into a Bruno body:json block.
+func pickJSONExample(m *openapi3.MediaType) string {
+	if m.Example != nil {
+		return prettyJSON(m.Example)
+	}
+	if m.Examples != nil {
+		for _, ex := range m.Examples {
+			if ex.Value != nil && ex.Value.Value != nil {
+				return prettyJSON(ex.Value.Value)
+			}
+		}
+	}
+	if m.Schema != nil {
+		return prettyJSON(synthesizeFromSchema(m.Schema, map[string]bool{}))
+	}
+	return ""
+}
+
+// synthesizeFromSchema recursively builds a Go value that mirrors
+// the schema's structure, using the schema's Example when present
+// and placeholder values otherwise. The visited map guards against
+// self-referential schemas (rare but possible with $ref loops).
+func synthesizeFromSchema(ref *openapi3.SchemaRef, visited map[string]bool) interface{} {
+	if ref == nil || ref.Value == nil {
+		return nil
+	}
+	if ref.Ref != "" {
+		if visited[ref.Ref] {
+			return nil
+		}
+		visited[ref.Ref] = true
+		defer delete(visited, ref.Ref)
+	}
+	s := ref.Value
+	if s.Example != nil {
+		return s.Example
+	}
+	if s.Default != nil {
+		return s.Default
+	}
+	if len(s.Enum) > 0 {
+		return s.Enum[0]
+	}
+
+	// kin-openapi uses a Types slice; for schemas we care about,
+	// exactly one type is declared.
+	tp := ""
+	if s.Type != nil && len(*s.Type) > 0 {
+		tp = (*s.Type)[0]
+	}
+	switch tp {
+	case "object":
+		return synthesizeObject(s, visited)
+	case "array":
+		if s.Items == nil {
+			return []interface{}{}
+		}
+		return []interface{}{synthesizeFromSchema(s.Items, visited)}
+	case "string":
+		return placeholderString(s.Format)
+	case "integer", "number":
+		return 0
+	case "boolean":
+		return false
+	}
+	// Composite schemas (allOf/oneOf/anyOf): walk the first variant.
+	if len(s.AllOf) > 0 {
+		return synthesizeFromSchema(s.AllOf[0], visited)
+	}
+	if len(s.OneOf) > 0 {
+		return synthesizeFromSchema(s.OneOf[0], visited)
+	}
+	if len(s.AnyOf) > 0 {
+		return synthesizeFromSchema(s.AnyOf[0], visited)
+	}
+	return nil
+}
+
+// synthesizeObject walks an object schema's Properties in
+// deterministic key order so the generated JSON is stable across runs.
+func synthesizeObject(s *openapi3.Schema, visited map[string]bool) map[string]interface{} {
+	out := map[string]interface{}{}
+	keys := make([]string, 0, len(s.Properties))
+	for k := range s.Properties {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		out[k] = synthesizeFromSchema(s.Properties[k], visited)
+	}
+	return out
+}
+
+// placeholderString picks a sensible string value for a given
+// format hint so copy-paste users get a body that passes surface
+// validation without hand-editing every field.
+func placeholderString(format string) string {
+	switch format {
+	case "uuid":
+		return "00000000-0000-0000-0000-000000000000"
+	case "date-time":
+		return "2026-04-20T00:00:00Z"
+	case "date":
+		return "2026-04-20"
+	case "email":
+		return "user@example.com"
+	case "uri", "url":
+		return "https://example.com"
+	}
+	return "string"
+}
+
+// prettyJSON formats a value with two-space indentation so the
+// Bruno editor renders it readably. On error (should not happen for
+// types we construct), fall back to a best-effort %#v.
+func prettyJSON(v interface{}) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%#v", v)
+	}
+	return string(b)
+}
+
+// cleanGeneratedFolders removes every subdirectory of root except
+// `environments/` (hand-maintained). Files directly in root
+// (bruno.json, collection.bru) are preserved.
+func cleanGeneratedFolders(root string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.MkdirAll(root, 0o755)
+		}
+		return err
+	}
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == "environments" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(root, e.Name())); err != nil {
+			return fmt.Errorf("remove %s: %w", e.Name(), err)
+		}
+	}
+	return nil
+}
+
+// writeOps creates the per-folder directories and writes one .bru
+// file per operation.
+func writeOps(ops []operation) error {
+	for _, op := range ops {
+		dir := filepath.Join(collectionRoot, op.Folder)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+		content := renderOp(op)
+		path := filepath.Join(dir, op.FileName)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// renderOp produces the full .bru text for one operation. The
+// block order follows Bruno's canonical layout so Bruno doesn't
+// rewrite files it reads -- saves noise in `make bruno` diffs.
+func renderOp(op operation) string {
+	var b strings.Builder
+
+	// meta block
+	fmt.Fprintf(&b, "meta {\n  name: %s\n  type: http\n  seq: %d\n}\n\n", op.Name, op.Seq)
+
+	// method block
+	url := substitutePathVars(op.Path)
+	method := strings.ToLower(op.Method)
+	bodyMode := "none"
+	if op.HasBody {
+		bodyMode = "json"
+	}
+	fmt.Fprintf(&b, "%s {\n  url: {{baseUrl}}/api%s\n  body: %s\n  auth: inherit\n}\n\n", method, url, bodyMode)
+
+	// query params
+	if len(op.Query) > 0 {
+		b.WriteString("params:query {\n")
+		for _, q := range op.Query {
+			prefix := ""
+			if q.Disabled {
+				prefix = "~"
+			}
+			fmt.Fprintf(&b, "  %s%s: %s\n", prefix, q.Name, q.Default)
+		}
+		b.WriteString("}\n\n")
+	}
+
+	// body block
+	if op.HasBody {
+		b.WriteString("body:json {\n")
+		// Indent the JSON by two spaces to nest inside the .bru block.
+		for _, line := range strings.Split(op.BodyJSON, "\n") {
+			if line == "" {
+				b.WriteString("\n")
+				continue
+			}
+			b.WriteString("  ")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		b.WriteString("}\n\n")
+	}
+
+	// docs block
+	if op.Summary != "" || op.Desc != "" {
+		b.WriteString("docs {\n")
+		if op.Summary != "" {
+			fmt.Fprintf(&b, "  # %s\n\n", op.Summary)
+		}
+		if op.Desc != "" {
+			for _, line := range strings.Split(op.Desc, "\n") {
+				b.WriteString("  ")
+				b.WriteString(line)
+				b.WriteString("\n")
+			}
+		}
+		b.WriteString("}\n")
+	}
+
+	return b.String()
+}
+
+// substitutePathVars converts `/files/{file_id}/view` to
+// `/files/{{fileId}}/view` so Bruno resolves the camelCase var from
+// the active environment.
+func substitutePathVars(path string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(path) {
+		if path[i] != '{' {
+			b.WriteByte(path[i])
+			i++
+			continue
+		}
+		j := strings.IndexByte(path[i:], '}')
+		if j < 0 {
+			// Malformed path -- write the rest verbatim.
+			b.WriteString(path[i:])
+			break
+		}
+		name := path[i+1 : i+j]
+		b.WriteString("{{")
+		b.WriteString(snakeToCamel(name))
+		b.WriteString("}}")
+		i += j + 1
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary
- Replaces the defunct Postman setup with a Bruno collection rooted at `api/bruno/`, one `.bru` per OpenAPI operation grouped by top-level path segment.
- Adds `scripts/brunogen/` (Go, ~400 LoC) that parses `openapi.yaml` via `kin-openapi` and emits a deterministic collection — re-runs with no spec change produce zero diff.
- Adds `make bruno` target + `bruno/README.md` so anyone can install Bruno, open the collection, paste a Clerk JWT into `authToken`, and exercise any of the 52 endpoints.

## What's in the collection
- `bruno/bruno.json` + `bruno/collection.bru` — collection manifest + bearer auth inherited by every request.
- `bruno/environments/dev.bru` + `bruno/environments/staging.bru` — `baseUrl`, secret `authToken`, and 9 NIL-UUID path-param vars (`fileId`, `studyGuideId`, …) so accidental sends hit a deterministic 404 instead of mutating real data.
- 52 generated `.bru` files across 8 folders: Courses, Files, Me, Quizzes, Schools, Sessions, Study Guides.

## Generator behaviour
- Walks `paths` in sorted order; within each folder, seq numbers are stable across runs.
- Request bodies: picks the first JSON example from the operation, then falls back to synthesising from the schema (with cycle-safe `$ref` handling).
- Path params: `{file_id}` → `{{fileId}}` (snake → camel) so they bind to the env vars.
- Rewrites everything under `bruno/` except `bruno.json`, `collection.bru`, `README.md`, and `environments/` (those stay hand-maintained).

## Test plan
- [x] `make bruno` emits 52 ops and leaves envs untouched
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Spot-checked generated bodies are single-indented JSON (post-fix from earlier `MarshalIndent` double-indent bug)
- [ ] Open `api/bruno/` in Bruno, paste a Clerk dev JWT into `authToken`, send `GET /api/me/files` and confirm 200
- [ ] Re-run `make bruno` — verify zero `git diff`