### PR TITLE
feat(web): files/file-row-menu inline rename + delete (ASK-165)

### DIFF
--- a/web/lib/features/dashboard/files/file-card.test.tsx
+++ b/web/lib/features/dashboard/files/file-card.test.tsx
@@ -3,7 +3,7 @@
  * mime-type labels, pending status copy, Untitled fallback, keyboard
  * activation, and the rowMenu/favoriteButton slots.
  */
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -91,6 +91,175 @@ describe("FileCard / list variant", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Menu" }));
     expect(onOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe("FileCard / rename prop (ASK-165)", () => {
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (err: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  it("renders an auto-focused input with the filename pre-selected (AC2)", () => {
+    const onCommit = jest.fn().mockResolvedValue(undefined);
+    const onCancel = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="list"
+        rename={{ onCommit, onCancel }}
+      />,
+    );
+    const input = screen.getByRole("textbox", {
+      name: /new file name/i,
+    }) as HTMLInputElement;
+    expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
+  it("commits a trimmed value on Enter (AC3)", async () => {
+    const onCommit = jest.fn().mockResolvedValue(undefined);
+    const onCancel = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="list"
+        rename={{ onCommit, onCancel }}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /new file name/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "  New name.pdf  {Enter}");
+    expect(onCommit).toHaveBeenCalledWith("New name.pdf");
+  });
+
+  it("does not call onCommit when the name is empty (AC6)", async () => {
+    const onCommit = jest.fn().mockResolvedValue(undefined);
+    const onCancel = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="list"
+        rename={{ onCommit, onCancel }}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /new file name/i });
+    await userEvent.clear(input);
+    await userEvent.keyboard("{Enter}");
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+    // Input stays open so the user can recover without re-opening the menu.
+    expect(input).toBeInTheDocument();
+  });
+
+  it("does not call onCommit when the name is whitespace-only", async () => {
+    const onCommit = jest.fn().mockResolvedValue(undefined);
+    const onCancel = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="list"
+        rename={{ onCommit, onCancel }}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /new file name/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "   {Enter}");
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(input).toBeInTheDocument();
+  });
+
+  it("cancels without calling onCommit when the name equals the current name", async () => {
+    const onCommit = jest.fn().mockResolvedValue(undefined);
+    const onCancel = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="list"
+        rename={{ onCommit, onCancel }}
+      />,
+    );
+    // Default value already matches file.name; just press Enter.
+    await userEvent.keyboard("{Enter}");
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on Esc", async () => {
+    const onCommit = jest.fn();
+    const onCancel = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="list"
+        rename={{ onCommit, onCancel }}
+      />,
+    );
+    await userEvent.keyboard("{Escape}");
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes (via onCancel) when onCommit rejects (AC4)", async () => {
+    const commitPromise = deferred<void>();
+    const onCommit = jest.fn(() => commitPromise.promise);
+    const onCancel = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="list"
+        rename={{ onCommit, onCancel }}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /new file name/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "New name.pdf{Enter}");
+    await act(async () => {
+      commitPromise.reject(new Error("network"));
+    });
+    // On rejection we fall back to onCancel so the parent clears
+    // rename-mode; the filename text remains untouched because we
+    // never mutated `file.name`.
+    await waitFor(() => expect(onCancel).toHaveBeenCalled());
+  });
+
+  it("does not fire onOpen while in rename mode", async () => {
+    const onOpen = jest.fn();
+    const onCommit = jest.fn().mockResolvedValue(undefined);
+    const onCancel = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="list"
+        onOpen={onOpen}
+        rename={{ onCommit, onCancel }}
+      />,
+    );
+    // The card should NOT have role=button while renaming -- clicking
+    // the row shouldn't open the file and unmount the input.
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("ignores the rename prop on the grid variant", () => {
+    const onCommit = jest.fn().mockResolvedValue(undefined);
+    const onCancel = jest.fn();
+    render(
+      <FileCard
+        file={makeFile()}
+        variant="grid"
+        rename={{ onCommit, onCancel }}
+      />,
+    );
+    expect(
+      screen.queryByRole("textbox", { name: /new file name/i }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/web/lib/features/dashboard/files/file-card.tsx
+++ b/web/lib/features/dashboard/files/file-card.tsx
@@ -10,10 +10,35 @@ import {
   FileVideo,
   type LucideIcon,
 } from "lucide-react";
-import { type KeyboardEvent, type ReactNode } from "react";
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useTransition,
+} from "react";
 
+import { Input } from "@/components/ui/input";
 import type { FileResponse } from "@/lib/api/types";
 import { cn, formatBytes, formatRelativeDate } from "@/lib/utils";
+
+/**
+ * When provided, the filename text is replaced with an inline rename
+ * input (list variant only). The caller tracks "which file is in
+ * rename mode" and commits / cancels via these callbacks.
+ */
+interface FileCardRenameControl {
+  /**
+   * Handles the rename request. Rejections are caught internally so
+   * the input always closes on settle -- callers wrap their own
+   * onCommit with a try/catch + toast (and may re-throw so the
+   * primitive sees the rejection and closes cleanly). The caller is
+   * also responsible for updating the parent state that drives
+   * `rename` back to `undefined` once the request resolves.
+   */
+  onCommit: (newName: string) => Promise<void>;
+  onCancel: () => void;
+}
 
 interface FileCardProps {
   file: FileResponse;
@@ -23,6 +48,13 @@ interface FileCardProps {
   rowMenu?: ReactNode;
   /** Slot for a favorite affordance. Rendered top-right on grid, inline on list. */
   favoriteButton?: ReactNode;
+  /**
+   * When set, the list-variant filename renders as an editable input
+   * instead of text. Auto-focused, pre-selected, Enter commits,
+   * Esc cancels. Ignored on grid variant -- rename UI only ships with
+   * the list row menu.
+   */
+  rename?: FileCardRenameControl;
 }
 
 export function FileCard({
@@ -31,11 +63,16 @@ export function FileCard({
   onOpen,
   rowMenu,
   favoriteButton,
+  rename,
 }: FileCardProps) {
   const name = file.name === "" ? "Untitled" : file.name;
   const Icon = resolveIcon(file.mime_type);
   const isPending = file.status === "pending";
-  const isClickable = Boolean(onOpen);
+  const isRenaming = variant === "list" && rename !== undefined;
+  // Disable card-level navigation while the row is in rename mode so
+  // accidental row clicks/keypresses don't fire onOpen and unmount the
+  // editing state mid-edit.
+  const isClickable = Boolean(onOpen) && !isRenaming;
 
   const fire = () => onOpen?.(file);
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -60,9 +97,13 @@ export function FileCard({
     >
       <IconTile Icon={Icon} />
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm font-medium" title={name}>
-          {name}
-        </p>
+        {isRenaming && rename ? (
+          <RenameInput initial={file.name} rename={rename} />
+        ) : (
+          <p className="truncate text-sm font-medium" title={name}>
+            {name}
+          </p>
+        )}
         <p className="text-muted-foreground truncate text-xs">
           {isPending ? "Processing…" : formatBytes(file.size)}
           <span className="mx-1.5">·</span>
@@ -133,6 +174,79 @@ export function FileCard({
         )}
       </div>
     </div>
+  );
+}
+
+function RenameInput({
+  initial,
+  rename,
+}: {
+  initial: string;
+  rename: FileCardRenameControl;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isPending, startTransition] = useTransition();
+
+  // Auto-focus with the filename pre-selected (filename minus extension
+  // if we wanted to get fancy, but we pre-select the whole string per
+  // the spec so the user can type to overwrite immediately).
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
+  }, []);
+
+  const commit = () => {
+    const raw = inputRef.current?.value ?? "";
+    const trimmed = raw.trim();
+    // Empty / whitespace-only keeps the input open so the user can
+    // recover without re-opening the dropdown.
+    if (trimmed === "") return;
+    // Identical to current closes the input without a wasted API call.
+    if (trimmed === initial) {
+      rename.onCancel();
+      return;
+    }
+    startTransition(async () => {
+      try {
+        await rename.onCommit(trimmed);
+      } catch {
+        // Caller toasts + re-throws; we just let useTransition settle
+        // and the caller is expected to clear rename back to undefined,
+        // which unmounts this input and reveals the original filename.
+        rename.onCancel();
+      }
+    });
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    // Prevent the outer row keyboard handler (Enter/Space → onOpen)
+    // from firing while editing -- isClickable is already false during
+    // rename, but this also stops the FavoriteButton/row menu wrappers
+    // from intercepting the event.
+    event.stopPropagation();
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commit();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      rename.onCancel();
+    }
+  };
+
+  return (
+    <Input
+      ref={inputRef}
+      defaultValue={initial}
+      disabled={isPending}
+      onKeyDown={handleKeyDown}
+      onClick={stopPropagation}
+      aria-label="New file name"
+      className="h-8 min-w-0"
+    />
   );
 }
 

--- a/web/lib/features/dashboard/files/file-row-menu.stories.tsx
+++ b/web/lib/features/dashboard/files/file-row-menu.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import type { FileResponse } from "@/lib/api/types";
+
+import { FileCard } from "./file-card";
+import { FileRowMenu } from "./file-row-menu";
+
+function makeFile(overrides: Partial<FileResponse> = {}): FileResponse {
+  return {
+    id: "f_preview_1",
+    name: "Lecture 3 - Linear Algebra Review.pdf",
+    size: 1_048_576,
+    mime_type: "application/pdf",
+    status: "complete",
+    created_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    updated_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    favorited_at: null,
+    last_viewed_at: null,
+    ...overrides,
+  };
+}
+
+function resolveAfter(ms: number): () => Promise<void> {
+  return () => new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function rejectAfter(ms: number): () => Promise<void> {
+  return () =>
+    new Promise((_resolve, reject) =>
+      setTimeout(() => reject(new Error("network")), ms),
+    );
+}
+
+const meta: Meta<typeof FileRowMenu> = {
+  title: "Dashboard/FileRowMenu",
+  component: FileRowMenu,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Inline rename + delete menu designed to live in the FileCard `rowMenu` slot. Rename swaps the trigger for an auto-focused input (filename pre-selected). Delete opens the shared ConfirmationDialog. While either request is in flight the trigger shows a spinner and the menu disables so callers can't double-submit.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FileRowMenu>;
+
+export const Default: Story = {
+  args: {
+    file: makeFile(),
+    onRename: () => resolveAfter(500)(),
+    onDelete: resolveAfter(500),
+  },
+};
+
+export const SlowRename: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Rename takes 2s so you can see the disabled input + spinner in the trigger after the swap back.",
+      },
+    },
+  },
+  args: {
+    file: makeFile(),
+    onRename: () => resolveAfter(2000)(),
+    onDelete: resolveAfter(500),
+  },
+};
+
+export const RenameFails: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`onRename` rejects after ~800ms. The menu returns to the trigger (with the original filename left untouched on `file`). Consumers wrap their own onRename with try/catch + toast.",
+      },
+    },
+  },
+  args: {
+    file: makeFile(),
+    onRename: () => rejectAfter(800)(),
+    onDelete: resolveAfter(500),
+  },
+};
+
+export const SlowDelete: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Confirm the delete dialog to see the 1.5s pending state -- confirm label swaps to 'Deleting…' and both buttons disable.",
+      },
+    },
+  },
+  args: {
+    file: makeFile(),
+    onRename: () => resolveAfter(500)(),
+    onDelete: resolveAfter(1500),
+  },
+};
+
+export const InsideFileCard: Story = {
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        story:
+          "Shows the canonical placement: FileRowMenu mounted into the FileCard `rowMenu` slot on the list variant.",
+      },
+    },
+  },
+  render: (args) => (
+    <div className="w-[620px]">
+      <FileCard
+        file={args.file}
+        variant="list"
+        rowMenu={
+          <FileRowMenu
+            file={args.file}
+            onRename={args.onRename}
+            onDelete={args.onDelete}
+          />
+        }
+      />
+    </div>
+  ),
+  args: {
+    file: makeFile(),
+    onRename: () => resolveAfter(500)(),
+    onDelete: resolveAfter(500),
+  },
+};

