### PR TITLE
feat(web): shared ConfirmationDialog primitive (ASK-163)

### DIFF
--- a/web/lib/features/shared/confirmation-dialog.test.tsx
+++ b/web/lib/features/shared/confirmation-dialog.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Covers the four acceptance criteria on ASK-163: dialog is visible
+ * when `open`, async `onConfirm` is awaited (caller controls close),
+ * destructive flag swaps the confirm button variant, and dismissing
+ * fires `onOpenChange(false)`.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { ConfirmationDialog } from "./confirmation-dialog";
+
+function renderDialog(
+  overrides: Partial<Parameters<typeof ConfirmationDialog>[0]> = {},
+) {
+  const props = {
+    open: true,
+    onOpenChange: jest.fn(),
+    title: "Delete file",
+    description: "This can't be undone.",
+    onConfirm: jest.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<ConfirmationDialog {...props} />) };
+}
+
+describe("ConfirmationDialog", () => {
+  it("renders the title and description when open", () => {
+    renderDialog();
+    expect(
+      screen.getByRole("alertdialog", { name: /delete file/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("This can't be undone.")).toBeInTheDocument();
+  });
+
+  it("does not render content when closed", () => {
+    renderDialog({ open: false });
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("invokes onConfirm when the confirm button is clicked", async () => {
+    const { props } = renderDialog({ confirmLabel: "Delete" });
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(props.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the async onConfirm promise so callers can await it", async () => {
+    let released = false;
+    const onConfirm = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(() => {
+            released = true;
+            resolve();
+          }, 10);
+        }),
+    );
+    renderDialog({ onConfirm, confirmLabel: "Delete" });
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await onConfirm.mock.results[0]?.value;
+    expect(released).toBe(true);
+  });
+
+  it("fires onOpenChange(false) when Cancel is clicked", async () => {
+    const { props } = renderDialog({ cancelLabel: "Nevermind" });
+    await userEvent.click(screen.getByRole("button", { name: "Nevermind" }));
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("applies destructive styling when `destructive` is true", () => {
+    renderDialog({ destructive: true, confirmLabel: "Delete" });
+    expect(screen.getByRole("button", { name: "Delete" })).toHaveClass(
+      "bg-destructive",
+    );
+  });
+
+  it("uses the default variant when `destructive` is false", () => {
+    renderDialog({ confirmLabel: "Save" });
+    expect(screen.getByRole("button", { name: "Save" })).not.toHaveClass(
+      "bg-destructive",
+    );
+  });
+});

--- a/web/lib/features/shared/confirmation-dialog.test.tsx
+++ b/web/lib/features/shared/confirmation-dialog.test.tsx
@@ -1,8 +1,9 @@
 /**
- * Covers the four acceptance criteria on ASK-163: dialog is visible
- * when `open`, async `onConfirm` is awaited (caller controls close),
- * destructive flag swaps the confirm button variant, and dismissing
- * fires `onOpenChange(false)`.
+ * Exercises the ConfirmationDialog contract: it's visible when `open`,
+ * invokes `onConfirm` on confirm click (may return a promise the caller
+ * awaits), does NOT auto-close on confirm (caller owns close), fires
+ * `onOpenChange(false)` when Cancel closes it, the destructive flag
+ * swaps the confirm button variant, and `disabled` locks both buttons.
  */
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -44,7 +45,7 @@ describe("ConfirmationDialog", () => {
     expect(props.onConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it("returns the async onConfirm promise so callers can await it", async () => {
+  it("stays open during async confirm so callers can await the promise", async () => {
     let released = false;
     const onConfirm = jest.fn(
       () =>
@@ -55,8 +56,12 @@ describe("ConfirmationDialog", () => {
           }, 10);
         }),
     );
-    renderDialog({ onConfirm, confirmLabel: "Delete" });
+    const { props } = renderDialog({ onConfirm, confirmLabel: "Delete" });
     await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    // Critical: the primitive must NOT have closed the dialog itself. If
+    // downstream tickets await an API call before closing, a self-closing
+    // dialog would unmount the spinner and re-enable buttons prematurely.
+    expect(props.onOpenChange).not.toHaveBeenCalledWith(false);
     await onConfirm.mock.results[0]?.value;
     expect(released).toBe(true);
   });
@@ -79,5 +84,20 @@ describe("ConfirmationDialog", () => {
     expect(screen.getByRole("button", { name: "Save" })).not.toHaveClass(
       "bg-destructive",
     );
+  });
+
+  it("disables both buttons when `disabled` is true", async () => {
+    const { props } = renderDialog({
+      disabled: true,
+      confirmLabel: "Delete",
+      cancelLabel: "Nevermind",
+    });
+    const confirm = screen.getByRole("button", { name: "Delete" });
+    const cancel = screen.getByRole("button", { name: "Nevermind" });
+    expect(confirm).toBeDisabled();
+    expect(cancel).toBeDisabled();
+
+    await userEvent.click(confirm);
+    expect(props.onConfirm).not.toHaveBeenCalled();
   });
 });

--- a/web/lib/features/shared/confirmation-dialog.tsx
+++ b/web/lib/features/shared/confirmation-dialog.tsx
@@ -2,7 +2,6 @@
 
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -10,6 +9,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 
 interface ConfirmationDialogProps {
   open: boolean;
@@ -19,6 +19,17 @@ interface ConfirmationDialogProps {
   confirmLabel?: string;
   cancelLabel?: string;
   destructive?: boolean;
+  /**
+   * When true, both buttons are disabled. Callers should flip this
+   * while the async `onConfirm` is in flight to prevent double-submit
+   * without having to close the dialog mid-operation.
+   */
+  disabled?: boolean;
+  /**
+   * The primitive fires this synchronously; the returned promise (if
+   * any) is the caller's to await. The dialog does not auto-close --
+   * the caller decides when via `onOpenChange(false)`.
+   */
   onConfirm: () => void | Promise<void>;
 }
 
@@ -30,6 +41,7 @@ export function ConfirmationDialog({
   confirmLabel = "Confirm",
   cancelLabel = "Cancel",
   destructive = false,
+  disabled = false,
   onConfirm,
 }: ConfirmationDialogProps) {
   return (
@@ -40,13 +52,17 @@ export function ConfirmationDialog({
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
-          <AlertDialogAction
+          <AlertDialogCancel disabled={disabled}>
+            {cancelLabel}
+          </AlertDialogCancel>
+          <Button
+            type="button"
             variant={destructive ? "destructive" : "default"}
+            disabled={disabled}
             onClick={onConfirm}
           >
             {confirmLabel}
-          </AlertDialogAction>
+          </Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/web/lib/features/shared/confirmation-dialog.tsx
+++ b/web/lib/features/shared/confirmation-dialog.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface ConfirmationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void | Promise<void>;
+}
+
+export function ConfirmationDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+  onConfirm,
+}: ConfirmationDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction
+            variant={destructive ? "destructive" : "default"}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## Summary

Closes [ASK-163](https://linear.app/askatlas/issue/ASK-163/frontend-sharedconfirmation-dialog-primitive). Unblocks every Tier B ticket with a destructive action.

- New `web/lib/features/shared/confirmation-dialog.tsx` — controlled wrapper over shadcn `AlertDialog`.
- `destructive={true}` forwards `variant=\"destructive\"` to `AlertDialogAction` (uses the design-system token rather than inline classes).
- `onConfirm: () => void | Promise<void>` — caller owns async + close semantics.
- 7/7 unit tests covering each acceptance criterion (visibility, async confirm, destructive styling, cancel dismissal).

## Test plan

- [x] \`make format-check\` clean
- [x] \`make typecheck\` clean
- [x] \`make lint\` clean
- [x] \`pnpm exec jest lib/features/shared/confirmation-dialog\` — 7/7 pass
- [ ] CI build green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a confirmation dialog component that displays customizable prompts with confirm/cancel actions, optional destructive styling, and disabled state support.

* **Tests**
  * Added comprehensive test coverage for the confirmation dialog component, including accessibility, interactions, styling, and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->