### PR TITLE
feat(web): quizzes/quiz-card (ASK-175)

### DIFF
--- a/web/lib/features/dashboard/quizzes/quiz-card.stories.tsx
+++ b/web/lib/features/dashboard/quizzes/quiz-card.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import type { QuizListItemResponse } from "@/lib/api/types";
+
+import { QuizCard } from "./quiz-card";
+
+function makeQuiz(
+  overrides: Partial<QuizListItemResponse> = {},
+): QuizListItemResponse {
+  return {
+    id: "q_preview_1",
+    title: "CPTS 322 — Midterm Review",
+    description: null,
+    question_count: 12,
+    creator: {
+      id: "u_preview_1",
+      first_name: "Ada",
+      last_name: "Lovelace",
+    },
+    created_at: new Date(Date.now() - 6 * 86_400_000).toISOString(),
+    updated_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    ...overrides,
+  };
+}
+
+const meta: Meta<typeof QuizCard> = {
+  title: "Dashboard/QuizCard",
+  component: QuizCard,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "List item for a quiz on the study-guide view page. Card tap opens the quiz detail; the inline Practice CTA routes straight into /practice?quiz={id}. Uses the stretched-link pattern so the Practice <Link> is a sibling of the overlay <Link>, not a descendant.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[620px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof QuizCard>;
+
+export const Default: Story = {
+  args: {
+    quiz: makeQuiz(),
+  },
+};
+
+export const SingleQuestion: Story = {
+  args: {
+    quiz: makeQuiz({ question_count: 1 }),
+  },
+};
+
+export const ManyQuestions: Story = {
+  args: {
+    quiz: makeQuiz({ question_count: 42 }),
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    quiz: makeQuiz({
+      title:
+        "Comprehensive Midterm Review Covering Chapters 1 Through 7 With A Focus On Systems Programming And Concurrent Execution Models",
+    }),
+  },
+};
+
+export const CustomHref: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates the `href` override, e.g. for a contextual view inside a study guide.",
+      },
+    },
+  },
+  args: {
+    quiz: makeQuiz(),
+    href: "/study-guides/g_preview_1/quizzes/q_preview_1",
+  },
+};

--- a/web/lib/features/dashboard/quizzes/quiz-card.test.tsx
+++ b/web/lib/features/dashboard/quizzes/quiz-card.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Exercises the ASK-175 acceptance criteria: title + question count +
+ * updated-at are visible; the Practice CTA targets /practice?quiz={id};
+ * and the card as a whole links to /quizzes/{id} (default) or a custom
+ * href when provided. Nested-link structure is not directly asserted;
+ * it's kept safe by the stretched-link pattern (Practice <Link> is a
+ * sibling of the overlay <Link>, not a descendant).
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import type { QuizListItemResponse } from "@/lib/api/types";
+
+import { QuizCard } from "./quiz-card";
+
+function makeQuiz(
+  overrides: Partial<QuizListItemResponse> = {},
+): QuizListItemResponse {
+  return {
+    id: "q_preview_1",
+    title: "CPTS 322 — Midterm Review",
+    description: null,
+    question_count: 12,
+    creator: {
+      id: "u_preview_1",
+      first_name: "Ada",
+      last_name: "Lovelace",
+    },
+    created_at: "2026-04-18T10:00:00Z",
+    updated_at: "2026-04-22T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("QuizCard", () => {
+  it("shows title, question count, and updated-at (AC1)", () => {
+    render(<QuizCard quiz={makeQuiz()} />);
+    expect(screen.getByText("CPTS 322 — Midterm Review")).toBeInTheDocument();
+    expect(screen.getByText(/12 questions/)).toBeInTheDocument();
+    expect(screen.getByText(/Updated/)).toBeInTheDocument();
+  });
+
+  it("pluralizes the question count correctly", () => {
+    render(<QuizCard quiz={makeQuiz({ question_count: 1 })} />);
+    expect(screen.getByText(/1 question/)).toBeInTheDocument();
+    expect(screen.queryByText(/1 questions/)).not.toBeInTheDocument();
+  });
+
+  it("links the Practice button to /practice?quiz={id} (AC2)", () => {
+    render(<QuizCard quiz={makeQuiz()} />);
+    expect(screen.getByRole("link", { name: "Practice" })).toHaveAttribute(
+      "href",
+      "/practice?quiz=q_preview_1",
+    );
+  });
+
+  it("links the card to /quizzes/{id} by default", () => {
+    render(<QuizCard quiz={makeQuiz()} />);
+    // The overlay Link is labeled by aria-label ("Open quiz {title}")
+    // so queryable by role+name rather than by its invisible text.
+    expect(
+      screen.getByRole("link", { name: /open quiz cpts 322/i }),
+    ).toHaveAttribute("href", "/quizzes/q_preview_1");
+  });
+
+  it("honors a custom href on the card", () => {
+    render(
+      <QuizCard
+        quiz={makeQuiz()}
+        href="/study-guides/g_1/quizzes/q_preview_1"
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: /open quiz cpts 322/i }),
+    ).toHaveAttribute("href", "/study-guides/g_1/quizzes/q_preview_1");
+  });
+
+  it("shows the creator's full name", () => {
+    render(<QuizCard quiz={makeQuiz()} />);
+    expect(screen.getByText(/by Ada Lovelace/)).toBeInTheDocument();
+  });
+});