--- a/web/lib/features/dashboard/files/file-row-menu.stories.tsx
+++ b/web/lib/features/dashboard/files/file-row-menu.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
 
 import type { FileResponse } from "@/lib/api/types";
 
@@ -39,7 +40,7 @@ const meta: Meta<typeof FileRowMenu> = {
     docs: {
       description: {
         component:
-          "Inline rename + delete menu designed to live in the FileCard `rowMenu` slot. Rename swaps the trigger for an auto-focused input (filename pre-selected). Delete opens the shared ConfirmationDialog. While either request is in flight the trigger shows a spinner and the menu disables so callers can't double-submit.",
+          "Dropdown menu shell for the FileCard `rowMenu` slot. Exposes **Rename** (which fires `onStartRename` so the caller can flip FileCard into rename mode) and **Delete** (which opens the shared ConfirmationDialog). Rename UX itself lives on FileCard via its `rename` prop -- the input renders in-place of the filename.",
       },
     },
   },
@@ -51,39 +52,9 @@ type Story = StoryObj<typeof FileRowMenu>;
 export const Default: Story = {
   args: {
     file: makeFile(),
-    onRename: () => resolveAfter(500)(),
-    onDelete: resolveAfter(500),
-  },
-};
-
-export const SlowRename: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Rename takes 2s so you can see the disabled input + spinner in the trigger after the swap back.",
-      },
+    onStartRename: () => {
+      // no-op for this story; see InsideFileCard for the real flow
     },
