### PR TITLE
chore(docs): deploy Storybook alongside Docusaurus on GitHub Pages

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - 'web/lib/**'
       - 'web/components/**'
+      - 'web/public/**'
       - 'web/.storybook/**'
       - 'web/package.json'
       - 'web/pnpm-lock.yaml'
@@ -49,9 +50,10 @@ jobs:
       - name: Build Storybook
         working-directory: web
         env:
-          # Storybook is served at `https://ask-atlas.github.io/AskAtlas/storybook/`,
-          # so Vite needs to rewrite asset URLs to that subpath. `.storybook/main.ts`
-          # reads this env into `viteFinal.base`.
+          # Preview iframe's asset URLs are rewritten via `viteFinal.base`
+          # in .storybook/main.ts. The Manager UI's assets already emit
+          # relative paths (`./sb-manager/runtime.js`), so they resolve
+          # correctly under any subpath without extra configuration.
           STORYBOOK_BASE_URL: /AskAtlas/storybook/
         run: pnpm build-storybook --output-dir storybook-static
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs to GitHub Pages
+name: Deploy Docs + Storybook to GitHub Pages
 
 on:
   push:
@@ -6,6 +6,12 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'web/lib/**'
+      - 'web/components/**'
+      - 'web/.storybook/**'
+      - 'web/package.json'
+      - 'web/pnpm-lock.yaml'
+      - '.github/workflows/docs-deploy.yml'
   workflow_dispatch:
 
 permissions:
@@ -19,25 +25,56 @@ concurrency:
 
 jobs:
   build:
-    name: Build Docusaurus
+    name: Build Docusaurus + Storybook
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docs
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      # --- Storybook (pnpm) ---
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node 22 (Storybook)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install web dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        working-directory: web
+        env:
+          # Storybook is served at `https://ask-atlas.github.io/AskAtlas/storybook/`,
+          # so Vite needs to rewrite asset URLs to that subpath. `.storybook/main.ts`
+          # reads this env into `viteFinal.base`.
+          STORYBOOK_BASE_URL: /AskAtlas/storybook/
+        run: pnpm build-storybook --output-dir storybook-static
+
+      # --- Docusaurus (npm) ---
+      - name: Set up Node 20 (Docusaurus)
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
-      - name: Install dependencies
+      - name: Install docs dependencies
+        working-directory: docs
         run: npm ci
 
-      - name: Build website
+      - name: Build Docusaurus
+        working-directory: docs
         run: npm run build
+
+      - name: Merge Storybook into Pages artifact
+        run: |
+          mkdir -p docs/build/storybook
+          cp -R web/storybook-static/. docs/build/storybook/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/docs/sprint-reviews/sprint-2.md
+++ b/docs/docs/sprint-reviews/sprint-2.md
@@ -28,7 +28,7 @@ No issues that were actively worked on this sprint were left incomplete. The ope
 | [#6](https://github.com/Ask-Atlas/AskAtlas/issues/6) | UI/UX design for the dashboard |
 | [#15](https://github.com/Ask-Atlas/AskAtlas/issues/15) | Design and implement the UI/UX for the Study Guide View |
 | [#19](https://github.com/Ask-Atlas/AskAtlas/issues/19) | UI/UX design for the library |
-| [#61](https://github.com/Ask-Atlas/AskAtlas/issues/61) | API - PATCH /api/files/{file_id} (update file metadata) |
+| [#61](https://github.com/Ask-Atlas/AskAtlas/issues/61) | API - PATCH `/api/files/{file_id}` (update file metadata) |
 
 ## Incomplete Issues/User Stories
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -100,6 +100,11 @@ const config: Config = {
         },
         { to: '/blog', label: 'Blog', position: 'left' },
         {
+          href: 'pathname:///storybook/',
+          label: 'Components',
+          position: 'left',
+        },
+        {
           href: 'https://github.com/Ask-Atlas/AskAtlas',
           label: 'GitHub',
           position: 'right',

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -100,7 +100,9 @@ const config: Config = {
         },
         { to: '/blog', label: 'Blog', position: 'left' },
         {
-          href: 'pathname:///storybook/',
+          // `pathname://` bypasses Docusaurus link rewriting, so the path
+          // has to include the Pages baseUrl (`/AskAtlas/`) explicitly.
+          href: 'pathname:///AskAtlas/storybook/',
           label: 'Components',
           position: 'left',
         },

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -12,6 +12,14 @@ const config: StorybookConfig = {
   ],
   framework: "@storybook/nextjs-vite",
   staticDirs: ["../public"],
+  // Deployed Storybook lives under a GitHub Pages subpath
+  // (https://ask-atlas.github.io/AskAtlas/storybook/), so the build
+  // needs its asset URLs rewritten. Local dev sticks with the default
+  // root base, preserving `pnpm storybook` on localhost:6006.
+  viteFinal: async (config) => {
+    config.base = process.env.STORYBOOK_BASE_URL ?? "/";
+    return config;
+  },
 };
 
 export default config;

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -17,7 +17,10 @@ const config: StorybookConfig = {
   // needs its asset URLs rewritten. Local dev sticks with the default
   // root base, preserving `pnpm storybook` on localhost:6006.
   viteFinal: async (config) => {
-    config.base = process.env.STORYBOOK_BASE_URL ?? "/";
+    const raw = process.env.STORYBOOK_BASE_URL?.trim();
+    // Normalize: empty -> root, always trailing slash so Vite's `base`
+    // produces correct relative resolution for every chunk.
+    config.base = !raw ? "/" : raw.endsWith("/") ? raw : `${raw}/`;
     return config;
   },
 };


### PR DESCRIPTION
## Summary

Extends the existing Pages workflow so Storybook deploys to \`https://ask-atlas.github.io/AskAtlas/storybook/\` alongside Docusaurus at the root. One canonical URL for the team, no per-env drift, no new vendors.

### What changes

- \`.github/workflows/docs-deploy.yml\`: now also installs web deps via pnpm, runs \`pnpm build-storybook\` with \`STORYBOOK_BASE_URL=/AskAtlas/storybook/\`, and copies the output into \`docs/build/storybook/\` before uploading the combined Pages artifact. Trigger paths expanded to \`web/lib/**\`, \`web/components/**\`, \`web/.storybook/**\`, and web package manifests.
- \`web/.storybook/main.ts\`: \`viteFinal\` hook reads \`STORYBOOK_BASE_URL\` so asset URLs resolve at the subpath. Local \`pnpm storybook\` keeps the default root base.
- \`docs/docusaurus.config.ts\`: added a top-nav \"Components\" link pointing at \`pathname:///storybook/\`.

### Drive-by fix

- \`docs/docs/sprint-reviews/sprint-2.md\`: wrapped \`{file_id}\` in backticks. MDX was evaluating it as a JSX expression and crashing the build — every Pages deploy has been red since the previous sprint. Small, safe, unblocks this PR.

## Test plan

- [x] Local \`pnpm build-storybook --output-dir storybook-static\` with \`STORYBOOK_BASE_URL=/AskAtlas/storybook/\` emits a clean \`storybook-static/\` using relative asset paths.
- [x] Local \`cd docs && npm run build\` succeeds end-to-end (SUCCESS marker in log).
- [x] Local merge step (\`cp -R web/storybook-static/. docs/build/storybook/\`) produces both \`docs/build/index.html\` and \`docs/build/storybook/index.html\`.
- [ ] Pages workflow run on merge succeeds; \`https://ask-atlas.github.io/AskAtlas/storybook/\` renders.