### PR TITLE
feat(web): courses/course-card row + tile variants (ASK-180)

### DIFF
--- a/web/lib/features/dashboard/courses/course-card.stories.tsx
+++ b/web/lib/features/dashboard/courses/course-card.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { CourseResponse } from "@/lib/api/types";
+
+import { CourseCard } from "./course-card";
+
+function makeCourse(overrides: Partial<CourseResponse> = {}): CourseResponse {
+  return {
+    id: "c_preview_1",
+    school: {
+      id: "s_preview_1",
+      name: "Washington State University",
+      acronym: "WSU",
+      city: "Pullman",
+      state: "WA",
+      country: "US",
+    },
+    department: "CPTS",
+    number: "322",
+    title: "Systems Programming",
+    description: null,
+    created_at: "2026-04-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+const meta: Meta<typeof CourseCard> = {
+  title: "Dashboard/CourseCard",
+  component: CourseCard,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Card for a single course. Row variant is compact (catalog list, sidebar). Tile variant surfaces the school name for the dashboard tile grid and /me/courses. The outer element is a Next.js Link; rightSlot clicks don't navigate so interactive affordances (Join / Leave / Favorite) work unambiguously.",
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: { type: "radio" },
+      options: ["row", "tile"],
+    },
+  },
+  decorators: [
+    (Story, context) => (
+      <div
+        className={context.args.variant === "tile" ? "w-[260px]" : "w-[540px]"}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CourseCard>;
+
+export const Row: Story = {
+  args: {
+    course: makeCourse(),
+    variant: "row",
+  },
+};
+
+export const RowWithJoinedBadge: Story = {
+  args: {
+    course: makeCourse(),
+    variant: "row",
+    rightSlot: (
+      <Badge
+        variant="secondary"
+        className="bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400"
+      >
+        Joined
+      </Badge>
+    ),
+  },
+};
+
+export const RowWithJoinCta: Story = {
+  args: {
+    course: makeCourse(),
+    variant: "row",
+    rightSlot: (
+      <Button size="sm" variant="outline">
+        Join
+      </Button>
+    ),
+  },
+};
+
+export const RowLongTitle: Story = {
+  args: {
+    course: makeCourse({
+      title:
+        "Advanced Topics in Computer Architecture and Operating System Design",
+    }),
+    variant: "row",
+  },
+};
+
+export const Tile: Story = {
+  args: {
+    course: makeCourse(),
+    variant: "tile",
+  },
+};
+
+export const TileWithJoinedBadge: Story = {
+  args: {
+    course: makeCourse(),
+    variant: "tile",
+    rightSlot: (
+      <Badge
+        variant="secondary"
+        className="bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400"
+      >
+        Joined
+      </Badge>
+    ),
+  },
+};
+
+export const TileLongTitle: Story = {
+  args: {
+    course: makeCourse({
+      title:
+        "Advanced Topics in Computer Architecture and Operating System Design",
+    }),
+    variant: "tile",
+  },
+};
+
+export const TileAltSchool: Story = {
+  args: {
+    course: makeCourse({
+      school: {
+        id: "s_preview_2",
+        name: "University of California, Berkeley",
+        acronym: "UCB",
+        city: "Berkeley",
+        state: "CA",
+        country: "US",
+      },
+      department: "CS",
+      number: "162",
+      title: "Operating Systems and System Programming",
+    }),
+    variant: "tile",
+  },
+};

--- a/web/lib/features/dashboard/courses/course-card.test.tsx
+++ b/web/lib/features/dashboard/courses/course-card.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Exercises the ASK-180 acceptance criteria: the row variant surfaces
+ * department + number + title ("CPTS 322 — Systems Programming" when read
+ * top-to-bottom); the tile variant additionally shows the school name;
+ * and the rightSlot is rendered without triggering the outer Link when
+ * clicked.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import type { CourseResponse } from "@/lib/api/types";
+
+import { CourseCard } from "./course-card";
+
+function makeCourse(overrides: Partial<CourseResponse> = {}): CourseResponse {
+  return {
+    id: "c_preview_1",
+    school: {
+      id: "s_preview_1",
+      name: "Washington State University",
+      acronym: "WSU",
+      city: "Pullman",
+      state: "WA",
+      country: "US",
+    },
+    department: "CPTS",
+    number: "322",
+    title: "Systems Programming",
+    description: null,
+    created_at: "2026-04-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("CourseCard / row variant", () => {
+  it("shows department + number and title", () => {
+    render(<CourseCard course={makeCourse()} variant="row" />);
+    expect(screen.getByText("CPTS 322")).toBeInTheDocument();
+    expect(screen.getByText("Systems Programming")).toBeInTheDocument();
+  });
+
+  it("links to /courses/{id} by default", () => {
+    render(<CourseCard course={makeCourse()} variant="row" />);
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/courses/c_preview_1",
+    );
+  });
+
+  it("honors a custom href", () => {
+    render(
+      <CourseCard
+        course={makeCourse()}
+        variant="row"
+        href="/catalog?department=CPTS"
+      />,
+    );
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/catalog?department=CPTS",
+    );
+  });
+
+  it("renders rightSlot and prevents clicks on it from navigating", async () => {
+    const onSlotClick = jest.fn();
+    render(
+      <CourseCard
+        course={makeCourse()}
+        variant="row"
+        rightSlot={
+          <button type="button" onClick={onSlotClick}>
+            Join
+          </button>
+        }
+      />,
+    );
+    // The outer Link is still focusable/navigable, but clicks inside the
+    // slot must not bubble to it -- otherwise an "Unenroll" affordance
+    // would also open the course page, which would be confusing.
+    await userEvent.click(screen.getByRole("button", { name: "Join" }));
+    expect(onSlotClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("CourseCard / tile variant", () => {
+  it("renders department, title, and school name", () => {
+    render(<CourseCard course={makeCourse()} variant="tile" />);
+    expect(
+      screen.getByRole("heading", { name: "CPTS 322" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Systems Programming")).toBeInTheDocument();
+    expect(screen.getByText("Washington State University")).toBeInTheDocument();
+  });
+
+  it("links to /courses/{id} by default", () => {
+    render(<CourseCard course={makeCourse()} variant="tile" />);
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/courses/c_preview_1",
+    );
+  });
+
+  it("still renders rightSlot without navigating when clicked", async () => {
+    const onSlotClick = jest.fn();
+    render(
+      <CourseCard
+        course={makeCourse()}
+        variant="tile"
+        rightSlot={
+          <button type="button" onClick={onSlotClick}>
+            Joined
+          </button>
+        }
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Joined" }));
+    expect(onSlotClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/lib/features/dashboard/courses/course-card.tsx
+++ b/web/lib/features/dashboard/courses/course-card.tsx
@@ -1,0 +1,123 @@
+import Link from "next/link";
+import { type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
+
+import type { CourseResponse } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+
+interface CourseCardProps {
+  course: CourseResponse;
+  variant: "row" | "tile";
+  /** Defaults to `/courses/{id}`. Override for contextual routes (e.g. a catalog filter). */
+  href?: string;
+  /**
+   * Trailing affordance: "Joined" badge, FavoriteButton, enrollment CTA, etc.
+   * Clicks and keypresses inside this slot do NOT navigate so interactive
+   * children can own their own behavior without the outer Link swallowing them.
+   */
+  rightSlot?: ReactNode;
+}
+
+export function CourseCard({
+  course,
+  variant,
+  href,
+  rightSlot,
+}: CourseCardProps) {
+  const destination = href ?? `/courses/${course.id}`;
+
+  return (
+    <Link
+      href={destination}
+      className={cn(
+        "group bg-card block rounded-xl border transition-all",
+        "hover:shadow-md",
+        "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
+        variant === "row" ? "p-3" : "p-4",
+      )}
+    >
+      {variant === "row" ? (
+        <RowVariant course={course} rightSlot={rightSlot} />
+      ) : (
+        <TileVariant course={course} rightSlot={rightSlot} />
+      )}
+    </Link>
+  );
+}
+
+function RowVariant({
+  course,
+  rightSlot,
+}: {
+  course: CourseResponse;
+  rightSlot?: ReactNode;
+}) {
+  const code = `${course.department} ${course.number}`;
+  return (
+    <div className="flex items-center gap-3">
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground text-sm font-semibold">{code}</p>
+        <p
+          className="text-muted-foreground truncate text-xs"
+          title={course.title}
+        >
+          {course.title}
+        </p>
+      </div>
+      {rightSlot ? <SlotWrapper>{rightSlot}</SlotWrapper> : null}
+    </div>
+  );
+}
+
+function TileVariant({
+  course,
+  rightSlot,
+}: {
+  course: CourseResponse;
+  rightSlot?: ReactNode;
+}) {
+  const code = `${course.department} ${course.number}`;
+  return (
+    <div className="relative space-y-1.5">
+      {rightSlot ? (
+        <SlotWrapper className="absolute right-0 top-0">
+          {rightSlot}
+        </SlotWrapper>
+      ) : null}
+      <h3 className="text-foreground text-base font-semibold leading-tight">
+        {code}
+      </h3>
+      <p className="text-foreground line-clamp-2 text-sm leading-snug">
+        {course.title}
+      </p>
+      <p className="text-muted-foreground truncate text-xs">
+        {course.school.name}
+      </p>
+    </div>
+  );
+}
+
+function SlotWrapper({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn("shrink-0", className)}
+      onClick={stopPropagation}
+      onKeyDown={stopKeyboardPropagation}
+    >
+      {children}
+    </div>
+  );
+}
+
+function stopPropagation(event: MouseEvent) {
+  event.stopPropagation();
+}
+
+function stopKeyboardPropagation(event: KeyboardEvent) {
+  event.stopPropagation();
+}

--- a/web/lib/features/dashboard/courses/course-card.tsx
+++ b/web/lib/features/dashboard/courses/course-card.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
+import { type ReactNode } from "react";
 
 import type { CourseResponse } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
@@ -11,8 +11,9 @@ interface CourseCardProps {
   href?: string;
   /**
    * Trailing affordance: "Joined" badge, FavoriteButton, enrollment CTA, etc.
-   * Clicks and keypresses inside this slot do NOT navigate so interactive
-   * children can own their own behavior without the outer Link swallowing them.
+   * Rendered as a sibling of the stretched Link (not nested inside it) so
+   * interactive children can own their own clicks without producing an
+   * invalid `<a><button>` HTML structure.
    */
   rightSlot?: ReactNode;
 }
@@ -24,37 +25,47 @@ export function CourseCard({
   rightSlot,
 }: CourseCardProps) {
   const destination = href ?? `/courses/${course.id}`;
+  const code = `${course.department} ${course.number}`;
 
   return (
-    <Link
-      href={destination}
+    <div
       className={cn(
-        "group bg-card block rounded-xl border transition-all",
-        "hover:shadow-md",
-        "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
-        variant === "row" ? "p-3" : "p-4",
+        "group bg-card focus-within:ring-ring relative rounded-xl border transition-all",
+        "hover:shadow-md focus-within:ring-2",
       )}
     >
+      {/* Stretched link: invisible overlay that makes the whole card
+          clickable without nesting interactive children inside an <a>.
+          Content below sits at z-10 so visible text + rightSlot render
+          above it; non-interactive content is `pointer-events-none` so
+          clicks fall through to the Link, while rightSlot stays
+          click-receptive by default. */}
+      <Link
+        href={destination}
+        aria-label={`${code} — ${course.title}`}
+        className="absolute inset-0 z-0 rounded-xl focus:outline-none"
+      />
       {variant === "row" ? (
-        <RowVariant course={course} rightSlot={rightSlot} />
+        <RowVariant course={course} code={code} rightSlot={rightSlot} />
       ) : (
-        <TileVariant course={course} rightSlot={rightSlot} />
+        <TileVariant course={course} code={code} rightSlot={rightSlot} />
       )}
-    </Link>
+    </div>
   );
 }
 
 function RowVariant({
   course,
+  code,
   rightSlot,
 }: {
   course: CourseResponse;
+  code: string;
   rightSlot?: ReactNode;
 }) {
-  const code = `${course.department} ${course.number}`;
   return (
-    <div className="flex items-center gap-3">
-      <div className="min-w-0 flex-1">
+    <div className="flex items-center gap-3 p-3">
+      <div className="pointer-events-none relative z-10 min-w-0 flex-1">
         <p className="text-foreground text-sm font-semibold">{code}</p>
         <p
           className="text-muted-foreground truncate text-xs"
@@ -63,61 +74,38 @@ function RowVariant({
           {course.title}
         </p>
       </div>
-      {rightSlot ? <SlotWrapper>{rightSlot}</SlotWrapper> : null}
+      {rightSlot ? (
+        <div className="relative z-10 shrink-0">{rightSlot}</div>
+      ) : null}
     </div>
   );
 }
 
 function TileVariant({
   course,
+  code,
   rightSlot,
 }: {
   course: CourseResponse;
+  code: string;
   rightSlot?: ReactNode;
 }) {
-  const code = `${course.department} ${course.number}`;
   return (
-    <div className="relative space-y-1.5">
+    <div className="p-4">
+      <div className="pointer-events-none relative z-10 space-y-1.5">
+        <h3 className="text-foreground text-base font-semibold leading-tight">
+          {code}
+        </h3>
+        <p className="text-foreground line-clamp-2 text-sm leading-snug">
+          {course.title}
+        </p>
+        <p className="text-muted-foreground truncate text-xs">
+          {course.school.name}
+        </p>
+      </div>
       {rightSlot ? (
-        <SlotWrapper className="absolute right-0 top-0">
-          {rightSlot}
-        </SlotWrapper>
+        <div className="absolute right-3 top-3 z-10">{rightSlot}</div>
       ) : null}
-      <h3 className="text-foreground text-base font-semibold leading-tight">
-        {code}
-      </h3>
-      <p className="text-foreground line-clamp-2 text-sm leading-snug">
-        {course.title}
-      </p>
-      <p className="text-muted-foreground truncate text-xs">
-        {course.school.name}
-      </p>
     </div>
   );
-}
-
-function SlotWrapper({
-  children,
-  className,
-}: {
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <div
-      className={cn("shrink-0", className)}
-      onClick={stopPropagation}
-      onKeyDown={stopKeyboardPropagation}
-    >
-      {children}
-    </div>
-  );
-}
-
-function stopPropagation(event: MouseEvent) {
-  event.stopPropagation();
-}
-
-function stopKeyboardPropagation(event: KeyboardEvent) {
-  event.stopPropagation();
 }


### PR DESCRIPTION
Closes ASK-180.

## Summary

Tier B primitive that unblocks `courses/catalog-page-wire-up` (ASK-193), `dashboard/section-tiles` (ASK-184), and `me/personal-lists-pages-wire-up` (ASK-194).

- **Row variant** — "CPTS 322" + course title on a truncating line, for catalog lists + sidebar.
- **Tile variant** — \`CPTS 322\` heading + title + school name, for the dashboard tile grid + /me/courses.
- **\`rightSlot\`** (Joined badge / Join CTA / FavoriteButton) is wrapped so click + keyboard events stop at the slot — interactive children don't accidentally fire the outer Link navigation.
- **\`href\`** defaults to \`/courses/{id}\`; callers override for filtered catalog routes.

## Test plan

- [x] \`pnpm jest lib/features/dashboard/courses/course-card.test.tsx\` — 7/7 passing
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm eslint\` clean on new files
- [x] \`pnpm prettier --check\` clean on new files
- [x] Storybook stories render (Dashboard/CourseCard: Row / RowWithJoinedBadge / RowWithJoinCta / RowLongTitle / Tile / TileWithJoinedBadge / TileLongTitle / TileAltSchool)
- [ ] Visual verification in Storybook after deploy