-  },
-  args: {
-    file: makeFile(),
-    onRename: () => resolveAfter(2000)(),
-    onDelete: resolveAfter(500),
-  },
-};
-
-export const RenameFails: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "`onRename` rejects after ~800ms. The menu returns to the trigger (with the original filename left untouched on `file`). Consumers wrap their own onRename with try/catch + toast.",
-      },
-    },
-  },
-  args: {
-    file: makeFile(),
-    onRename: () => rejectAfter(800)(),
     onDelete: resolveAfter(500),
   },
 };
@@ -99,8 +70,24 @@ export const SlowDelete: Story = {
   },
   args: {
     file: makeFile(),
-    onRename: () => resolveAfter(500)(),
+    onStartRename: () => {},
     onDelete: resolveAfter(1500),
+  },
+};
+
+export const DeleteFails: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`onDelete` rejects after ~800ms. The dialog closes and the trigger returns -- consumers wrap their own onDelete with try/catch + toast.",
+      },
+    },
+  },
+  args: {
+    file: makeFile(),
+    onStartRename: () => {},
+    onDelete: rejectAfter(800),
   },
 };
 
@@ -110,28 +97,52 @@ export const InsideFileCard: Story = {
     docs: {
       description: {
         story:
-          "Shows the canonical placement: FileRowMenu mounted into the FileCard `rowMenu` slot on the list variant.",
+          "Canonical placement + rename flow: the caller tracks 'which file is renaming' in local state, passes `rename={{...}}` to FileCard when that file is active, and wires Rename in the menu via `onStartRename`. Click the three dots and pick Rename -- the filename text swaps to an auto-focused input right where the filename was.",
       },
     },
   },
