### PR TITLE
feat(web): courses/section-membership-button (ASK-182)

### DIFF
--- a/web/lib/features/dashboard/courses/section-membership-button.stories.tsx
+++ b/web/lib/features/dashboard/courses/section-membership-button.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { SectionMembershipButton } from "./section-membership-button";
+
+function resolveAfter(ms: number): () => Promise<void> {
+  return () => new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function rejectAfter(ms: number): () => Promise<void> {
+  return () =>
+    new Promise((_resolve, reject) =>
+      setTimeout(() => reject(new Error("network")), ms),
+    );
+}
+
+const meta: Meta<typeof SectionMembershipButton> = {
+  title: "Dashboard/SectionMembershipButton",
+  component: SectionMembershipButton,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Three-state inline enrollment control. Join is a one-tap optimistic action; Leave goes through the shared ConfirmationDialog so users can't drop a section by accident. The caller drives the `membership` prop after a successful request; failures revert automatically via `useOptimistic` and the caller surfaces a toast.",
+      },
+    },
+  },
+  argTypes: {
+    membership: {
+      control: { type: "radio" },
+      options: ["member", "not-member", "unknown"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SectionMembershipButton>;
+
+export const NotMember: Story = {
+  args: {
+    membership: "not-member",
+    onJoin: resolveAfter(500),
+    onLeave: resolveAfter(500),
+  },
+};
+
+export const Member: Story = {
+  args: {
+    membership: "member",
+    onJoin: resolveAfter(500),
+    onLeave: resolveAfter(500),
+  },
+};
+
+export const Unknown: Story = {
+  args: {
+    membership: "unknown",
+    onJoin: resolveAfter(500),
+    onLeave: resolveAfter(500),
+  },
+};
+
+export const SlowJoin: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Simulates a 2s round-trip so you can see the pending/disabled state after the optimistic swap.",
+      },
+    },
+  },
+  args: {
+    membership: "not-member",
+    onJoin: resolveAfter(2000),
+    onLeave: resolveAfter(500),
+  },
+};
+
+export const JoinFails: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`onJoin` rejects after ~800ms. The button optimistically shows Enrolled, then reverts to Join when the transition settles. Consumers wrap their own onJoin with a try/catch + toast.",
+      },
+    },
+  },
+  args: {
+    membership: "not-member",
+    onJoin: rejectAfter(800),
+    onLeave: resolveAfter(500),
+  },
+};
+
+export const LeaveFlow: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Start at `member` and click Enrolled to open the leave confirmation. The 1.2s `onLeave` keeps the dialog open + disabled while resolving so the confirm button can show 'Leaving…'.",
+      },
+    },
+  },
+  args: {
+    membership: "member",
+    onJoin: resolveAfter(500),
+    onLeave: resolveAfter(1200),
+  },
+};

