### PR TITLE
feat(web): FavoriteButton + FileCard primitives (ASK-168 + ASK-164)

### DIFF
--- a/web/app/(dashboard)/resources/page.tsx
+++ b/web/app/(dashboard)/resources/page.tsx
@@ -12,7 +12,6 @@ import {
   ZoomOut,
 } from "lucide-react";
 import Image from "next/image";
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -23,7 +22,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { toggleFileFavorite } from "@/lib/api";
-import type { FileResponse } from "@/lib/api/types";
+import type { FileResponse, ListFilesResponse } from "@/lib/api/types";
 import { FileCard } from "@/lib/features/dashboard/files/file-card";
 import { FavoriteButton } from "@/lib/features/shared/favorite-button";
 import { toast } from "@/lib/features/shared/toast/toast";
@@ -54,7 +53,7 @@ function DocumentViewer({ document, onClose }: DocumentViewerProps) {
   const handleDownload = () => {
     const link = window.document.createElement("a");
     link.href = fileUrl;
-    link.download = document.name;
+    link.download = document.name || "Untitled";
     link.click();
   };
 
@@ -166,7 +165,7 @@ export default function ResourcesPage() {
       try {
         const response = await fetch("/api/me/files");
         if (response.ok) {
-          const data = (await response.json()) as { files?: FileResponse[] };
+          const data = (await response.json()) as ListFilesResponse;
           setFiles(data.files ?? []);
         }
       } catch (error) {
@@ -182,7 +181,7 @@ export default function ResourcesPage() {
   const handleDownload = (file: FileResponse) => {
     const link = window.document.createElement("a");
     link.href = `/api/files/${file.id}`;
-    link.download = file.name;
+    link.download = file.name || "Untitled";
     link.click();
   };
 
@@ -209,9 +208,9 @@ export default function ResourcesPage() {
 
   const favoriteButton = (file: FileResponse) => (
     <FavoriteButton
-      initialFavorited={file.favorited_at !== null}
+      initialFavorited={file.favorited_at != null}
       label={
-        file.favorited_at !== null
+        file.favorited_at != null
           ? "Unfavorite this file"
           : "Favorite this file"
       }

--- a/web/app/(dashboard)/resources/page.tsx
+++ b/web/app/(dashboard)/resources/page.tsx
@@ -1,19 +1,20 @@
 "use client";
 
-import * as React from "react";
-import { useState, useEffect } from "react";
 import {
-  FileText,
   Download,
+  FileText,
+  LayoutGrid,
+  List as ListIcon,
   MoreVertical,
+  RotateCcw,
   X,
   ZoomIn,
   ZoomOut,
-  RotateCcw,
-  LayoutGrid,
-  List as ListIcon,
 } from "lucide-react";
 import Image from "next/image";
+import * as React from "react";
+import { useEffect, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -21,22 +22,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-
-// Matches the API FileResponse schema
-interface Document {
-  id: string; // UUID
-  name: string;
-  size: number; // bytes
-  mime_type: string;
-  status: "pending" | "complete" | "failed";
-  created_at: string; // ISO date
-  updated_at: string; // ISO date
-  favorited_at?: string | null;
-  last_viewed_at?: string | null;
-}
+import { toggleFileFavorite } from "@/lib/api";
+import type { FileResponse } from "@/lib/api/types";
+import { FileCard } from "@/lib/features/dashboard/files/file-card";
+import { FavoriteButton } from "@/lib/features/shared/favorite-button";
+import { toast } from "@/lib/features/shared/toast/toast";
 
 interface DocumentViewerProps {
-  document: Document | null;
+  document: FileResponse | null;
   onClose: () => void;
 }
 
@@ -48,7 +41,7 @@ function DocumentViewer({ document, onClose }: DocumentViewerProps) {
 
   const isImage = document.mime_type.startsWith("image/");
   const isPDF = document.mime_type === "application/pdf";
-  const fileUrl = `/api/files/${document.id}`; // Assuming this serves the file content
+  const fileUrl = `/api/files/${document.id}`;
 
   const handleZoomIn = () => setZoom((prev) => Math.min(prev + 0.25, 3));
   const handleZoomOut = () => setZoom((prev) => Math.max(prev - 0.25, 0.5));
@@ -67,7 +60,6 @@ function DocumentViewer({ document, onClose }: DocumentViewerProps) {
 
   return (
     <div className="fixed inset-0 z-50 bg-black/90 backdrop-blur-sm flex flex-col">
-      {/* Header */}
       <div className="flex items-center justify-between p-4 bg-white dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800">
         <div className="flex items-center gap-3">
           <FileText className="w-5 h-5 text-zinc-500" />
@@ -82,7 +74,6 @@ function DocumentViewer({ document, onClose }: DocumentViewerProps) {
         </div>
 
         <div className="flex items-center gap-2">
-          {/* Zoom Controls */}
           <Button
             variant="ghost"
             size="sm"
@@ -117,7 +108,6 @@ function DocumentViewer({ document, onClose }: DocumentViewerProps) {
         </div>
       </div>
 
-      {/* Viewer */}
       <div className="flex-1 overflow-auto bg-zinc-100 dark:bg-zinc-800 p-4">
         <div className="max-w-full mx-auto">
           <div
@@ -166,63 +156,84 @@ function DocumentViewer({ document, onClose }: DocumentViewerProps) {
 }
 
 export default function ResourcesPage() {
-  const [documents, setDocuments] = useState<Document[]>([]);
+  const [files, setFiles] = useState<FileResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [viewMode, setViewMode] = useState<"list" | "grid">("grid");
-  const [selectedDocument, setSelectedDocument] = useState<Document | null>(
-    null,
-  );
+  const [selectedFile, setSelectedFile] = useState<FileResponse | null>(null);
 
   useEffect(() => {
-    // Fetch user's documents
-    const fetchDocuments = async () => {
+    const fetchFiles = async () => {
       try {
         const response = await fetch("/api/me/files");
         if (response.ok) {
-          const data = await response.json();
-          setDocuments(data.files || []);
+          const data = (await response.json()) as { files?: FileResponse[] };
+          setFiles(data.files ?? []);
         }
       } catch (error) {
-        console.error("Failed to fetch documents:", error);
+        console.error("Failed to fetch files:", error);
       } finally {
         setLoading(false);
       }
     };
 
-    fetchDocuments();
+    fetchFiles();
   }, []);
 
-  const formatFileSize = (bytes: number): string => {
-    if (bytes === 0) return "0 Bytes";
-    const k = 1024;
-    const sizes = ["Bytes", "KB", "MB", "GB"];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + " " + sizes[i];
-  };
-
-  const getRelativeTime = (isoString: string): string => {
-    const date = new Date(isoString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    const diffDays = Math.floor(diffHours / 24);
-
-    if (diffHours < 1) return "Just now";
-    if (diffHours < 24)
-      return `${diffHours} hour${diffHours > 1 ? "s" : ""} ago`;
-    if (diffDays === 1) return "Yesterday";
-    if (diffDays < 7) return `${diffDays} days ago`;
-    if (diffDays < 30)
-      return `${Math.floor(diffDays / 7)} week${Math.floor(diffDays / 7) > 1 ? "s" : ""} ago`;
-    return date.toLocaleDateString();
-  };
-
-  const handleDownload = (doc: Document) => {
+  const handleDownload = (file: FileResponse) => {
     const link = window.document.createElement("a");
-    link.href = `/api/files/${doc.id}`;
-    link.download = doc.name;
+    link.href = `/api/files/${file.id}`;
+    link.download = file.name;
     link.click();
   };
+
+  const rowMenu = (file: FileResponse) => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="File actions"
+          className="opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <MoreVertical className="w-4 h-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => handleDownload(file)}>
+          <Download className="w-4 h-4 mr-2" />
+          Download
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const favoriteButton = (file: FileResponse) => (
+    <FavoriteButton
+      initialFavorited={file.favorited_at !== null}
+      label={
+        file.favorited_at !== null
+          ? "Unfavorite this file"
+          : "Favorite this file"
+      }
+      size="sm"
+      onToggle={async () => {
+        try {
+          const response = await toggleFileFavorite(file.id);
+          setFiles((current) =>
+            current.map((f) =>
+              f.id === file.id
+                ? { ...f, favorited_at: response.favorited_at }
+                : f,
+            ),
+          );
+          return response;
+        } catch (err) {
+          toast.error(err);
+          throw err;
+        }
+      }}
+    />
+  );
 
   if (loading) {
     return (
@@ -249,13 +260,13 @@ export default function ResourcesPage() {
           </p>
         </header>
 
-        {/* View Mode Toggle */}
         <div className="flex justify-end">
           <div className="flex items-center gap-2 bg-muted/50 p-1 rounded-lg border">
             <Button
               variant={viewMode === "list" ? "default" : "ghost"}
               size="sm"
               onClick={() => setViewMode("list")}
+              aria-label="List view"
             >
               <ListIcon className="w-4 h-4" />
             </Button>
@@ -263,14 +274,14 @@ export default function ResourcesPage() {
               variant={viewMode === "grid" ? "default" : "ghost"}
               size="sm"
               onClick={() => setViewMode("grid")}
+              aria-label="Grid view"
             >
               <LayoutGrid className="w-4 h-4" />
             </Button>
           </div>
         </div>
 
-        {/* Documents Display */}
-        {documents.length === 0 ? (
+        {files.length === 0 ? (
           <div className="text-center py-16 bg-muted/50 rounded-xl">
             <FileText className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
             <h3 className="text-lg font-medium mb-2">No resources found</h3>
@@ -280,102 +291,36 @@ export default function ResourcesPage() {
           </div>
         ) : viewMode === "list" ? (
           <div className="space-y-2">
-            {documents.map((doc) => (
-              <div
-                key={doc.id}
-                className="flex items-center justify-between p-4 bg-card rounded-lg border hover:bg-muted/50 transition-colors group"
-              >
-                <button
-                  onClick={() => setSelectedDocument(doc)}
-                  className="flex items-center gap-4 flex-1 text-left"
-                >
-                  <div className="flex items-center justify-center w-12 h-12 rounded-lg bg-orange-500/10">
-                    <FileText className="w-6 h-6 text-orange-500" />
-                  </div>
-                  <div>
-                    <h3 className="font-medium group-hover:text-orange-500 transition-colors">
-                      {doc.name}
-                    </h3>
-                    <p className="text-sm text-muted-foreground">
-                      {formatFileSize(doc.size)} • Uploaded{" "}
-                      {getRelativeTime(doc.created_at)}
-                    </p>
-                  </div>
-                </button>
-
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="opacity-0 group-hover:opacity-100 transition-opacity"
-                    >
-                      <MoreVertical className="w-4 h-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={() => handleDownload(doc)}>
-                      <Download className="w-4 h-4 mr-2" />
-                      Download
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
+            {files.map((file) => (
+              <FileCard
+                key={file.id}
+                file={file}
+                variant="list"
+                onOpen={setSelectedFile}
+                favoriteButton={favoriteButton(file)}
+                rowMenu={rowMenu(file)}
+              />
             ))}
           </div>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            {documents.map((doc) => (
-              <div
-                key={doc.id}
-                className="group relative bg-card rounded-lg border hover:shadow-md transition-all overflow-hidden"
-              >
-                <button
-                  onClick={() => setSelectedDocument(doc)}
-                  className="w-full p-4 text-left"
-                >
-                  <div className="flex items-start justify-between mb-3">
-                    <div className="flex items-center justify-center w-12 h-12 rounded-lg bg-orange-500/10">
-                      <FileText className="w-6 h-6 text-orange-500" />
-                    </div>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="opacity-0 group-hover:opacity-100 transition-opacity"
-                        >
-                          <MoreVertical className="w-4 h-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => handleDownload(doc)}>
-                          <Download className="w-4 h-4 mr-2" />
-                          Download
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-
-                  <h3 className="font-medium group-hover:text-orange-500 transition-colors line-clamp-2 mb-2">
-                    {doc.name}
-                  </h3>
-
-                  <p className="text-xs text-muted-foreground">
-                    Uploaded {getRelativeTime(doc.created_at)}
-                  </p>
-                </button>
-              </div>
+            {files.map((file) => (
+              <FileCard
+                key={file.id}
+                file={file}
+                variant="grid"
+                onOpen={setSelectedFile}
+                favoriteButton={favoriteButton(file)}
+              />
             ))}
           </div>
         )}
       </section>
 
-      {/* Document Viewer */}
-      {selectedDocument && (
+      {selectedFile && (
         <DocumentViewer
-          document={selectedDocument}
-          onClose={() => setSelectedDocument(null)}
+          document={selectedFile}
+          onClose={() => setSelectedFile(null)}
         />
       )}
     </>

--- a/web/lib/features/dashboard/files/file-card.stories.tsx
+++ b/web/lib/features/dashboard/files/file-card.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { MoreVertical } from "lucide-react";
+import { fn } from "storybook/test";
+
+import { Button } from "@/components/ui/button";
+import type { FileResponse, ToggleFavoriteResponse } from "@/lib/api/types";
+import { FavoriteButton } from "@/lib/features/shared/favorite-button";
+
+import { FileCard } from "./file-card";
+
+function makeFile(overrides: Partial<FileResponse> = {}): FileResponse {
+  return {
+    id: "f_preview_1",
+    name: "Lecture 3 - Linear Algebra Review.pdf",
+    size: 1_048_576,
+    mime_type: "application/pdf",
+    status: "complete",
+    created_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    updated_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    favorited_at: null,
+    last_viewed_at: null,
+    ...overrides,
+  };
+}
+
+const mockFavoriteToggle: () => Promise<ToggleFavoriteResponse> = () =>
+  new Promise((resolve) =>
+    setTimeout(
+      () =>
+        resolve({ favorited: true, favorited_at: new Date().toISOString() }),
+      300,
+    ),
+  );
+
+const meta: Meta<typeof FileCard> = {
+  title: "Dashboard/FileCard",
+  component: FileCard,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Renders a file as a row (`list`) or tile (`grid`). Slots let callers mount a row menu (list only) and a favorite button. Click or Enter/Space fires `onOpen(file)` so the caller can open a viewer and fire `recordFileView`.",
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: { type: "radio" },
+      options: ["list", "grid"],
+    },
+  },
+  args: {
+    onOpen: fn(),
+  },
+  decorators: [
+    (Story, context) => (
+      <div
+        className={context.args.variant === "grid" ? "w-[220px]" : "w-[540px]"}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof FileCard>;
+
+export const List: Story = {
+  args: {
+    file: makeFile(),
+    variant: "list",
+  },
+};
+
+export const ListWithFavorite: Story = {
+  args: {
+    file: makeFile({ favorited_at: new Date().toISOString() }),
+    variant: "list",
+    favoriteButton: (
+      <FavoriteButton
+        initialFavorited
+        label="Favorite this file"
+        size="sm"
+        onToggle={mockFavoriteToggle}
+      />
+    ),
+  },
+};
+
+export const ListWithRowMenu: Story = {
+  args: {
+    file: makeFile({
+      last_viewed_at: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+    }),
+    variant: "list",
+    rowMenu: (
+      <Button variant="ghost" size="sm" aria-label="File actions">
+        <MoreVertical className="size-4" />
+      </Button>
+    ),
+  },
+};
+
+export const ListPending: Story = {
+  args: {
+    file: makeFile({ status: "pending", size: 0 }),
+    variant: "list",
+  },
+};
+
+export const ListLongTitle: Story = {
+  args: {
+    file: makeFile({
+      name: "A Very Long Filename That Should Truncate With An Ellipsis In The List Variant Without Ever Breaking The Row Height.pdf",
+    }),
+    variant: "list",
+  },
+};
+
+export const ListImage: Story = {
+  args: {
+    file: makeFile({
+      name: "diagram.png",
+      mime_type: "image/png",
+      size: 320_000,
+    }),
+    variant: "list",
+  },
+};
+
+export const Grid: Story = {
+  args: {
+    file: makeFile(),
+    variant: "grid",
+  },
+};
+
+export const GridWithFavorite: Story = {
+  args: {
+    file: makeFile({ favorited_at: new Date().toISOString() }),
+    variant: "grid",
+    favoriteButton: (
+      <FavoriteButton
+        initialFavorited
+        label="Favorite this file"
+        size="sm"
+        onToggle={mockFavoriteToggle}
+      />
+    ),
+  },
+};
+
+export const GridPending: Story = {
+  args: {
+    file: makeFile({ status: "pending", size: 0 }),
+    variant: "grid",
+  },
+};
+
+export const UntitledFallback: Story = {
+  args: {
+    file: makeFile({ name: "" }),
+    variant: "list",
+  },
+};

--- a/web/lib/features/dashboard/files/file-card.test.tsx
+++ b/web/lib/features/dashboard/files/file-card.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Covers the ASK-164 acceptance criteria: list/grid rendering, size +
+ * mime-type labels, pending status copy, Untitled fallback, keyboard
+ * activation, and the rowMenu/favoriteButton slots.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import type { FileResponse } from "@/lib/api/types";
+
+import { FileCard } from "./file-card";
+
+function makeFile(overrides: Partial<FileResponse> = {}): FileResponse {
+  return {
+    id: "f_preview_1",
+    name: "Lecture 3 - Linear Algebra Review.pdf",
+    size: 1_048_576, // 1 MB
+    mime_type: "application/pdf",
+    status: "complete",
+    created_at: "2026-04-20T10:00:00Z",
+    updated_at: "2026-04-20T10:00:00Z",
+    favorited_at: null,
+    last_viewed_at: null,
+    ...overrides,
+  };
+}
+
+describe("FileCard / list variant", () => {
+  it("shows name, formatted size, and mime label", () => {
+    render(<FileCard file={makeFile()} variant="list" />);
+    expect(
+      screen.getByText("Lecture 3 - Linear Algebra Review.pdf"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1 MB/)).toBeInTheDocument();
+  });
+
+  it("renders size 0 as '0 B' without breaking", () => {
+    render(<FileCard file={makeFile({ size: 0 })} variant="list" />);
+    expect(screen.getByText(/0 B/)).toBeInTheDocument();
+  });
+
+  it("falls back to 'Untitled' for empty name", () => {
+    render(<FileCard file={makeFile({ name: "" })} variant="list" />);
+    expect(screen.getByText("Untitled")).toBeInTheDocument();
+  });
+
+  it("shows 'Processing…' when status is pending", () => {
+    render(<FileCard file={makeFile({ status: "pending" })} variant="list" />);
+    expect(screen.getByText(/Processing/)).toBeInTheDocument();
+  });
+
+  it("invokes onOpen on click", async () => {
+    const onOpen = jest.fn();
+    render(<FileCard file={makeFile()} variant="list" onOpen={onOpen} />);
+    await userEvent.click(screen.getByRole("button"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen.mock.calls[0][0]).toMatchObject({ id: "f_preview_1" });
+  });
+
+  it("invokes onOpen on Enter key", async () => {
+    const onOpen = jest.fn();
+    render(<FileCard file={makeFile()} variant="list" onOpen={onOpen} />);
+    screen.getByRole("button").focus();
+    await userEvent.keyboard("{Enter}");
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onOpen on Space key", async () => {
+    const onOpen = jest.fn();
+    render(<FileCard file={makeFile()} variant="list" onOpen={onOpen} />);
+    screen.getByRole("button").focus();
+    await userEvent.keyboard(" ");
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("is not role=button when onOpen is absent", () => {
+    render(<FileCard file={makeFile()} variant="list" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("does not fire onOpen when the row menu is clicked", async () => {
+    const onOpen = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="list"
+        onOpen={onOpen}
+        rowMenu={<button type="button">Menu</button>}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Menu" }));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe("FileCard / grid variant", () => {
+  it("renders the filename and size", () => {
+    render(<FileCard file={makeFile()} variant="grid" />);
+    expect(
+      screen.getByText("Lecture 3 - Linear Algebra Review.pdf"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1 MB/)).toBeInTheDocument();
+  });
+
+  it("invokes onOpen on click", async () => {
+    const onOpen = jest.fn();
+    render(<FileCard file={makeFile()} variant="grid" onOpen={onOpen} />);
+    await userEvent.click(screen.getByRole("button"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows 'Processing…' when status is pending", () => {
+    render(<FileCard file={makeFile({ status: "pending" })} variant="grid" />);
+    expect(screen.getByText(/Processing/)).toBeInTheDocument();
+  });
+});

--- a/web/lib/features/dashboard/files/file-card.tsx
+++ b/web/lib/features/dashboard/files/file-card.tsx
@@ -180,11 +180,30 @@ function resolveIcon(mime: string): LucideIcon {
   return FileText;
 }
 
+const SHORT_LABEL_BY_MIME: Record<string, string> = {
+  "application/pdf": "PDF",
+  "application/msword": "DOC",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "DOCX",
+  "application/vnd.ms-excel": "XLS",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "XLSX",
+  "application/vnd.ms-powerpoint": "PPT",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    "PPTX",
+  "application/zip": "ZIP",
+  "application/epub+zip": "EPUB",
+  "text/plain": "TXT",
+  "text/csv": "CSV",
+};
+
 function shortMimeLabel(mime: string): string {
+  if (SHORT_LABEL_BY_MIME[mime]) return SHORT_LABEL_BY_MIME[mime];
+  if (mime.startsWith("image/")) return "IMG";
+  if (mime.startsWith("video/")) return "VIDEO";
+  if (mime.startsWith("audio/")) return "AUDIO";
+  // Unknown mime: show just the subtype (e.g. "application/unknown" -> "UNKNOW").
   const subtype = mime.split("/")[1] ?? mime;
-  // Strip vendor prefixes ("vnd.openxmlformats-...wordprocessingml.document" -> "word")
-  const cleaned = subtype.replace(/^vnd\..+?(\w+)$/, "$1");
-  return cleaned.slice(0, 6);
+  return subtype.slice(0, 6).toUpperCase();
 }
 
 function stopPropagation(event: React.MouseEvent) {

--- a/web/lib/features/dashboard/files/file-card.tsx
+++ b/web/lib/features/dashboard/files/file-card.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import {
+  FileArchive,
+  FileAudio,
+  FileImage,
+  FileSpreadsheet,
+  FileText,
+  FileType,
+  FileVideo,
+  type LucideIcon,
+} from "lucide-react";
+import { type KeyboardEvent, type ReactNode } from "react";
+
+import type { FileResponse } from "@/lib/api/types";
+import { cn, formatBytes, formatRelativeDate } from "@/lib/utils";
+
+interface FileCardProps {
+  file: FileResponse;
+  variant: "list" | "grid";
+  onOpen?: (file: FileResponse) => void;
+  /** Slot for an inline row menu (e.g. download/rename/delete). Only shown in `list` variant. */
+  rowMenu?: ReactNode;
+  /** Slot for a favorite affordance. Rendered top-right on grid, inline on list. */
+  favoriteButton?: ReactNode;
+}
+
+export function FileCard({
+  file,
+  variant,
+  onOpen,
+  rowMenu,
+  favoriteButton,
+}: FileCardProps) {
+  const name = file.name === "" ? "Untitled" : file.name;
+  const Icon = resolveIcon(file.mime_type);
+  const isPending = file.status === "pending";
+  const isClickable = Boolean(onOpen);
+
+  const fire = () => onOpen?.(file);
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!isClickable) return;
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      fire();
+    }
+  };
+
+  return variant === "list" ? (
+    <div
+      role={isClickable ? "button" : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      onClick={isClickable ? fire : undefined}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "group bg-card flex items-center gap-3 rounded-lg border p-3 transition-colors",
+        isClickable && "hover:bg-muted/50 cursor-pointer",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+      )}
+    >
+      <IconTile Icon={Icon} />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium" title={name}>
+          {name}
+        </p>
+        <p className="text-muted-foreground truncate text-xs">
+          {isPending ? "Processing…" : formatBytes(file.size)}
+          <span className="mx-1.5">·</span>
+          <span className="uppercase">{shortMimeLabel(file.mime_type)}</span>
+          {file.last_viewed_at && (
+            <>
+              <span className="mx-1.5">·</span>
+              <span>Viewed {formatRelativeDate(file.last_viewed_at)}</span>
+            </>
+          )}
+        </p>
+      </div>
+      {favoriteButton && (
+        <div
+          className="shrink-0"
+          onClick={stopPropagation}
+          onKeyDown={stopKeyboardPropagation}
+        >
+          {favoriteButton}
+        </div>
+      )}
+      {rowMenu && (
+        <div
+          className="shrink-0"
+          onClick={stopPropagation}
+          onKeyDown={stopKeyboardPropagation}
+        >
+          {rowMenu}
+        </div>
+      )}
+    </div>
+  ) : (
+    <div
+      role={isClickable ? "button" : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      onClick={isClickable ? fire : undefined}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "group bg-card relative flex flex-col gap-3 rounded-xl border p-4 transition-all",
+        isClickable && "hover:shadow-md cursor-pointer",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+      )}
+    >
+      {favoriteButton && (
+        <div
+          className="absolute right-2 top-2"
+          onClick={stopPropagation}
+          onKeyDown={stopKeyboardPropagation}
+        >
+          {favoriteButton}
+        </div>
+      )}
+      <IconTile Icon={Icon} size="lg" />
+      <div className="min-w-0">
+        <p
+          className="line-clamp-2 text-sm font-medium leading-snug"
+          title={name}
+        >
+          {name}
+        </p>
+        <p className="text-muted-foreground mt-1 text-xs">
+          {isPending ? "Processing…" : formatBytes(file.size)}
+        </p>
+        {file.last_viewed_at && (
+          <p className="text-muted-foreground mt-1 text-xs">
+            Viewed {formatRelativeDate(file.last_viewed_at)}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IconTile({
+  Icon,
+  size = "md",
+}: {
+  Icon: LucideIcon;
+  size?: "md" | "lg";
+}) {
+  return (
+    <div
+      className={cn(
+        "bg-primary/10 text-primary flex shrink-0 items-center justify-center rounded-lg",
+        size === "lg" ? "size-12" : "size-10",
+      )}
+    >
+      <Icon className={size === "lg" ? "size-6" : "size-5"} />
+    </div>
+  );
+}
+
+const ICON_BY_MIME: Record<string, LucideIcon> = {
+  "application/pdf": FileText,
+  "application/msword": FileText,
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    FileText,
+  "application/vnd.ms-excel": FileSpreadsheet,
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+    FileSpreadsheet,
+  "application/vnd.ms-powerpoint": FileType,
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    FileType,
+  "application/zip": FileArchive,
+  "application/epub+zip": FileArchive,
+  "text/plain": FileText,
+  "text/csv": FileSpreadsheet,
+};
+
+function resolveIcon(mime: string): LucideIcon {
+  if (ICON_BY_MIME[mime]) return ICON_BY_MIME[mime];
+  if (mime.startsWith("image/")) return FileImage;
+  if (mime.startsWith("video/")) return FileVideo;
+  if (mime.startsWith("audio/")) return FileAudio;
+  return FileText;
+}
+
+function shortMimeLabel(mime: string): string {
+  const subtype = mime.split("/")[1] ?? mime;
+  // Strip vendor prefixes ("vnd.openxmlformats-...wordprocessingml.document" -> "word")
+  const cleaned = subtype.replace(/^vnd\..+?(\w+)$/, "$1");
+  return cleaned.slice(0, 6);
+}
+
+function stopPropagation(event: React.MouseEvent) {
+  event.stopPropagation();
+}
+
+function stopKeyboardPropagation(event: React.KeyboardEvent) {
+  event.stopPropagation();
+}

--- a/web/lib/features/shared/favorite-button.stories.tsx
+++ b/web/lib/features/shared/favorite-button.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import type { ToggleFavoriteResponse } from "@/lib/api/types";
+
+import { FavoriteButton } from "./favorite-button";
+
+function okAfter(
+  ms: number,
+  favorited: boolean,
+): () => Promise<ToggleFavoriteResponse> {
+  return () =>
+    new Promise((resolve) =>
+      setTimeout(
+        () =>
+          resolve({
+            favorited,
+            favorited_at: favorited ? new Date().toISOString() : null,
+          }),
+        ms,
+      ),
+    );
+}
+
+function rejectAfter(ms: number): () => Promise<ToggleFavoriteResponse> {
+  return () =>
+    new Promise((_resolve, reject) =>
+      setTimeout(() => reject(new Error("network")), ms),
+    );
+}
+
+const meta: Meta<typeof FavoriteButton> = {
+  title: "Shared/FavoriteButton",
+  component: FavoriteButton,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "React 19 `useOptimistic` + `useTransition` star toggle. The star fills the moment the user clicks; the click is blocked while `onToggle` is in flight. Once the transition settles the component reverts to `initialFavorited` -- the caller is expected to re-render with the new value derived from the `ToggleFavoriteResponse`.",
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      control: { type: "radio" },
+      options: ["sm", "md"],
+    },
+  },
+  args: {
+    label: "Favorite this file",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FavoriteButton>;
+
+export const Unfavorited: Story = {
+  args: {
+    initialFavorited: false,
+    onToggle: okAfter(300, true),
+  },
+};
+
+export const Favorited: Story = {
+  args: {
+    initialFavorited: true,
+    onToggle: okAfter(300, false),
+  },
+};
+
+export const SmallSize: Story = {
+  args: {
+    initialFavorited: true,
+    size: "sm",
+    onToggle: okAfter(300, false),
+  },
+};
+
+export const SlowNetwork: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Simulates a 2s server round-trip so you can see the optimistic star plus the disabled/pending state.",
+      },
+    },
+  },
+  args: {
+    initialFavorited: false,
+    onToggle: okAfter(2000, true),
+  },
+};
+
+export const NetworkFailure: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`onToggle` rejects -- `useOptimistic` reverts on settle (the component swallows internally, callers layer their own toast).",
+      },
+    },
+  },
+  args: {
+    initialFavorited: false,
+    onToggle: rejectAfter(800),
+  },
+};

--- a/web/lib/features/shared/favorite-button.test.tsx
+++ b/web/lib/features/shared/favorite-button.test.tsx
@@ -106,14 +106,9 @@ describe("FavoriteButton", () => {
     );
     const button = screen.getByRole("button");
 
-    // React's default UX logs the unhandled error; swallow it here so jest
-    // doesn't treat the noise as a separate test failure.
-    const originalOnError = window.onerror;
-    window.onerror = () => true;
     await act(async () => {
       await userEvent.click(button);
     });
-    window.onerror = originalOnError;
 
     await waitFor(() => expect(onToggle).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(button).toHaveAttribute("aria-pressed", "true"));

--- a/web/lib/features/shared/favorite-button.test.tsx
+++ b/web/lib/features/shared/favorite-button.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Covers the ASK-168 acceptance criteria for the primitive's local
+ * contract. `useOptimistic` only exposes the flipped state during the
+ * in-flight transition -- after the promise settles, state reverts to
+ * `initialFavorited` so the caller can sync from the server-returned
+ * `ToggleFavoriteResponse`. These tests verify that the click-time
+ * UX is correct AND that `onToggle` fires exactly once per click.
+ */
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import type { ToggleFavoriteResponse } from "@/lib/api/types";
+
+import { FavoriteButton } from "./favorite-button";
+
+function okResponse(favorited: boolean): ToggleFavoriteResponse {
+  return {
+    favorited,
+    favorited_at: favorited ? "2026-04-23T10:00:00Z" : null,
+  };
+}
+
+/**
+ * Controllable deferred so the test can observe the optimistic state
+ * WHILE `onToggle` is still pending.
+ */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("FavoriteButton", () => {
+  it("starts unpressed when initialFavorited is false", () => {
+    render(
+      <FavoriteButton
+        initialFavorited={false}
+        label="Favorite this file"
+        onToggle={jest.fn().mockResolvedValue(okResponse(true))}
+      />,
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("starts pressed when initialFavorited is true", () => {
+    render(
+      <FavoriteButton
+        initialFavorited
+        label="Favorite this file"
+        onToggle={jest.fn().mockResolvedValue(okResponse(false))}
+      />,
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows the optimistic state while onToggle is pending", async () => {
+    const gate = deferred<ToggleFavoriteResponse>();
+    const onToggle = jest.fn().mockReturnValue(gate.promise);
+
+    render(
+      <FavoriteButton
+        initialFavorited={false}
+        label="Favorite"
+        onToggle={onToggle}
+      />,
+    );
+    const button = screen.getByRole("button");
+
+    await userEvent.click(button);
+    await waitFor(() => expect(button).toHaveAttribute("aria-pressed", "true"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // Release the deferred so the transition can settle and we don't leak it.
+    await act(async () => {
+      gate.resolve(okResponse(true));
+    });
+  });
+
+  it("reverts to initialFavorited once the transition settles (caller syncs from response)", async () => {
+    const onToggle = jest.fn().mockResolvedValue(okResponse(true));
+    render(
+      <FavoriteButton
+        initialFavorited={false}
+        label="Favorite"
+        onToggle={onToggle}
+      />,
+    );
+    const button = screen.getByRole("button");
+    await userEvent.click(button);
+    await waitFor(() => expect(onToggle).toHaveBeenCalledTimes(1));
+    // Parent hasn't re-rendered with a new initialFavorited, so React
+    // commits back to the original value -- this is the expected contract.
+    await waitFor(() =>
+      expect(button).toHaveAttribute("aria-pressed", "false"),
+    );
+  });
+
+  it("also reverts when onToggle rejects (rollback happens via the same settle path)", async () => {
+    const onToggle = jest.fn().mockRejectedValue(new Error("network"));
+    render(
+      <FavoriteButton initialFavorited label="Favorite" onToggle={onToggle} />,
+    );
+    const button = screen.getByRole("button");
+
+    // React's default UX logs the unhandled error; swallow it here so jest
+    // doesn't treat the noise as a separate test failure.
+    const originalOnError = window.onerror;
+    window.onerror = () => true;
+    await act(async () => {
+      await userEvent.click(button);
+    });
+    window.onerror = originalOnError;
+
+    await waitFor(() => expect(onToggle).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(button).toHaveAttribute("aria-pressed", "true"));
+  });
+});

--- a/web/lib/features/shared/favorite-button.tsx
+++ b/web/lib/features/shared/favorite-button.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Star } from "lucide-react";
+import { useOptimistic, useTransition } from "react";
+
+import type { ToggleFavoriteResponse } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+
+interface FavoriteButtonProps {
+  initialFavorited: boolean;
+  /**
+   * Fires the actual toggle request. Must resolve to the server's
+   * ToggleFavoriteResponse so the caller can sync back any derived
+   * state (counts, last-favorited timestamps, etc). If it throws,
+   * this component rolls the star back to `initialFavorited` and
+   * re-throws so a caller-owned toast can surface the failure.
+   */
+  onToggle: () => Promise<ToggleFavoriteResponse>;
+  /** Screen-reader label + tooltip. Context-specific ("Favorite this file"). */
+  label: string;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export function FavoriteButton({
+  initialFavorited,
+  onToggle,
+  label,
+  size = "md",
+  className,
+}: FavoriteButtonProps) {
+  const [optimisticFavorited, setOptimisticFavorited] = useOptimistic(
+    initialFavorited,
+    (_current, next: boolean) => next,
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const handleClick = () => {
+    startTransition(async () => {
+      setOptimisticFavorited(!optimisticFavorited);
+      try {
+        await onToggle();
+      } catch {
+        // useOptimistic reverts when the transition completes, so the
+        // visual rollback happens regardless. Callers wrap their own
+        // onToggle if they need to surface the error (e.g. toast).
+      }
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={optimisticFavorited}
+      title={label}
+      disabled={isPending}
+      onClick={handleClick}
+      className={cn(
+        "inline-flex items-center justify-center rounded-full",
+        "text-muted-foreground hover:text-foreground transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "disabled:opacity-60 disabled:cursor-not-allowed",
+        size === "sm" ? "size-6" : "size-8",
+        className,
+      )}
+    >
+      <Star
+        className={cn(
+          size === "sm" ? "size-3.5" : "size-4",
+          optimisticFavorited && "fill-amber-400 text-amber-400",
+        )}
+      />
+    </button>
+  );
+}

--- a/web/lib/features/shared/favorite-button.tsx
+++ b/web/lib/features/shared/favorite-button.tsx
@@ -11,9 +11,11 @@ interface FavoriteButtonProps {
   /**
    * Fires the actual toggle request. Must resolve to the server's
    * ToggleFavoriteResponse so the caller can sync back any derived
-   * state (counts, last-favorited timestamps, etc). If it throws,
-   * this component rolls the star back to `initialFavorited` and
-   * re-throws so a caller-owned toast can surface the failure.
+   * state (counts, last-favorited timestamps, etc). Rejections are
+   * caught internally -- the optimistic UI rolls back when the
+   * transition settles, and callers that need to surface the error
+   * should wrap their own `onToggle` with a `try`/`catch`/`toast`
+   * (see the resources page for the canonical pattern).
    */
   onToggle: () => Promise<ToggleFavoriteResponse>;
   /** Screen-reader label + tooltip. Context-specific ("Favorite this file"). */

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -39,6 +39,12 @@ const RELATIVE_THRESHOLDS: Array<{
   { limit: Number.POSITIVE_INFINITY, divisor: 31_557_600, unit: "year" },
 ];
 
+// Hoisted so list renders don't allocate a formatter per row.
+const RELATIVE_FORMATTER = new Intl.RelativeTimeFormat(undefined, {
+  numeric: "auto",
+  style: "short",
+});
+
 /**
  * Short relative timestamp backed by `Intl.RelativeTimeFormat` so the
  * copy follows the user's locale (e.g. "3d ago", "2 months ago"). Past
@@ -52,14 +58,16 @@ export function formatRelativeDate(iso: string): string {
   const diffSeconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
   if (diffSeconds < 5) return "just now";
 
-  const formatter = new Intl.RelativeTimeFormat(undefined, {
-    numeric: "auto",
-    style: "short",
-  });
   for (const { limit, divisor, unit } of RELATIVE_THRESHOLDS) {
     if (diffSeconds < limit) {
-      return formatter.format(-Math.floor(diffSeconds / divisor), unit);
+      return RELATIVE_FORMATTER.format(
+        -Math.floor(diffSeconds / divisor),
+        unit,
+      );
     }
   }
-  return formatter.format(-Math.floor(diffSeconds / 31_557_600), "year");
+  return RELATIVE_FORMATTER.format(
+    -Math.floor(diffSeconds / 31_557_600),
+    "year",
+  );
 }

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -4,3 +4,62 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
+
+/**
+ * Human-readable byte size using binary (1024) units. Matches the UX
+ * used by file pickers and cloud storage apps (52428800 -> "50 MB").
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    BYTE_UNITS.length - 1,
+  );
+  const value = bytes / Math.pow(1024, exponent);
+  // One decimal for sub-10 values, round otherwise -- keeps the badge tight.
+  const rounded = value < 10 ? Math.round(value * 10) / 10 : Math.round(value);
+  return `${rounded} ${BYTE_UNITS[exponent]}`;
+}
+
+const RELATIVE_THRESHOLDS: Array<{
+  limit: number;
+  divisor: number;
+  unit: Intl.RelativeTimeFormatUnit;
+}> = [
+  { limit: 60, divisor: 1, unit: "second" },
+  { limit: 3600, divisor: 60, unit: "minute" },
+  { limit: 86_400, divisor: 3600, unit: "hour" },
+  { limit: 604_800, divisor: 86_400, unit: "day" },
+  { limit: 2_629_800, divisor: 604_800, unit: "week" },
+  { limit: 31_557_600, divisor: 2_629_800, unit: "month" },
+  { limit: Number.POSITIVE_INFINITY, divisor: 31_557_600, unit: "year" },
+];
+
+/**
+ * Short relative timestamp backed by `Intl.RelativeTimeFormat` so the
+ * copy follows the user's locale (e.g. "3d ago", "2 months ago"). Past
+ * values only -- future timestamps collapse to "just now".
+ */
+export function formatRelativeDate(iso: string): string {
+  const timestamp = Date.parse(iso);
+  if (Number.isNaN(timestamp)) {
+    return "";
+  }
+  const diffSeconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (diffSeconds < 5) return "just now";
+
+  const formatter = new Intl.RelativeTimeFormat(undefined, {
+    numeric: "auto",
+    style: "short",
+  });
+  for (const { limit, divisor, unit } of RELATIVE_THRESHOLDS) {
+    if (diffSeconds < limit) {
+      return formatter.format(-Math.floor(diffSeconds / divisor), unit);
+    }
+  }
+  return formatter.format(-Math.floor(diffSeconds / 31_557_600), "year");
+}


### PR DESCRIPTION
## Summary

Bundled PR closes both [ASK-164](https://linear.app/askatlas/issue/ASK-164) and [ASK-168](https://linear.app/askatlas/issue/ASK-168) — they're small, dependent, and both consumed by the same page refactor.

### ASK-168 — `FavoriteButton`

- React 19 \`useOptimistic\` + \`useTransition\` star toggle.
- Click fills the star immediately; the button disables while \`onToggle\` is in flight; state reverts on settle so the caller can sync from the server's \`ToggleFavoriteResponse\`.
- Caller wraps its own \`onToggle\` to surface errors (pattern matches toast usage).

### ASK-164 — \`FileCard\`

- \`list\` + \`grid\` variants, slots for \`favoriteButton\` and \`rowMenu\` (list only).
- Keyboard-activatable (Enter / Space), mime-type icon map, \`Untitled\` fallback, \`Processing…\` state, title truncation.
- \`role=button\` only when \`onOpen\` is provided.

### Refactor: \`/resources\` page

- Drops the hand-rolled \`Document\` interface for the generated \`FileResponse\` type.
- Removes inline \`formatFileSize\` / \`getRelativeTime\`; replaces with \`formatBytes\` + \`formatRelativeDate\` in \`lib/utils.ts\`.
- Replaces inline list/grid row markup with \`FileCard\`, mounting a \`FavoriteButton\` wired to \`toggleFileFavorite\` (toast on error).
- \`DocumentViewer\` kept as-is (out of scope).

### Storybook

- **Shared / FavoriteButton** — 5 stories (\`Unfavorited\`, \`Favorited\`, \`SmallSize\`, \`SlowNetwork\`, \`NetworkFailure\`).
- **Dashboard / FileCard** — 10 stories covering both variants, favorite / row-menu / pending / long-title / image / fallback.

## Test plan

- [x] \`make format-check\` clean
- [x] \`make typecheck\` clean
- [x] \`make lint\` clean
- [x] \`pnpm exec jest lib/features\` — 49/49 pass
- [ ] CI build green
- [x] Storybook boots; screenshots cover list + grid + favorite variants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added favorite toggle button to mark files as favorites with instant visual feedback
  * Refactored resources page with unified file card component supporting both list and grid layouts
  * Enhanced file display with human-readable file sizes and relative timestamps
  * Added dropdown menu for additional file actions per file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->