### PR TITLE
feat(web): shared toast provider + typed helpers (ASK-159)

### DIFF
--- a/web/app/(dashboard)/layout.tsx
+++ b/web/app/(dashboard)/layout.tsx
@@ -10,6 +10,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { ToastProvider } from "@/lib/features/shared/toast/toast-provider";
 
 export default async function DashboardLayout({
   children,
@@ -38,6 +39,7 @@ export default async function DashboardLayout({
             <main className="flex flex-1 flex-col gap-4 p-4">{children}</main>
           </SidebarInset>
         </SidebarProvider>
+        <ToastProvider />
       </DashboardCommonCopyProvider>
     </TooltipProvider>
   );

--- a/web/lib/features/shared/toast/toast-provider.tsx
+++ b/web/lib/features/shared/toast/toast-provider.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { Toaster } from "sonner";
+
+export function ToastProvider() {
+  return <Toaster position="top-right" richColors closeButton />;
+}

--- a/web/lib/features/shared/toast/toast.test.ts
+++ b/web/lib/features/shared/toast/toast.test.ts
@@ -8,9 +8,10 @@
  */
 jest.mock("sonner", () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
+    success: jest.fn(() => 1),
+    error: jest.fn(() => 2),
+    info: jest.fn(() => 3),
+    dismiss: jest.fn(),
   },
 }));
 
@@ -24,6 +25,7 @@ import { toast } from "./toast";
 const mockSuccess = sonnerToast.success as jest.Mock;
 const mockError = sonnerToast.error as jest.Mock;
 const mockInfo = sonnerToast.info as jest.Mock;