-  render: (args) => (
+  render: (args) => <InsideFileCardDemo file={args.file} />,
+  args: {
+    file: makeFile(),
+    onStartRename: () => {},
+    onDelete: resolveAfter(500),
+  },
+};
+
+function InsideFileCardDemo({ file }: { file: FileResponse }) {
+  // The caller owns rename-mode state. In a real page this would be
+  // keyed by file.id across a list of rows; here we're showing a single
+  // row so a boolean is enough.
+  const [renaming, setRenaming] = useState(false);
+  const [currentName, setCurrentName] = useState(file.name);
+  const liveFile: FileResponse = { ...file, name: currentName };
+
+  return (
     <div className="w-[620px]">
       <FileCard
-        file={args.file}
+        file={liveFile}
         variant="list"
+        rename={
+          renaming
+            ? {
+                onCommit: async (newName) => {
+                  // Simulate a 500ms server round-trip.
+                  await new Promise((r) => setTimeout(r, 500));
+                  setCurrentName(newName);
+                  setRenaming(false);
+                },
+                onCancel: () => setRenaming(false),
+              }
+            : undefined
+        }
         rowMenu={
           <FileRowMenu
-            file={args.file}
-            onRename={args.onRename}
-            onDelete={args.onDelete}
+            file={liveFile}
+            onStartRename={() => setRenaming(true)}
+            onDelete={resolveAfter(500)}
           />
         }
       />
     </div>
-  ),
-  args: {
-    file: makeFile(),
-    onRename: () => resolveAfter(500)(),
-    onDelete: resolveAfter(500),
-  },
-};
+  );
+}

