### PR TITLE
feat(web): root + dashboard error boundaries and 404 pages (ASK-160)

### DIFF
--- a/web/app/(dashboard)/error.tsx
+++ b/web/app/(dashboard)/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ErrorBoundaryContent } from "@/lib/features/shared/error/error-boundary-content";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <ErrorBoundaryContent error={error} reset={reset} />;
+}

--- a/web/app/(dashboard)/not-found.tsx
+++ b/web/app/(dashboard)/not-found.tsx
@@ -1,5 +1,16 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
 import { NotFoundContent } from "@/lib/features/shared/error/not-found-content";
 
 export default function DashboardNotFound() {
-  return <NotFoundContent />;
+  return (
+    <NotFoundContent
+      action={
+        <Button asChild>
+          <Link href="/home">Back to dashboard</Link>
+        </Button>
+      }
+    />
+  );
 }

--- a/web/app/(dashboard)/not-found.tsx
+++ b/web/app/(dashboard)/not-found.tsx
@@ -1,0 +1,5 @@
+import { NotFoundContent } from "@/lib/features/shared/error/not-found-content";
+
+export default function DashboardNotFound() {
+  return <NotFoundContent />;
+}

--- a/web/app/error.tsx
+++ b/web/app/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ErrorBoundaryContent } from "@/lib/features/shared/error/error-boundary-content";
+
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <ErrorBoundaryContent error={error} reset={reset} />;
+}

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,5 +1,22 @@
+import { auth } from "@clerk/nextjs/server";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
 import { NotFoundContent } from "@/lib/features/shared/error/not-found-content";
 