--- a/web/lib/features/dashboard/courses/section-membership-button.test.tsx
+++ b/web/lib/features/dashboard/courses/section-membership-button.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Exercises the ASK-182 acceptance criteria: three-state rendering
+ * (unknown/not-member/member), optimistic join + revert on failure,
+ * and the member-state leave flow via ConfirmationDialog (cancel
+ * doesn't call onLeave, confirm does).
+ */
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { SectionMembershipButton } from "./section-membership-button";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("SectionMembershipButton / unknown state", () => {
+  it("renders a disabled spinner while membership is being resolved", () => {
+    render(
+      <SectionMembershipButton
+        membership="unknown"
+        onJoin={jest.fn()}
+        onLeave={jest.fn()}
+      />,
+    );
+    const button = screen.getByRole("button", { name: /checking enrollment/i });
+    expect(button).toBeDisabled();
+  });
+});
+
+describe("SectionMembershipButton / not-member state", () => {
+  it('renders a "Join" button', () => {
+    render(
+      <SectionMembershipButton
+        membership="not-member"
+        onJoin={jest.fn().mockResolvedValue(undefined)}
+        onLeave={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Join" })).toBeInTheDocument();
+  });
+
+  it("fires onJoin when clicked and keeps the button disabled while pending", async () => {
+    const joinPromise = deferred<void>();
+    const onJoin = jest.fn(() => joinPromise.promise);
+    render(
+      <SectionMembershipButton
+        membership="not-member"
+        onJoin={onJoin}
+        onLeave={jest.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    expect(onJoin).toHaveBeenCalledTimes(1);
+    // The button must not accept repeat clicks while the request is
+    // in flight -- otherwise a double-click enrolls the user twice.
+    expect(screen.getByRole("button")).toBeDisabled();
+    joinPromise.resolve();
+    await waitFor(() => expect(onJoin).toHaveBeenCalledTimes(1));
+  });
+
+  it("reverts to the Join label when onJoin rejects (AC3)", async () => {
+    const joinPromise = deferred<void>();
+    const onJoin = jest.fn(() => joinPromise.promise);
+    render(
+      <SectionMembershipButton
+        membership="not-member"
+        onJoin={onJoin}
+        onLeave={jest.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    // Rejection is wrapped in `act` so React flushes the settled-transition
+    // state update (useOptimistic revert) before our assertion runs.
+    await act(async () => {
+      joinPromise.reject(new Error("network"));
+    });
+    // After the transition settles, useOptimistic reverts and the
+    // button returns to the pre-click label. Caller is responsible
+    // for surfacing a toast via its own try/catch around onJoin.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Join" })).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("SectionMembershipButton / member state", () => {
+  it('renders an "Enrolled" button', () => {
+    render(
+      <SectionMembershipButton
+        membership="member"
+        onJoin={jest.fn()}
+        onLeave={jest.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Enrolled" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the leave confirmation dialog without firing onLeave", async () => {
+    const onLeave = jest.fn().mockResolvedValue(undefined);
+    render(
+      <SectionMembershipButton
+        membership="member"
+        onJoin={jest.fn()}
+        onLeave={onLeave}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Enrolled" }));
+    expect(
+      screen.getByRole("alertdialog", { name: /leave this section/i }),
+    ).toBeInTheDocument();
+    expect(onLeave).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onLeave when the dialog is cancelled", async () => {
+    const onLeave = jest.fn().mockResolvedValue(undefined);
+    render(
+      <SectionMembershipButton
+        membership="member"
+        onJoin={jest.fn()}
+        onLeave={onLeave}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Enrolled" }));
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onLeave).not.toHaveBeenCalled();
+  });
+
+  it("fires onLeave when the dialog is confirmed (AC2)", async () => {
+    const leavePromise = deferred<void>();
+    const onLeave = jest.fn(() => leavePromise.promise);
+    render(
+      <SectionMembershipButton
+        membership="member"
+        onJoin={jest.fn()}
+        onLeave={onLeave}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Enrolled" }));
+    await userEvent.click(screen.getByRole("button", { name: "Leave" }));
+    expect(onLeave).toHaveBeenCalledTimes(1);
+    leavePromise.resolve();
+  });
+});

--- a/web/lib/features/dashboard/courses/section-membership-button.tsx
+++ b/web/lib/features/dashboard/courses/section-membership-button.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useOptimistic, useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { ConfirmationDialog } from "@/lib/features/shared/confirmation-dialog";
+import { cn } from "@/lib/utils";
+
+type MembershipState = "member" | "not-member" | "unknown";
+
+interface SectionMembershipButtonProps {
+  membership: MembershipState;
+  /**
+   * Fires the actual join request. Rejections are caught internally so
+   * the optimistic state reverts on settle; callers surface errors
+   * through their own toast (so different surfaces -- detail page vs
+   * onboarding -- can phrase the failure in context).
+   */
+  onJoin: () => Promise<void>;
+  /** Fires after the leave confirmation dialog is confirmed. Same error contract as `onJoin`. */
+  onLeave: () => Promise<void>;
+  className?: string;
+}
+
+export function SectionMembershipButton({
+  membership,
+  onJoin,
+  onLeave,
+  className,
+}: SectionMembershipButtonProps) {
+  const [optimisticMembership, setOptimisticMembership] = useOptimistic(
+    membership,
+    (_current, next: MembershipState) => next,
+  );
+  const [isPending, startTransition] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  if (optimisticMembership === "unknown") {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        disabled
+        aria-label="Checking enrollment"
+        className={className}
+      >
+        <Loader2 className="size-4 animate-spin" aria-hidden />
+      </Button>
+    );
+  }
+
+  if (optimisticMembership === "member") {
+    const handleConfirmLeave = () => {
+      startTransition(async () => {
+        setOptimisticMembership("not-member");
+        try {
+          await onLeave();
+        } catch {
+          // useOptimistic reverts on settle; caller surfaces toast.
+        } finally {
+          setConfirmOpen(false);
+        }
+      });
+    };
+
+    return (
+      <>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isPending}
+          onClick={() => setConfirmOpen(true)}
+          className={cn("min-w-[5.5rem]", className)}
+        >
+          Enrolled
+        </Button>
+        <ConfirmationDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          title="Leave this section?"
+          description="You'll lose access to section members and course announcements. You can rejoin later."
+          confirmLabel={isPending ? "Leaving…" : "Leave"}
+          cancelLabel="Cancel"
+          destructive
+          disabled={isPending}
+          onConfirm={handleConfirmLeave}
+        />
+      </>
+    );
+  }
+
+  const handleJoin = () => {
+    startTransition(async () => {
+      setOptimisticMembership("member");
+      try {
+        await onJoin();
+      } catch {
+        // useOptimistic reverts on settle; caller surfaces toast.
+      }
+    });
+  };
+
+  return (
+    <Button
+      type="button"
+      disabled={isPending}
+      onClick={handleJoin}
+      className={cn("min-w-[5.5rem]", className)}
+    >
+      Join
+    </Button>
+  );
+}


### PR DESCRIPTION
Closes ASK-182.

## Summary

Tier B primitive that unblocks \`courses/detail-page-wire-up\` (ASK-197) and \`onboarding/flow-page-wire-up\` (ASK-200). Plugs directly into the \`rightSlot\` shipped in ASK-180's CourseCard.

Three-state inline control, caller-driven:

- **not-member** — single-tap **Join** with \`useOptimistic\` swap to *Enrolled*; pending-disabled guard prevents double-click enrollment.
- **member** — **Enrolled** opens the shared \`ConfirmationDialog\`. Confirm fires \`onLeave\` with the dialog kept open + disabled while the request resolves (confirm label swaps to "Leaving…"). Cancel does not fire \`onLeave\`.
- **unknown** — disabled spinner while the caller resolves membership server-side.

Failures revert automatically via \`useOptimistic\` on transition settle. Callers wrap with \`try/catch\` and surface their own context-appropriate toast — matching the FavoriteButton contract so a single failure playbook covers both.

## Test plan

- [x] \`pnpm jest lib/features/dashboard/courses/section-membership-button.test.tsx\` — 8/8 passing, no \`act\` warnings
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm eslint\` clean on new files
- [x] \`pnpm prettier --check\` clean on new files
- [x] Storybook stories render (Dashboard/SectionMembershipButton: NotMember / Member / Unknown / SlowJoin / JoinFails / LeaveFlow)
- [ ] Visual verification in Storybook after deploy