### PR TITLE
fix(web): close click dead-zones on CourseCard stretched-link

### DIFF
--- a/web/lib/features/dashboard/courses/course-card.tsx
+++ b/web/lib/features/dashboard/courses/course-card.tsx
@@ -63,9 +63,13 @@ function RowVariant({
   code: string;
   rightSlot?: ReactNode;
 }) {
+  // The flex container is pointer-events-none so clicks on padding or
+  // the gap between text and slot fall through to the overlay Link
+  // (rather than dying on this empty wrapper). Only the slot wrapper
+  // re-enables pointer events so it can own its own click.
   return (
-    <div className="flex items-center gap-3 p-3">
-      <div className="pointer-events-none relative z-10 min-w-0 flex-1">
+    <div className="pointer-events-none flex items-center gap-3 p-3">
+      <div className="relative z-10 min-w-0 flex-1">
         <p className="text-foreground text-sm font-semibold">{code}</p>
         <p
           className="text-muted-foreground truncate text-xs"
@@ -75,7 +79,9 @@ function RowVariant({
         </p>
       </div>
       {rightSlot ? (
-        <div className="relative z-10 shrink-0">{rightSlot}</div>
+        <div className="pointer-events-auto relative z-10 shrink-0">
+          {rightSlot}
+        </div>
       ) : null}
     </div>
   );
@@ -90,9 +96,10 @@ function TileVariant({
   code: string;
   rightSlot?: ReactNode;
 }) {
+  // Same dead-zone fix as RowVariant -- see comment above.
   return (
-    <div className="p-4">
-      <div className="pointer-events-none relative z-10 space-y-1.5">
+    <div className="pointer-events-none p-4">
+      <div className="relative z-10 space-y-1.5">
         <h3 className="text-foreground text-base font-semibold leading-tight">
           {code}
         </h3>
@@ -104,7 +111,9 @@ function TileVariant({
         </p>
       </div>
       {rightSlot ? (
-        <div className="absolute right-3 top-3 z-10">{rightSlot}</div>
+        <div className="pointer-events-auto absolute right-3 top-3 z-10">
+          {rightSlot}
+        </div>
       ) : null}
     </div>
   );


### PR DESCRIPTION
Follow-up to ASK-180 code review (self-caught while reviewing ASK-175 QuizCard).

## Summary

The stretched-link pattern on CourseCard had dead click zones: the flex / padding wrapper around the content layer was \`pointer-events-auto\` by default, so clicks on \`p-3\`/\`p-4\` padding or the gap between the text block and \`rightSlot\` died on the wrapper instead of falling through to the overlay Link. Users clicking the card's edges got no navigation.

## Fix

Same approach as ASK-175 QuizCard:

- Wrapper: \`pointer-events-none\` so the entire content layer is transparent to clicks and they fall through to the overlay Link.
- Slot wrapper: \`pointer-events-auto\` re-enables clicks on the one element that must receive them.
- Applied to both row and tile variants.

## Test plan

- [x] Existing 7/7 CourseCard tests continue to pass (regression mode is "clicks on padding no longer navigate", which jsdom doesn't simulate — visual check in Storybook covers it).
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm prettier --check\` clean
- [ ] Visual verification in Storybook after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved click detection on course cards by fixing "dead zones" in padding and gaps. Clicks now register more reliably across the entire card surface while preserving independent interaction on specific interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->