-export default function RootNotFound() {
-  return <NotFoundContent />;
+export default async function RootNotFound() {
+  const { userId } = await auth();
+  const isAuthenticated = Boolean(userId);
+
+  return (
+    <NotFoundContent
+      action={
+        <Button asChild>
+          <Link href={isAuthenticated ? "/home" : "/"}>
+            {isAuthenticated ? "Back to dashboard" : "Back to home"}
+          </Link>
+        </Button>
+      }
+    />
+  );
 }

--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,0 +1,5 @@
+import { NotFoundContent } from "@/lib/features/shared/error/not-found-content";
+
+export default function RootNotFound() {
+  return <NotFoundContent />;
+}

--- a/web/lib/features/shared/error/error-boundary-content.test.tsx
+++ b/web/lib/features/shared/error/error-boundary-content.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Covers the narrowing logic that matters in prod: 401 triggers a
+ * hard redirect via the `hardRedirect` helper and renders nothing,
+ * ApiError bodies get surfaced, everything else falls back to a safe
+ * generic string. The retry button just has to wire to the `reset`
+ * prop.
+ */
+jest.mock("./redirect", () => ({
+  hardRedirect: jest.fn(),
+}));
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { ApiError } from "@/lib/api/errors";
+import type { AppError } from "@/lib/api/types";
+
+import { ErrorBoundaryContent } from "./error-boundary-content";
+import { hardRedirect } from "./redirect";
+
+const mockRedirect = hardRedirect as jest.Mock;
+
+function fakeResponse(status: number): Response {
+  return { status } as unknown as Response;
+}
+
+describe("ErrorBoundaryContent", () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+  });
+
+  it("redirects to /sign-in and renders nothing when the error is a 401", async () => {
+    const { container } = render(
+      <ErrorBoundaryContent
+        error={new ApiError("op: 401", fakeResponse(401), null)}
+        reset={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(mockRedirect).toHaveBeenCalledWith("/sign-in"));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("surfaces ApiError.body.message when the envelope is present", () => {
+    const body: AppError = {
+      code: 403,
+      status: "forbidden",
+      message: "You don't have access to this resource.",
+    };
+    render(
+      <ErrorBoundaryContent
+        error={new ApiError("op: 403", fakeResponse(403), body)}
+        reset={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("You don't have access to this resource."),
+    ).toBeInTheDocument();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a generic message for ApiError without a body", () => {
+    render(
+      <ErrorBoundaryContent
+        error={new ApiError("op: 500", fakeResponse(500), null)}
+        reset={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("We hit an unexpected problem."),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to a generic message for a plain Error", () => {
+    render(
+      <ErrorBoundaryContent error={new Error("boom")} reset={jest.fn()} />,
+    );
+
+    expect(
+      screen.getByText("We hit an unexpected problem."),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes reset when the retry button is clicked", async () => {
+    const reset = jest.fn();
+    render(<ErrorBoundaryContent error={new Error("boom")} reset={reset} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/lib/features/shared/error/error-boundary-content.tsx
+++ b/web/lib/features/shared/error/error-boundary-content.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/api/errors";
+
+import { hardRedirect } from "./redirect";
+
+interface ErrorBoundaryContentProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+const SIGN_IN_PATH = "/sign-in";
+
+export function ErrorBoundaryContent({
+  error,
+  reset,
+}: ErrorBoundaryContentProps) {
+  const isAuthExpired = error instanceof ApiError && error.status === 401;
+
+  useEffect(() => {
+    if (isAuthExpired) {
+      hardRedirect(SIGN_IN_PATH);
+    }
+  }, [isAuthExpired]);
+
+  if (isAuthExpired) {
+    return null;
+  }
+
+  const message =
+    error instanceof ApiError && error.body?.message
+      ? error.body.message
+      : "We hit an unexpected problem.";
+
+  return (
+    <main className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8">
+      <h1 className="text-2xl font-semibold">Something went wrong</h1>
+      <p className="text-muted-foreground max-w-md text-center">{message}</p>
+      <Button onClick={reset}>Try again</Button>
+    </main>
+  );
+}

--- a/web/lib/features/shared/error/not-found-content.tsx
+++ b/web/lib/features/shared/error/not-found-content.tsx
@@ -1,17 +1,17 @@
-import Link from "next/link";
+import type { ReactNode } from "react";
 
-import { Button } from "@/components/ui/button";
+interface NotFoundContentProps {
+  action: ReactNode;
+}
 
-export function NotFoundContent() {
+export function NotFoundContent({ action }: NotFoundContentProps) {
   return (
     <main className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8">
       <h1 className="text-2xl font-semibold">Page not found</h1>
       <p className="text-muted-foreground max-w-md text-center">
         This page doesn&apos;t exist or has moved.
       </p>
-      <Button asChild>
-        <Link href="/home">Back to dashboard</Link>
-      </Button>
+      {action}
     </main>
   );
 }

--- a/web/lib/features/shared/error/not-found-content.tsx
+++ b/web/lib/features/shared/error/not-found-content.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export function NotFoundContent() {
+  return (
+    <main className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8">
+      <h1 className="text-2xl font-semibold">Page not found</h1>
+      <p className="text-muted-foreground max-w-md text-center">
+        This page doesn&apos;t exist or has moved.
+      </p>
+      <Button asChild>
+        <Link href="/home">Back to dashboard</Link>
+      </Button>
+    </main>
+  );
+}

--- a/web/lib/features/shared/error/redirect.ts
+++ b/web/lib/features/shared/error/redirect.ts
@@ -1,0 +1,8 @@
+/**
+ * Full-page navigation helper for safety-net redirects (e.g. 401 token
+ * expiry). Wrapped so tests can spy on redirect intent without fighting
+ * jsdom's non-configurable `window.location`.
+ */
+export function hardRedirect(path: string): void {
+  window.location.href = path;
+}

--- a/web/package.json
+++ b/web/package.json
@@ -38,6 +38,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -1663,6 +1666,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -5876,6 +5885,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
       '@types/react-dom': 19.2.3(@types/react@19.2.10)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tsconfig/node10@1.0.12': {}
 


### PR DESCRIPTION
## Summary

Closes [ASK-160](https://linear.app/askatlas/issue/ASK-160/frontend-sharederror-boundary-pages-errortsx-not-foundtsx-conventions). Unblocks every Tier C ticket — prevents thrown `ApiError`s from becoming blank 500 pages in prod.

- `app/error.tsx` and `app/(dashboard)/error.tsx` catch render-time errors; dashboard variant preserves sidebar/header chrome.
- `app/not-found.tsx` and `app/(dashboard)/not-found.tsx` render a friendly 404 with a back-to-dashboard link.
- Shared `ErrorBoundaryContent` client component: surfaces `ApiError.body.message` when present, falls back to "We hit an unexpected problem.", and hard-redirects to `/sign-in` on 401 token expiry.
- `hardRedirect` helper isolates `window.location.href =` so it's cleanly mockable in jsdom (tests cannot redefine `window.location`).
- Added `@testing-library/user-event` (devDep) for retry-button coverage.

## Test plan

- [x] `make format-check` clean
- [x] `make typecheck` clean
- [x] `make lint` clean
- [x] `pnpm exec jest lib/features/shared/error` — 5/5 pass
- [ ] CI build green
- [ ] Manual: navigate to a bogus URL locally, see the 404 page