--- a/web/lib/features/dashboard/quizzes/quiz-card.tsx
+++ b/web/lib/features/dashboard/quizzes/quiz-card.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import type { QuizListItemResponse } from "@/lib/api/types";
+import { cn, formatRelativeDate } from "@/lib/utils";
+
+interface QuizCardProps {
+  quiz: QuizListItemResponse;
+  /** Defaults to `/quizzes/{id}`. Override for contextual routes. */
+  href?: string;
+}
+
+export function QuizCard({ quiz, href }: QuizCardProps) {
+  const destination = href ?? `/quizzes/${quiz.id}`;
+  const creatorName =
+    `${quiz.creator.first_name} ${quiz.creator.last_name}`.trim();
+  const questionLabel =
+    quiz.question_count === 1
+      ? "1 question"
+      : `${quiz.question_count} questions`;
+
+  return (
+    <div
+      className={cn(
+        "group bg-card focus-within:ring-ring relative rounded-xl border transition-all",
+        "hover:shadow-md focus-within:ring-2",
+      )}
+    >
+      {/* Stretched link: the whole card navigates to the quiz detail,
+          but the Practice button below is a sibling (not a descendant)
+          of this Link so it can own its own navigation without
+          producing an invalid nested <a><a> tree. */}
+      <Link
+        href={destination}
+        aria-label={`Open quiz ${quiz.title}`}
+        className="absolute inset-0 z-0 rounded-xl focus:outline-none"
+      />
+      {/* Content layer is pointer-events-none so clicks anywhere on the
+          card (padding, gap, text) pass through to the overlay Link.
+          Only the Practice button re-enables pointer events so it can
+          receive its own navigation click. */}
+      <div className="pointer-events-none flex items-center gap-3 p-4">
+        <div className="relative z-10 min-w-0 flex-1">
+          <p
+            className="text-foreground line-clamp-2 text-sm font-semibold leading-snug"
+            title={quiz.title}
+          >
+            {quiz.title}
+          </p>
+          <p className="text-muted-foreground mt-1 text-xs">
+            {questionLabel}
+            <span className="mx-1.5">·</span>
+            <span>by {creatorName}</span>
+            <span className="mx-1.5">·</span>
+            <span>Updated {formatRelativeDate(quiz.updated_at)}</span>
+          </p>
+        </div>
+        <div className="pointer-events-auto relative z-10 shrink-0">
+          <Button asChild size="sm">
+            <Link href={`/practice?quiz=${quiz.id}`}>Practice</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes ASK-175.

## Summary

Tier B primitive that unblocks \`study-guides/view-page-wire-up\` (ASK-190). List item for a quiz on the study-guide view page.

- **Body:** title, pluralized question count, creator full name, relative \`updated_at\` via the existing \`formatRelativeDate\` helper.
- **Whole-card tap** opens \`/quizzes/{id}\` — override via \`href\` prop for contextual routes.
- **Inline Practice CTA** routes to \`/practice?quiz={id}\`, rendered as a sibling of the stretched overlay \`<Link>\` so we don't produce invalid \`<a><a>\` nesting and the button navigates to practice without also firing the card-level Link.
- **Click dead-zone fix** (caught in code review): the content layer is \`pointer-events-none\` so clicks on padding + gap whitespace fall through to the overlay Link; Practice wrapper re-enables pointer events. Same bug exists in the CourseCard from ASK-180 — out of scope here, will follow up with a small fix PR.

## Test plan

- [x] \`pnpm jest lib/features/dashboard/quizzes/quiz-card.test.tsx\` — 6/6 passing
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm eslint\` clean on new files
- [x] \`pnpm prettier --check\` clean on new files
- [x] Storybook stories render (Dashboard/QuizCard: Default / SingleQuestion / ManyQuestions / LongTitle / CustomHref)
- [ ] Visual verification in Storybook after deploy