### PR TITLE
feat(web): shared EmptyState + Skeleton primitives (ASK-161 + ASK-162)

### DIFF
--- a/web/components/ui/empty-state.stories.tsx
+++ b/web/components/ui/empty-state.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { FileText, Inbox, Search } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+import { EmptyState } from "./empty-state";
+
+const meta: Meta<typeof EmptyState> = {
+  title: "UI/EmptyState",
+  component: EmptyState,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Tier A primitive for list/grid surfaces that have nothing to render. Slots (icon, body, action) are all optional so the same component covers everything from a tiny inline 'no results' message to a full zero-state with illustration and CTA.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] rounded-md border border-dashed">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+export const TitleOnly: Story = {
+  args: {
+    title: "No files yet",
+  },
+};
+
+export const WithBody: Story = {
+  args: {
+    title: "No files yet",
+    body: "Upload a PDF, slide deck, or image to get started.",
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    title: "No files yet",
+    body: "Upload a PDF, slide deck, or image to get started.",
+    icon: <Inbox className="size-10" />,
+  },
+};
+
+export const FullZeroState: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Everything: icon, title, body, CTA. Canonical shape for a list page with no rows.",
+      },
+    },
+  },
+  args: {
+    title: "No files yet",
+    body: "Upload a PDF, slide deck, or image to get started.",
+    icon: <FileText className="size-10" />,
+    action: <Button>Upload a file</Button>,
+  },
+};
+
+export const NoSearchResults: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Common variant for filtered lists when a query returns nothing.",
+      },
+    },
+  },
+  args: {
+    title: "No results",
+    body: 'Nothing matches "linear algebra". Try a different search.',
+    icon: <Search className="size-10" />,
+  },
+};