+const mockDismiss = sonnerToast.dismiss as jest.Mock;
 
 function fakeResponse(status: number): Response {
   return { status } as unknown as Response;
@@ -33,23 +35,31 @@ beforeEach(() => {
   mockSuccess.mockClear();
   mockError.mockClear();
   mockInfo.mockClear();
+  mockDismiss.mockClear();
 });
 
 describe("toast.success", () => {
-  it("forwards the message to sonner.success", () => {
-    toast.success("Saved");
+  it("forwards the message and returns the sonner id", () => {
+    const id = toast.success("Saved");
     expect(mockSuccess).toHaveBeenCalledWith("Saved");
+    expect(id).toBe(1);
   });
 });
 
 describe("toast.info", () => {
-  it("forwards the message to sonner.info", () => {
-    toast.info("Heads up");
+  it("forwards the message and returns the sonner id", () => {
+    const id = toast.info("Heads up");
     expect(mockInfo).toHaveBeenCalledWith("Heads up");
+    expect(id).toBe(3);
   });
 });
 
 describe("toast.error", () => {
+  it("surfaces a non-empty string as the message", () => {
+    toast.error("bare string");
+    expect(mockError).toHaveBeenCalledWith("bare string");
+  });
+
   it("uses ApiError.body.message when the envelope is present", () => {
     const body: AppError = {
       code: 404,
@@ -65,18 +75,45 @@ describe("toast.error", () => {
     expect(mockError).toHaveBeenCalledWith("Request failed (500)");
   });
 
+  it("falls back to `Request failed (STATUS)` when ApiError body.message is empty", () => {
+    const body: AppError = { code: 500, status: "internal", message: "" };
+    toast.error(new ApiError("op failed: 500", fakeResponse(500), body));
+    expect(mockError).toHaveBeenCalledWith("Request failed (500)");
+  });
+
   it("uses Error.message for non-ApiError errors", () => {
     toast.error(new Error("network down"));
     expect(mockError).toHaveBeenCalledWith("network down");
   });
 
-  it("falls back to a generic message for non-Error values", () => {
-    toast.error("bare string");
+  it("falls back to the generic message when Error.message is empty", () => {
+    toast.error(new Error(""));
     expect(mockError).toHaveBeenCalledWith("Something went wrong");
   });
 
-  it("falls back to a generic message for null", () => {
+  it("falls back to the generic message for an empty string", () => {
+    toast.error("");
+    expect(mockError).toHaveBeenCalledWith("Something went wrong");
+  });
+
+  it("falls back to the generic message for null", () => {
     toast.error(null);
     expect(mockError).toHaveBeenCalledWith("Something went wrong");
+  });
+
+  it("returns the sonner id", () => {
+    expect(toast.error(new Error("x"))).toBe(2);
+  });
+});
+
+describe("toast.dismiss", () => {
+  it("forwards a specific id to sonner.dismiss", () => {
+    toast.dismiss(7);
+    expect(mockDismiss).toHaveBeenCalledWith(7);
+  });
+
+  it("dismisses all toasts when called without an id", () => {
+    toast.dismiss();
+    expect(mockDismiss).toHaveBeenCalledWith(undefined);
   });
 });

--- a/web/lib/features/shared/toast/toast.test.ts
+++ b/web/lib/features/shared/toast/toast.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the typed `toast` dispatcher. Exercises the error
+ * narrowing so downstream callers can trust `toast.error(err)` with an
+ * unknown value without leaking "[object Object]" style messages.
+ *
+ * `sonner` is mocked -- we only care that the right branch fires the
+ * right message. Visual behaviour is covered by Playwright later.
+ */
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+import { toast as sonnerToast } from "sonner";
+
+import { ApiError } from "@/lib/api/errors";
+import type { AppError } from "@/lib/api/types";
+
+import { toast } from "./toast";
+
+const mockSuccess = sonnerToast.success as jest.Mock;
+const mockError = sonnerToast.error as jest.Mock;
+const mockInfo = sonnerToast.info as jest.Mock;
+
+function fakeResponse(status: number): Response {
+  return { status } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockSuccess.mockClear();
+  mockError.mockClear();
+  mockInfo.mockClear();
+});
+
+describe("toast.success", () => {
+  it("forwards the message to sonner.success", () => {
+    toast.success("Saved");
+    expect(mockSuccess).toHaveBeenCalledWith("Saved");
+  });
+});
+
+describe("toast.info", () => {
+  it("forwards the message to sonner.info", () => {
+    toast.info("Heads up");
+    expect(mockInfo).toHaveBeenCalledWith("Heads up");
+  });
+});
+
+describe("toast.error", () => {
+  it("uses ApiError.body.message when the envelope is present", () => {
+    const body: AppError = {
+      code: 404,
+      status: "not_found",
+      message: "file missing",
+    };
+    toast.error(new ApiError("op failed: 404", fakeResponse(404), body));
+    expect(mockError).toHaveBeenCalledWith("file missing");
+  });
+
+  it("falls back to `Request failed (STATUS)` when ApiError has no body", () => {
+    toast.error(new ApiError("op failed: 500", fakeResponse(500), null));
+    expect(mockError).toHaveBeenCalledWith("Request failed (500)");
+  });
+
+  it("uses Error.message for non-ApiError errors", () => {
+    toast.error(new Error("network down"));
+    expect(mockError).toHaveBeenCalledWith("network down");
+  });
+
+  it("falls back to a generic message for non-Error values", () => {
+    toast.error("bare string");
+    expect(mockError).toHaveBeenCalledWith("Something went wrong");
+  });
+
+  it("falls back to a generic message for null", () => {
+    toast.error(null);
+    expect(mockError).toHaveBeenCalledWith("Something went wrong");
+  });
+});

--- a/web/lib/features/shared/toast/toast.ts
+++ b/web/lib/features/shared/toast/toast.ts
@@ -1,0 +1,23 @@
+import { toast as sonnerToast } from "sonner";
+
+import { ApiError } from "@/lib/api/errors";
+
+export const toast = {
+  success: (message: string): void => {
+    sonnerToast.success(message);
+  },
+  error: (err: unknown): void => {
+    if (err instanceof ApiError) {
+      sonnerToast.error(err.body?.message ?? `Request failed (${err.status})`);
+      return;
+    }
+    if (err instanceof Error) {
+      sonnerToast.error(err.message);
+      return;
+    }
+    sonnerToast.error("Something went wrong");
+  },
+  info: (message: string): void => {
+    sonnerToast.info(message);
+  },
+};

--- a/web/lib/features/shared/toast/toast.ts
+++ b/web/lib/features/shared/toast/toast.ts
@@ -2,22 +2,26 @@ import { toast as sonnerToast } from "sonner";
 
 import { ApiError } from "@/lib/api/errors";
 
+type ToastId = string | number;
+
 export const toast = {
-  success: (message: string): void => {
-    sonnerToast.success(message);
-  },
-  error: (err: unknown): void => {
+  success: (message: string): ToastId => sonnerToast.success(message),
+  info: (message: string): ToastId => sonnerToast.info(message),
+  error: (err: unknown): ToastId => {
+    if (typeof err === "string" && err.length > 0) {
+      return sonnerToast.error(err);
+    }
     if (err instanceof ApiError) {
-      sonnerToast.error(err.body?.message ?? `Request failed (${err.status})`);
-      return;
+      return sonnerToast.error(
+        err.body?.message || `Request failed (${err.status})`,
+      );
     }
-    if (err instanceof Error) {
-      sonnerToast.error(err.message);
-      return;
+    if (err instanceof Error && err.message) {
+      return sonnerToast.error(err.message);
     }
-    sonnerToast.error("Something went wrong");
+    return sonnerToast.error("Something went wrong");
   },
-  info: (message: string): void => {
-    sonnerToast.info(message);
+  dismiss: (id?: ToastId): void => {
+    sonnerToast.dismiss(id);
   },
 };

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "react-dom": "19.2.3",
     "react-fast-marquee": "^1.6.5",
     "react-hook-form": "^7.73.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.3.6"
   },

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-hook-form:
         specifier: ^7.73.1
         version: 7.73.1(react@19.2.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -3788,6 +3791,12 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8389,6 +8398,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Closes [ASK-159](https://linear.app/askatlas/issue/ASK-159/frontend-sharedtoast-provider-sonner-typed-toast-helpers). Unblocks every Tier B/C ticket that calls a mutating server action.

- Add `sonner` as a runtime dependency.
- New `web/lib/features/shared/toast/toast-provider.tsx` — mounts a single top-right `<Toaster>` with `richColors` and `closeButton`.
- New `web/lib/features/shared/toast/toast.ts` — `success` / `error` / `info` wrappers. `error(err)` narrows `ApiError` → `err.body.message` (or `Request failed (STATUS)`), then `Error.message`, then the generic `"Something went wrong"`.
- `ToastProvider` mounted at the end of the dashboard layout tree.
- `toast.test.ts` covers every `error` narrowing branch.

Deviation from ticket: the helper imports `ApiError` from `@/lib/api/errors` (not the `@/lib/api` barrel). The barrel pulls Clerk server code that breaks jsdom tests and bloats the client bundle for a helper that only needs the error class.

## Test plan

- [x] `make format-check` clean
- [x] `make typecheck` clean
- [x] `make lint` clean
- [x] `pnpm exec jest lib/features/shared/toast` — 7/7 pass
- [ ] CI build green
- [ ] Manual smoke: call `toast.success("hi")` from any dashboard client component — renders top-right, auto-dismisses ~4s