### PR TITLE
fix(deploy): harden against concurrent containerd pull races

### DIFF
--- a/.github/workflows/api-deployments.yml
+++ b/.github/workflows/api-deployments.yml
@@ -1,4 +1,4 @@
-name: API Application Deployments 
+name: API Application Deployments
 
 on:
   workflow_dispatch:
@@ -11,6 +11,15 @@ on:
         - dev
         - stage
         - prod
+
+# Serialize deploys that target the same VM. Api + web share a host
+# per environment, and concurrent `docker pull` invocations race on
+# containerd's snapshotter/content store (lchown/rename/lease-not-found).
+# Matching group lives in web-deployments.yml so the two workflows
+# contend for the same slot per environment.
+concurrency:
+  group: vm-deploy-${{ inputs.environment }}
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/web-deployments.yml
+++ b/.github/workflows/web-deployments.yml
@@ -1,4 +1,4 @@
-name: Web Application Deployments 
+name: Web Application Deployments
 
 on:
   workflow_dispatch:
@@ -11,6 +11,15 @@ on:
         - dev
         - stage
         - prod
+
+# Serialize deploys that target the same VM. Api + web share a host
+# per environment, and concurrent `docker pull` invocations race on
+# containerd's snapshotter/content store (lchown/rename/lease-not-found).
+# Matching group lives in api-deployments.yml so the two workflows
+# contend for the same slot per environment.
+concurrency:
+  group: vm-deploy-${{ inputs.environment }}
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -36,7 +36,7 @@ for attempt in 1 2 3; do
         echo "✗ docker pull failed after 3 attempts"
         exit 1
     fi
-    SLEEP=$(( attempt * 10 ))
+    SLEEP=$((attempt * 10))
     echo "Pull attempt $attempt failed; retrying in ${SLEEP}s..."
     sleep "$SLEEP"
 done

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,7 +24,22 @@ echo "Logging in to GHCR..."
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin 2>/dev/null || echo "Already logged in"
 
 echo "Pulling image..."
-docker pull "$IMAGE"
+# Concurrent api+web pulls on the same VM occasionally race containerd's
+# snapshotter/content store (lchown/rename/lease-not-found errors).
+# Retry with backoff -- pulls are idempotent and the second attempt
+# nearly always succeeds once the contending pull has finished.
+for attempt in 1 2 3; do
+    if docker pull "$IMAGE"; then
+        break
+    fi
+    if [ "$attempt" -eq 3 ]; then
+        echo "✗ docker pull failed after 3 attempts"
+        exit 1
+    fi
+    SLEEP=$(( attempt * 10 ))
+    echo "Pull attempt $attempt failed; retrying in ${SLEEP}s..."
+    sleep "$SLEEP"
+done
 docker image inspect "$LOCAL_TAG" &>/dev/null && {
     echo "Rotating tags: $LOCAL_TAG -> $PREVIOUS_TAG"
     docker tag "$LOCAL_TAG" "$PREVIOUS_TAG"


### PR DESCRIPTION
## Summary

Api + web deploys for each env share a VM, and today they race containerd's snapshotter/content store. Attempt-1 logs across 7 transient failures this week show three related signatures, all downstream of two parallel `docker pull` invocations:

- `failed to extract layer ... failed to Lchown ... no such file`
- `failed commit on ref ... rename ... no such file`
- `lease does not exist: not found`

Bigger images widen the collision window, which is why this started getting worse.

## Fix

**Two layers, complementary:**

1. **`scripts/deploy.sh`** — wrap `docker pull` in a 3-attempt loop with 10s / 20s backoff. Pulls are idempotent; the race loser almost always succeeds on retry once the contending pull has settled. Exit semantics unchanged (exits `1` after 3 failures).
2. **`.github/workflows/{api,web}-deployments.yml`** — add a top-level concurrency group keyed on `vm-deploy-${{ inputs.environment }}`. Both workflows share the key, so api + web deploys targeting the same env queue through one slot — no more two parallel SSH sessions pulling onto the same VM. Deploys to different envs still run in parallel.

Concurrency group prevents the race, retry catches residual / unrelated containerd hiccups. `cancel-in-progress: false` so no queued deploy gets dropped.

## Not in scope

- VM containerd upgrade (would help, needs ops access).
- Cross-env serialization (would over-serialize if dev + stage really do run on separate VMs).

## Test plan

- [x] `bash -n scripts/deploy.sh` — syntax clean; `set -eu` compatible (`if docker pull` is a protected errexit context).
- [ ] Dispatch dev + stage × api + web to exercise the concurrency group. With the fix in place, api-dev + web-dev should queue behind each other; api-stage + web-stage likewise.
- [ ] No containerd pull failures on the dispatched round.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Normalized workflow names for API and Web deployment pipelines by removing trailing whitespace
* Enhanced deployment stability by preventing concurrent deployments to the same environment, ensuring only one deployment runs at a time
* Improved deployment robustness with automatic retry logic for container image retrieval, including exponential backoff on failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->