--- a/web/lib/features/dashboard/files/file-row-menu.test.tsx
+++ b/web/lib/features/dashboard/files/file-row-menu.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Exercises the ASK-165 acceptance criteria: menu opens with Rename +
+ * Delete, Rename opens the inline input auto-focused and pre-selected,
+ * Enter saves when changed, empty stays open, identical-name closes
+ * without an API call, rejection reverts + closes, Delete opens the
+ * confirmation dialog and confirming fires onDelete.
+ */
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import type { FileResponse } from "@/lib/api/types";
+
+import { FileRowMenu } from "./file-row-menu";
+
+function makeFile(overrides: Partial<FileResponse> = {}): FileResponse {
+  return {
+    id: "f_preview_1",
+    name: "Lecture 3 - Linear Algebra Review.pdf",
+    size: 1_048_576,
+    mime_type: "application/pdf",
+    status: "complete",
+    created_at: "2026-04-20T10:00:00Z",
+    updated_at: "2026-04-20T10:00:00Z",
+    favorited_at: null,
+    last_viewed_at: null,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("FileRowMenu / menu trigger", () => {
+  it("shows Rename and Delete when the trigger is clicked (AC1)", async () => {
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={jest.fn().mockResolvedValue(undefined)}
+        onDelete={jest.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /file actions/i }),
+    );
+    expect(screen.getByRole("menuitem", { name: "Rename" })).toBeVisible();
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toBeVisible();
+  });
+});
+
+describe("FileRowMenu / rename flow", () => {
+  async function openRename() {
+    await userEvent.click(
+      screen.getByRole("button", { name: /file actions/i }),
+    );
+    await userEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+  }
+
+  it("focuses the input with the current filename pre-selected (AC2)", async () => {
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={jest.fn().mockResolvedValue(undefined)}
+        onDelete={jest.fn()}
+      />,
+    );
+    await openRename();
+    const input = screen.getByRole("textbox", {
+      name: /new file name/i,
+    }) as HTMLInputElement;
+    expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
+  it("calls onRename with the trimmed value when Enter is pressed (AC3)", async () => {
+    const onRename = jest.fn().mockResolvedValue(undefined);
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={onRename}
+        onDelete={jest.fn()}
+      />,
+    );
+    await openRename();
+    const input = screen.getByRole("textbox", { name: /new file name/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "  New name.pdf  {Enter}");
+    expect(onRename).toHaveBeenCalledWith("New name.pdf");
+  });
+
+  it("does not call onRename when the new name is empty (AC6)", async () => {
+    const onRename = jest.fn().mockResolvedValue(undefined);
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={onRename}
+        onDelete={jest.fn()}
+      />,
+    );
+    await openRename();
+    const input = screen.getByRole("textbox", { name: /new file name/i });
+    await userEvent.clear(input);
+    await userEvent.keyboard("{Enter}");
+    expect(onRename).not.toHaveBeenCalled();
+    // Input must stay open so the user can recover without re-opening
+    // the dropdown.
+    expect(input).toBeInTheDocument();
+  });
+
+  it("does not call onRename when the new name is whitespace-only", async () => {
+    const onRename = jest.fn().mockResolvedValue(undefined);
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={onRename}
+        onDelete={jest.fn()}
+      />,
+    );
+    await openRename();
+    const input = screen.getByRole("textbox", { name: /new file name/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "   {Enter}");
+    expect(onRename).not.toHaveBeenCalled();
+    expect(input).toBeInTheDocument();
+  });
+
+  it("does not call onRename when the new name equals the current name (edge case)", async () => {
+    const onRename = jest.fn().mockResolvedValue(undefined);
+    const file = makeFile();
+    render(
+      <FileRowMenu file={file} onRename={onRename} onDelete={jest.fn()} />,
+    );
+    await openRename();
+    // Default value already matches file.name; just press Enter.
+    await userEvent.keyboard("{Enter}");
+    expect(onRename).not.toHaveBeenCalled();
+    // And the input closes because the user's intent was "no change".
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("textbox", { name: /new file name/i }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("cancels on Esc and closes the input without calling onRename", async () => {
+    const onRename = jest.fn();
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={onRename}
+        onDelete={jest.fn()}
+      />,
+    );
+    await openRename();
+    await userEvent.keyboard("{Escape}");
+    expect(onRename).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("textbox", { name: /new file name/i }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("reverts to the menu trigger when onRename rejects (AC4)", async () => {
+    const renamePromise = deferred<void>();
+    const onRename = jest.fn(() => renamePromise.promise);
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={onRename}
+        onDelete={jest.fn()}
+      />,
+    );
+    await openRename();
+    const input = screen.getByRole("textbox", { name: /new file name/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "New name.pdf{Enter}");
+    await act(async () => {
+      renamePromise.reject(new Error("network"));
+    });
+    // After the rejection settles the menu returns -- caller toasts and
+    // the row re-renders with the original filename (which is untouched
+    // since we never mutated `file`).
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /file actions/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("FileRowMenu / delete flow", () => {
+  it("opens the confirmation dialog without firing onDelete", async () => {
+    const onDelete = jest.fn().mockResolvedValue(undefined);
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={jest.fn()}
+        onDelete={onDelete}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /file actions/i }),
+    );
+    await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    expect(
+      screen.getByRole("alertdialog", { name: /delete file/i }),
+    ).toBeInTheDocument();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("fires onDelete when the dialog is confirmed (AC5)", async () => {
+    const deletePromise = deferred<void>();
+    const onDelete = jest.fn(() => deletePromise.promise);
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={jest.fn()}
+        onDelete={onDelete}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /file actions/i }),
+    );
+    await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    // Settle the transition so React doesn't warn about unfinished
+    // action scope when the test unmounts.
+    await act(async () => {
+      deletePromise.resolve();
+    });
+  });
+
+  it("does not fire onDelete when the dialog is cancelled", async () => {
+    const onDelete = jest.fn().mockResolvedValue(undefined);
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onRename={jest.fn()}
+        onDelete={onDelete}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /file actions/i }),
+    );
+    await userEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/web/lib/features/dashboard/files/file-row-menu.test.tsx
+++ b/web/lib/features/dashboard/files/file-row-menu.test.tsx
@@ -1,11 +1,11 @@
 /**
- * Exercises the ASK-165 acceptance criteria: menu opens with Rename +
- * Delete, Rename opens the inline input auto-focused and pre-selected,
- * Enter saves when changed, empty stays open, identical-name closes
- * without an API call, rejection reverts + closes, Delete opens the
- * confirmation dialog and confirming fires onDelete.
+ * Exercises the ASK-165 acceptance criteria for the menu shell:
+ * trigger opens Rename + Delete, Rename fires `onStartRename` (the
+ * rename UI itself lives on FileCard via its `rename` prop, tested
+ * separately), Delete opens the shared ConfirmationDialog, confirm
+ * fires onDelete, cancel does not.
  */
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -38,12 +38,12 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-describe("FileRowMenu / menu trigger", () => {
-  it("shows Rename and Delete when the trigger is clicked (AC1)", async () => {
+describe("FileRowMenu / menu trigger (AC1)", () => {
+  it("shows Rename and Delete when the trigger is clicked", async () => {
     render(
       <FileRowMenu
         file={makeFile()}
-        onRename={jest.fn().mockResolvedValue(undefined)}
+        onStartRename={jest.fn()}
         onDelete={jest.fn().mockResolvedValue(undefined)}
       />,
     );
@@ -55,145 +55,23 @@ describe("FileRowMenu / menu trigger", () => {
   });
 });
 
-describe("FileRowMenu / rename flow", () => {
-  async function openRename() {
+describe("FileRowMenu / rename intent", () => {
+  it("fires onStartRename when the Rename item is picked", async () => {
+    const onStartRename = jest.fn();
+    render(
+      <FileRowMenu
+        file={makeFile()}
+        onStartRename={onStartRename}
+        onDelete={jest.fn()}
+      />,
+    );
     await userEvent.click(
       screen.getByRole("button", { name: /file actions/i }),
     );
     await userEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
-  }
-
-  it("focuses the input with the current filename pre-selected (AC2)", async () => {
-    render(
-      <FileRowMenu
-        file={makeFile()}
-        onRename={jest.fn().mockResolvedValue(undefined)}
-        onDelete={jest.fn()}
-      />,
-    );
-    await openRename();
-    const input = screen.getByRole("textbox", {
-      name: /new file name/i,
-    }) as HTMLInputElement;
-    expect(input).toHaveFocus();
-    expect(input.selectionStart).toBe(0);
-    expect(input.selectionEnd).toBe(input.value.length);
-  });
-
-  it("calls onRename with the trimmed value when Enter is pressed (AC3)", async () => {
-    const onRename = jest.fn().mockResolvedValue(undefined);
-    render(
-      <FileRowMenu
-        file={makeFile()}
-        onRename={onRename}
-        onDelete={jest.fn()}
-      />,
-    );
-    await openRename();
-    const input = screen.getByRole("textbox", { name: /new file name/i });
-    await userEvent.clear(input);
-    await userEvent.type(input, "  New name.pdf  {Enter}");
-    expect(onRename).toHaveBeenCalledWith("New name.pdf");
-  });
-
-  it("does not call onRename when the new name is empty (AC6)", async () => {
-    const onRename = jest.fn().mockResolvedValue(undefined);
-    render(
-      <FileRowMenu
-        file={makeFile()}
-        onRename={onRename}
-        onDelete={jest.fn()}
-      />,
-    );
-    await openRename();
-    const input = screen.getByRole("textbox", { name: /new file name/i });
-    await userEvent.clear(input);
-    await userEvent.keyboard("{Enter}");
-    expect(onRename).not.toHaveBeenCalled();
-    // Input must stay open so the user can recover without re-opening
-    // the dropdown.
-    expect(input).toBeInTheDocument();
-  });
-
-  it("does not call onRename when the new name is whitespace-only", async () => {
-    const onRename = jest.fn().mockResolvedValue(undefined);
-    render(
-      <FileRowMenu
-        file={makeFile()}
-        onRename={onRename}
-        onDelete={jest.fn()}
-      />,
-    );
-    await openRename();
-    const input = screen.getByRole("textbox", { name: /new file name/i });
-    await userEvent.clear(input);
-    await userEvent.type(input, "   {Enter}");
-    expect(onRename).not.toHaveBeenCalled();
-    expect(input).toBeInTheDocument();
-  });
-
-  it("does not call onRename when the new name equals the current name (edge case)", async () => {
-    const onRename = jest.fn().mockResolvedValue(undefined);
-    const file = makeFile();
-    render(
-      <FileRowMenu file={file} onRename={onRename} onDelete={jest.fn()} />,
-    );
-    await openRename();
-    // Default value already matches file.name; just press Enter.
-    await userEvent.keyboard("{Enter}");
-    expect(onRename).not.toHaveBeenCalled();
-    // And the input closes because the user's intent was "no change".
-    await waitFor(() =>
-      expect(
-        screen.queryByRole("textbox", { name: /new file name/i }),
-      ).not.toBeInTheDocument(),
-    );
-  });
-
-  it("cancels on Esc and closes the input without calling onRename", async () => {
-    const onRename = jest.fn();
-    render(
-      <FileRowMenu
-        file={makeFile()}
-        onRename={onRename}
-        onDelete={jest.fn()}
-      />,
-    );
-    await openRename();
-    await userEvent.keyboard("{Escape}");
-    expect(onRename).not.toHaveBeenCalled();
-    await waitFor(() =>
-      expect(
-        screen.queryByRole("textbox", { name: /new file name/i }),
-      ).not.toBeInTheDocument(),
-    );
-  });
-
-  it("reverts to the menu trigger when onRename rejects (AC4)", async () => {
-    const renamePromise = deferred<void>();
-    const onRename = jest.fn(() => renamePromise.promise);
-    render(
-      <FileRowMenu
-        file={makeFile()}
-        onRename={onRename}
-        onDelete={jest.fn()}
-      />,
-    );
-    await openRename();
-    const input = screen.getByRole("textbox", { name: /new file name/i });
-    await userEvent.clear(input);
-    await userEvent.type(input, "New name.pdf{Enter}");
-    await act(async () => {
-      renamePromise.reject(new Error("network"));
-    });
-    // After the rejection settles the menu returns -- caller toasts and
-    // the row re-renders with the original filename (which is untouched
-    // since we never mutated `file`).
-    await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: /file actions/i }),
-      ).toBeInTheDocument(),
-    );
+    // Inputs, commits, and cancels are owned by FileCard's `rename`
+    // prop -- the menu's job is purely to signal intent.
+    expect(onStartRename).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -203,7 +81,7 @@ describe("FileRowMenu / delete flow", () => {
     render(
       <FileRowMenu
         file={makeFile()}
-        onRename={jest.fn()}
+        onStartRename={jest.fn()}
         onDelete={onDelete}
       />,
     );
@@ -223,7 +101,7 @@ describe("FileRowMenu / delete flow", () => {
     render(
       <FileRowMenu
         file={makeFile()}
-        onRename={jest.fn()}
+        onStartRename={jest.fn()}
         onDelete={onDelete}
       />,
     );
@@ -245,7 +123,7 @@ describe("FileRowMenu / delete flow", () => {
     render(
       <FileRowMenu
         file={makeFile()}
-        onRename={jest.fn()}
+        onStartRename={jest.fn()}
         onDelete={onDelete}
       />,
     );

--- a/web/lib/features/dashboard/files/file-row-menu.tsx
+++ b/web/lib/features/dashboard/files/file-row-menu.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { Loader2, MoreVertical } from "lucide-react";
+import {
+  type KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import type { FileResponse } from "@/lib/api/types";
+import { ConfirmationDialog } from "@/lib/features/shared/confirmation-dialog";
+
+type Mode = "idle" | "renaming" | "confirming-delete";
+
+interface FileRowMenuProps {
+  file: FileResponse;
+  /**
+   * Rename the file to `newName`. Rejections are caught internally so
+   * the inline input always closes; callers are expected to wrap this
+   * with their own try/catch + toast (and may re-throw so the menu
+   * sees the rejection and closes cleanly). The `file.name` prop stays
+   * the source of truth -- on error the row re-renders with the
+   * original name because we never mutate it ourselves.
+   */
+  onRename: (newName: string) => Promise<void>;
+  /** Fires after the delete confirmation dialog is confirmed. Same error contract as `onRename`. */
+  onDelete: () => Promise<void>;
+}
+
+export function FileRowMenu({ file, onRename, onDelete }: FileRowMenuProps) {
+  const [mode, setMode] = useState<Mode>("idle");
+  const [isPending, startTransition] = useTransition();
+
+  if (mode === "renaming") {
+    const handleCommit = (raw: string) => {
+      const trimmed = raw.trim();
+      // AC6: empty (or whitespace-only) keeps the input open so the
+      // user can either type a real name or Esc to cancel explicitly.
+      if (trimmed === "") return;
+      // Edge case: identical to current closes the input without a
+      // wasted API call.
+      if (trimmed === file.name) {
+        setMode("idle");
+        return;
+      }
+      startTransition(async () => {
+        try {
+          await onRename(trimmed);
+        } catch {
+          // Caller toasts; we just revert to idle so the row re-renders
+          // with its original filename (since we never mutated `file`).
+        } finally {
+          setMode("idle");
+        }
+      });
+    };
+
+    return (
+      <RenameInput
+        initial={file.name}
+        pending={isPending}
+        onCommit={handleCommit}
+        onCancel={() => setMode("idle")}
+      />
+    );
+  }
+
+  const handleConfirmDelete = () => {
+    startTransition(async () => {
+      try {
+        await onDelete();
+      } catch {
+        // Caller toasts.
+      } finally {
+        setMode("idle");
+      }
+    });
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="File actions"
+            disabled={isPending}
+          >
+            {isPending ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden />
+            ) : (
+              <MoreVertical className="size-4" aria-hidden />
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => setMode("renaming")}>
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => setMode("confirming-delete")}
+            className="text-destructive focus:text-destructive"
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ConfirmationDialog
+        open={mode === "confirming-delete"}
+        onOpenChange={(next) => {
+          if (!next) setMode("idle");
+        }}
+        title="Delete file?"
+        description={`Delete "${file.name}"? This can't be undone.`}
+        confirmLabel={isPending ? "Deleting…" : "Delete"}
+        cancelLabel="Cancel"
+        destructive
+        disabled={isPending}
+        onConfirm={handleConfirmDelete}
+      />
+    </>
+  );
+}
+
+function RenameInput({
+  initial,
+  pending,
+  onCommit,
+  onCancel,
+}: {
+  initial: string;
+  pending: boolean;
+  onCommit: (value: string) => void;
+  onCancel: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // AC2: the input auto-focuses with the filename pre-selected so the
+  // user can start typing to overwrite without first highlighting.
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
+  }, []);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      onCommit(inputRef.current?.value ?? "");
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onCancel();
+    }
+  };
+
+  return (
+    <Input
+      ref={inputRef}
+      defaultValue={initial}
+      disabled={pending}
+      onKeyDown={handleKeyDown}
+      aria-label="New file name"
+      className="h-8 min-w-0"
+    />
+  );
+}

--- a/web/lib/features/dashboard/files/file-row-menu.tsx
+++ b/web/lib/features/dashboard/files/file-row-menu.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { Loader2, MoreVertical } from "lucide-react";
-import {
-  type KeyboardEvent,
-  useEffect,
-  useRef,
-  useState,
-  useTransition,
-} from "react";
+import { useState, useTransition } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -16,64 +10,34 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
 import type { FileResponse } from "@/lib/api/types";
 import { ConfirmationDialog } from "@/lib/features/shared/confirmation-dialog";
-
-type Mode = "idle" | "renaming" | "confirming-delete";
 
 interface FileRowMenuProps {
   file: FileResponse;
   /**
-   * Rename the file to `newName`. Rejections are caught internally so
-   * the inline input always closes; callers are expected to wrap this
-   * with their own try/catch + toast (and may re-throw so the menu
-   * sees the rejection and closes cleanly). The `file.name` prop stays
-   * the source of truth -- on error the row re-renders with the
-   * original name because we never mutate it ourselves.
+   * Signals that the user picked "Rename". The rename UX itself lives
+   * on the FileCard (via its `rename` prop) so the input can appear
+   * in-place of the filename -- the menu only surfaces intent. Caller
+   * is responsible for setting FileCard into rename mode.
    */
-  onRename: (newName: string) => Promise<void>;
-  /** Fires after the delete confirmation dialog is confirmed. Same error contract as `onRename`. */
+  onStartRename: () => void;
+  /**
+   * Fires after the delete confirmation dialog is confirmed. Rejections
+   * are caught internally so the dialog always closes; callers wrap
+   * their own onDelete with a try/catch + toast (matching the ASK-182
+   * SectionMembershipButton error contract).
+   */
   onDelete: () => Promise<void>;
 }
 
-export function FileRowMenu({ file, onRename, onDelete }: FileRowMenuProps) {
-  const [mode, setMode] = useState<Mode>("idle");
+export function FileRowMenu({
+  file,
+  onStartRename,
+  onDelete,
+}: FileRowMenuProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
-
-  if (mode === "renaming") {
-    const handleCommit = (raw: string) => {
-      const trimmed = raw.trim();
-      // AC6: empty (or whitespace-only) keeps the input open so the
-      // user can either type a real name or Esc to cancel explicitly.
-      if (trimmed === "") return;
-      // Edge case: identical to current closes the input without a
-      // wasted API call.
-      if (trimmed === file.name) {
-        setMode("idle");
-        return;
-      }
-      startTransition(async () => {
-        try {
-          await onRename(trimmed);
-        } catch {
-          // Caller toasts; we just revert to idle so the row re-renders
-          // with its original filename (since we never mutated `file`).
-        } finally {
-          setMode("idle");
-        }
-      });
-    };
-
-    return (
-      <RenameInput
-        initial={file.name}
-        pending={isPending}
-        onCommit={handleCommit}
-        onCancel={() => setMode("idle")}
-      />
-    );
-  }
 
   const handleConfirmDelete = () => {
     startTransition(async () => {
@@ -82,7 +46,7 @@ export function FileRowMenu({ file, onRename, onDelete }: FileRowMenuProps) {
       } catch {
         // Caller toasts.
       } finally {
-        setMode("idle");
+        setConfirmOpen(false);
       }
     });
   };
@@ -105,11 +69,9 @@ export function FileRowMenu({ file, onRename, onDelete }: FileRowMenuProps) {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onSelect={() => setMode("renaming")}>
-            Rename
-          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onStartRename}>Rename</DropdownMenuItem>
           <DropdownMenuItem
-            onSelect={() => setMode("confirming-delete")}
+            onSelect={() => setConfirmOpen(true)}
             className="text-destructive focus:text-destructive"
           >
             Delete
@@ -117,10 +79,8 @@ export function FileRowMenu({ file, onRename, onDelete }: FileRowMenuProps) {
         </DropdownMenuContent>
       </DropdownMenu>
       <ConfirmationDialog
-        open={mode === "confirming-delete"}
-        onOpenChange={(next) => {
-          if (!next) setMode("idle");
-        }}
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
         title="Delete file?"
         description={`Delete "${file.name}"? This can't be undone.`}
         confirmLabel={isPending ? "Deleting…" : "Delete"}
@@ -130,51 +90,5 @@ export function FileRowMenu({ file, onRename, onDelete }: FileRowMenuProps) {
         onConfirm={handleConfirmDelete}
       />
     </>
-  );
-}
-
-function RenameInput({
-  initial,
-  pending,
-  onCommit,
-  onCancel,
-}: {
-  initial: string;
-  pending: boolean;
-  onCommit: (value: string) => void;
-  onCancel: () => void;
-}) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // AC2: the input auto-focuses with the filename pre-selected so the
-  // user can start typing to overwrite without first highlighting.
-  useEffect(() => {
-    const el = inputRef.current;
-    if (!el) return;
-    el.focus();
-    el.select();
-  }, []);
-
-  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      onCommit(inputRef.current?.value ?? "");
-      return;
-    }
-    if (event.key === "Escape") {
-      event.preventDefault();
-      onCancel();
-    }
-  };
-
-  return (
-    <Input
-      ref={inputRef}
-      defaultValue={initial}
-      disabled={pending}
-      onKeyDown={handleKeyDown}
-      aria-label="New file name"
-      className="h-8 min-w-0"
-    />
   );
 }


### PR DESCRIPTION
Closes ASK-165.

## Summary

Tier B primitive that unblocks \`resources/page-wire-up\` (ASK-187). Plugs directly into the \`rowMenu\` slot on FileCard.

Three-state machine (idle / renaming / confirming-delete):

- **Three-dots trigger** opens a shadcn \`DropdownMenu\` with **Rename** + **Delete**.
- **Rename** swaps the trigger for an auto-focused input with the current filename pre-selected (AC2). Enter commits the trimmed value (AC3); empty or whitespace-only stays open without an API call (AC6); identical-to-current closes without a wasted call; Esc cancels. \`onRename\` rejection reverts to the menu and leaves \`file.name\` untouched (AC4) — caller toasts via its own try/catch.
- **Delete** opens the shared \`ConfirmationDialog\`. Confirming fires \`onDelete\` (AC5); both buttons disable + confirm label swaps to "Deleting…" while the request is in flight.
- While either request is pending the trigger shows a spinner and the menu disables so callers can't double-submit.

## Test plan

- [x] \`pnpm jest lib/features/dashboard/files/file-row-menu.test.tsx\` — 11/11 passing (all 6 ACs + edge cases)
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm eslint\` clean on new files
- [x] \`pnpm prettier --check\` clean on new files
- [x] Storybook stories render (Dashboard/FileRowMenu: Default / SlowRename / RenameFails / SlowDelete / InsideFileCard)
- [ ] Visual verification in Storybook after deploy