--- a/web/components/ui/empty-state.test.tsx
+++ b/web/components/ui/empty-state.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Exercises the ASK-161 acceptance criteria: title-only render hides the
+ * optional slots, the full prop set renders icon/title/body/action in
+ * DOM order, and a custom `className` merges via `cn()` without stomping
+ * the base layout classes (so consumers can tweak spacing or width per
+ * surface without reinventing the primitive).
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { EmptyState } from "./empty-state";
+
+describe("EmptyState", () => {
+  it("renders only the title when no optional props are provided", () => {
+    render(<EmptyState title="No files yet" />);
+    expect(
+      screen.getByRole("heading", { name: "No files yet" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("empty-icon")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("empty-action")).not.toBeInTheDocument();
+  });
+
+  it("renders icon, title, body, and action in that DOM order", () => {
+    const { container } = render(
+      <EmptyState
+        title="No files yet"
+        body="Upload a file to get started."
+        icon={<svg data-testid="empty-icon" />}
+        action={
+          <button type="button" data-testid="empty-action">
+            Upload
+          </button>
+        }
+      />,
+    );
+    const root = container.firstElementChild;
+    expect(root).not.toBeNull();
+    const children = Array.from(root?.children ?? []);
+    // Slots must render in the documented visual order so consumers can
+    // reason about layout without reading the implementation.
+    expect(children[0]?.querySelector("[data-testid='empty-icon']")).not.toBe(
+      null,
+    );
+    expect(children[1]?.tagName).toBe("H3");
+    expect(children[2]?.tagName).toBe("P");
+    expect(children[3]?.querySelector("[data-testid='empty-action']")).not.toBe(
+      null,
+    );
+  });
+
+  it("merges a custom className with the base layout classes", () => {
+    const { container } = render(
+      <EmptyState title="No files yet" className="border border-dashed" />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("border");
+    // Base layout must still apply -- otherwise consumers could accidentally
+    // break centering by passing any className.
+    expect(root.className).toContain("flex");
+    expect(root.className).toContain("text-center");
+  });
+
+  it("omits the body paragraph entirely when body is not passed", () => {
+    const { container } = render(<EmptyState title="No files yet" />);
+    expect(container.querySelector("p")).toBeNull();
+  });
+});

--- a/web/components/ui/empty-state.tsx
+++ b/web/components/ui/empty-state.tsx
@@ -1,0 +1,35 @@
+import { type ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface EmptyStateProps {
+  title: string;
+  body?: string;
+  action?: ReactNode;
+  icon?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  title,
+  body,
+  action,
+  icon,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 p-8 text-center",
+        className,
+      )}
+    >
+      {icon ? <div className="text-muted-foreground">{icon}</div> : null}
+      <h3 className="text-lg font-semibold">{title}</h3>
+      {body ? (
+        <p className="text-muted-foreground max-w-sm text-sm">{body}</p>
+      ) : null}
+      {action ? <div className="mt-2">{action}</div> : null}
+    </div>
+  );
+}

--- a/web/components/ui/skeleton-grid.stories.tsx
+++ b/web/components/ui/skeleton-grid.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { SkeletonGrid } from "./skeleton-grid";
+
+const meta: Meta<typeof SkeletonGrid> = {
+  title: "UI/SkeletonGrid",
+  component: SkeletonGrid,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Compound skeleton for card grids (file tiles, course tiles, quiz cards). Responsive 2 -> 3 -> 4 columns matches the real FileCard grid so the placeholder doesn't shift layout on data arrival.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SkeletonGrid>;
+
+export const Default: Story = {};
+
+export const Small: Story = {
+  args: { count: 3 },
+};
+
+export const Large: Story = {
+  args: { count: 12 },
+};

--- a/web/components/ui/skeleton-grid.test.tsx
+++ b/web/components/ui/skeleton-grid.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Exercises the ASK-162 acceptance criteria for the grid variant:
+ * default count renders 6 cards, explicit count wins, responsive grid
+ * classes are present, and a custom className composes cleanly.
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { SkeletonGrid } from "./skeleton-grid";
+
+describe("SkeletonGrid", () => {
+  it("renders 6 cards by default", () => {
+    render(<SkeletonGrid />);
+    const grid = screen.getByTestId("skeleton-grid");
+    expect(grid.children).toHaveLength(6);
+  });
+
+  it("renders the requested number of cards", () => {
+    render(<SkeletonGrid count={4} />);
+    const grid = screen.getByTestId("skeleton-grid");
+    expect(grid.children).toHaveLength(4);
+  });
+
+  it("applies responsive grid columns", () => {
+    render(<SkeletonGrid />);
+    const grid = screen.getByTestId("skeleton-grid");
+    // 2 -> 3 -> 4 columns keeps card grids legible on phone/tablet/desktop
+    // without per-page overrides.
+    expect(grid.className).toContain("grid-cols-2");
+    expect(grid.className).toContain("md:grid-cols-3");
+    expect(grid.className).toContain("lg:grid-cols-4");
+  });
+
+  it("forwards a custom className without dropping base layout", () => {
+    render(<SkeletonGrid className="mt-8" />);
+    const grid = screen.getByTestId("skeleton-grid");
+    expect(grid.className).toContain("mt-8");
+    expect(grid.className).toContain("grid");
+  });
+
+  it("is hidden from assistive tech", () => {
+    render(<SkeletonGrid />);
+    expect(screen.getByTestId("skeleton-grid")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+});

--- a/web/components/ui/skeleton-grid.tsx
+++ b/web/components/ui/skeleton-grid.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface SkeletonGridProps {
+  count?: number;
+  className?: string;
+}
+
+export function SkeletonGrid({ count = 6, className }: SkeletonGridProps) {
+  return (
+    <div
+      aria-hidden
+      data-testid="skeleton-grid"
+      className={cn(
+        "grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4",
+        className,
+      )}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <Skeleton key={i} className="aspect-square w-full" />
+      ))}
+    </div>
+  );
+}

--- a/web/components/ui/skeleton-list.stories.tsx
+++ b/web/components/ui/skeleton-list.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { SkeletonList } from "./skeleton-list";
+
+const meta: Meta<typeof SkeletonList> = {
+  title: "UI/SkeletonList",
+  component: SkeletonList,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Compound skeleton for row-based lists (files, study guides, resources). Callers render it while the data query is pending and swap it for the real list when it resolves.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[540px] rounded-md border">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SkeletonList>;
+
+export const Default: Story = {};
+
+export const Single: Story = {
+  args: { count: 1 },
+};
+
+export const LongList: Story = {
+  args: { count: 8 },
+};

--- a/web/components/ui/skeleton-list.test.tsx
+++ b/web/components/ui/skeleton-list.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * Exercises the ASK-162 acceptance criteria for the list variant:
+ * the default count renders 3 rows, an explicit count wins, and the
+ * container receives a custom className without losing the base layout.
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { SkeletonList } from "./skeleton-list";
+
+describe("SkeletonList", () => {
+  it("renders 3 rows by default", () => {
+    render(<SkeletonList />);
+    const list = screen.getByTestId("skeleton-list");
+    expect(list.children).toHaveLength(3);
+  });
+
+  it("renders the requested number of rows", () => {
+    render(<SkeletonList count={5} />);
+    const list = screen.getByTestId("skeleton-list");
+    expect(list.children).toHaveLength(5);
+  });
+
+  it("forwards a custom className without dropping base layout", () => {
+    render(<SkeletonList className="max-w-md" />);
+    const list = screen.getByTestId("skeleton-list");
+    expect(list.className).toContain("max-w-md");
+    expect(list.className).toContain("flex");
+  });
+
+  it("is hidden from assistive tech", () => {
+    render(<SkeletonList />);
+    // Callers pair this with their own aria-live region (e.g. 'Loading
+    // files…') so screen readers get one semantic announcement instead
+    // of N pulsing placeholders.
+    expect(screen.getByTestId("skeleton-list")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+});

--- a/web/components/ui/skeleton-list.tsx
+++ b/web/components/ui/skeleton-list.tsx
@@ -1,0 +1,27 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface SkeletonListProps {
+  count?: number;
+  className?: string;
+}
+
+export function SkeletonList({ count = 3, className }: SkeletonListProps) {
+  return (
+    <ul
+      aria-hidden
+      data-testid="skeleton-list"
+      className={cn("flex flex-col", className)}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <li key={i} className="flex items-center gap-3 p-3">
+          <Skeleton className="size-10 rounded-md" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
Closes ASK-161, ASK-162.

## Summary

Tier A shared primitives that unblock every downstream list/grid page wire-up (home, resources, practice, study-guides, courses, me/*).

- **EmptyState** (`components/ui/empty-state.tsx`) — title + optional body/icon/action slots. No live-region role so consumers own a11y semantics (a search "no results" screen can opt in to `aria-live`; a zero-state upload CTA stays silent).
- **SkeletonList** (`components/ui/skeleton-list.tsx`) — row-shaped placeholders for file/study-guide/resource lists, `aria-hidden` so callers own the loading announcement.
- **SkeletonGrid** (`components/ui/skeleton-grid.tsx`) — responsive 2 -> 3 -> 4 column placeholder matched to the FileCard grid to avoid layout shift on data arrival.

## Test plan

- [x] `pnpm jest components/ui/{empty-state,skeleton-list,skeleton-grid}.test.tsx` — 13/13 passing
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm prettier --check` clean for new files
- [x] Storybook stories render (UI/EmptyState, UI/SkeletonList, UI/SkeletonGrid)
- [ ] Visual verification in Storybook after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EmptyState component for displaying empty page states with support for titles, descriptions, icons, and custom actions.
  * Added SkeletonGrid and SkeletonList components for responsive loading state placeholders across different layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->