### PR TITLE
feat(web): study-guides/study-guide-form shared create + edit (ASK-170)

### DIFF
--- a/web/lib/features/dashboard/study-guides/study-guide-form.stories.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import type { StudyGuideDetailResponse } from "@/lib/api/types";
+
+import { StudyGuideForm } from "./study-guide-form";
+
+function makeStudyGuide(
+  overrides: Partial<StudyGuideDetailResponse> = {},
+): StudyGuideDetailResponse {
+  return {
+    id: "g_preview_1",
+    title: "CPTS 322 Midterm Review",
+    description: null,
+    content:
+      "# Overview\n\nThis guide covers mutexes, semaphores, and monitors in the context of the CPTS 322 midterm.\n\n## Mutex vs Semaphore\n\nA mutex is owned by a single thread; a semaphore counts permits.",
+    tags: ["midterm", "concurrency", "systems-programming"],
+    creator: { id: "u_preview_1", first_name: "Ada", last_name: "Lovelace" },
+    course: {
+      id: "c_preview_1",
+      department: "CPTS",
+      number: "322",
+      title: "Systems Programming",
+    },
+    vote_score: 0,
+    user_vote: null,
+    view_count: 0,
+    is_recommended: false,
+    recommended_by: [],
+    quizzes: [],
+    resources: [],
+    files: [],
+    created_at: new Date(Date.now() - 7 * 86_400_000).toISOString(),
+    updated_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    ...overrides,
+  } as StudyGuideDetailResponse;
+}
+
+function resolveAfter(ms: number): () => Promise<void> {
+  return () => new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const meta: Meta<typeof StudyGuideForm> = {
+  title: "Dashboard/StudyGuideForm",
+  component: StudyGuideForm,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Shared create + edit form backed by react-hook-form + Zod + shadcn Form primitives. Save is reactively disabled until title (≥3) and content (≥10) pass validation. Caller handles success redirect + error toast; server-side validation errors are surfaced by projecting ApiError details onto fields via the exposed `setError` ref.",
+      },
+    },
+  },
+  argTypes: {
+    mode: {
+      control: { type: "radio" },
+      options: ["create", "edit"],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof StudyGuideForm>;
+
+export const CreateEmpty: Story = {
+  args: {
+    mode: "create",
+    onSubmit: resolveAfter(500),
+    onCancel: () => {},
+  },
+};
+
+export const EditPrefilled: Story = {
+  args: {
+    mode: "edit",
+    initial: makeStudyGuide(),
+    onSubmit: resolveAfter(500),
+    onCancel: () => {},
+  },
+};
+
+export const SlowSubmit: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Simulates a 2s round-trip so you can see the button label swap to 'Creating…' and Cancel disable.",
+      },
+    },
+  },
+  args: {
+    mode: "create",
+    onSubmit: resolveAfter(2000),
+    onCancel: () => {},
+  },
+};
+
+export const EditEmptyTags: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Edit mode when the guide has no tags -- verifies the tags input pre-fills with an empty string.",
+      },
+    },
+  },
+  args: {
+    mode: "edit",
+    initial: makeStudyGuide({ tags: [] }),
+    onSubmit: resolveAfter(500),
+    onCancel: () => {},
+  },
+};

--- a/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Exercises the ASK-170 acceptance criteria: create-mode submit
+ * with valid fields shapes the body correctly (AC1); edit-mode
+ * pre-fills from `initial` (AC2); title/content below min-length
+ * disables Save + shows inline error (AC3, AC4); Cancel callback
+ * fires; tags are comma-split/trimmed on submit; and the imperative
+ * `setError` hook surfaces server-side validation errors for AC5.
+ */
+import { createRef } from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import type { StudyGuideDetailResponse } from "@/lib/api/types";
+
+import { StudyGuideForm, type StudyGuideFormHandle } from "./study-guide-form";
+
+function makeStudyGuide(
+  overrides: Partial<StudyGuideDetailResponse> = {},
+): StudyGuideDetailResponse {
+  return {
+    id: "g_preview_1",
+    title: "CPTS 322 Midterm Review",
+    description: null,
+    content: "# Chapter 1\n\nSystems programming is...",
+    tags: ["midterm", "systems-programming"],
+    creator: { id: "u_preview_1", first_name: "Ada", last_name: "Lovelace" },
+    course: {
+      id: "c_preview_1",
+      department: "CPTS",
+      number: "322",
+      title: "Systems Programming",
+    },
+    vote_score: 0,
+    user_vote: null,
+    view_count: 0,
+    is_recommended: false,
+    recommended_by: [],
+    quizzes: [],
+    resources: [],
+    files: [],
+    created_at: "2026-04-20T10:00:00Z",
+    updated_at: "2026-04-20T10:00:00Z",
+    ...overrides,
+  } as StudyGuideDetailResponse;
+}
+
+describe("StudyGuideForm / create mode", () => {
+  it("submits the shaped body when valid fields are filled (AC1)", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    render(
+      <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
+    );
+    await userEvent.type(screen.getByLabelText(/title/i), "Concurrency notes");
+    await userEvent.type(
+      screen.getByLabelText(/content/i),
+      "# Overview\n\nMutexes, semaphores, and monitors.",
+    );
+    await userEvent.type(
+      screen.getByLabelText(/tags/i),
+      "concurrency, threads, systems",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: "Concurrency notes",
+      content: "# Overview\n\nMutexes, semaphores, and monitors.",
+      tags: ["concurrency", "threads", "systems"],
+    });
+  });
+
+  it("trims whitespace around comma-separated tags", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    render(
+      <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
+    );
+    await userEvent.type(screen.getByLabelText(/title/i), "Title here");
+    await userEvent.type(
+      screen.getByLabelText(/content/i),
+      "Body long enough to pass validation threshold.",
+    );
+    await userEvent.type(
+      screen.getByLabelText(/tags/i),
+      "  midterm ,  concurrency  ,,  systems  ",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: ["midterm", "concurrency", "systems"],
+        }),
+      ),
+    );
+  });
+
+  it("disables Save and shows inline error while title is below 3 chars (AC3)", async () => {
+    render(
+      <StudyGuideForm
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await userEvent.type(screen.getByLabelText(/title/i), "Hi");
+    await userEvent.type(
+      screen.getByLabelText(/content/i),
+      "Body long enough to satisfy the min-length requirement.",
+    );
+    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
+    await waitFor(() =>
+      expect(
+        screen.getByText("Title must be at least 3 characters"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("disables Save and shows inline error while content is below 10 chars (AC4)", async () => {
+    render(
+      <StudyGuideForm
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await userEvent.type(screen.getByLabelText(/title/i), "Valid title");
+    await userEvent.type(screen.getByLabelText(/content/i), "short");
+    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
+    await waitFor(() =>
+      expect(
+        screen.getByText("Content must be at least 10 characters"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("fires onCancel when Cancel is clicked", async () => {
+    const onCancel = jest.fn();
+    render(
+      <StudyGuideForm mode="create" onSubmit={jest.fn()} onCancel={onCancel} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("StudyGuideForm / edit mode", () => {
+  it("pre-fills the form from `initial` (AC2)", () => {
+    const initial = makeStudyGuide();
+    render(
+      <StudyGuideForm
+        mode="edit"
+        initial={initial}
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    expect(screen.getByLabelText(/title/i)).toHaveValue(
+      "CPTS 322 Midterm Review",
+    );
+    expect(screen.getByLabelText(/content/i)).toHaveValue(
+      "# Chapter 1\n\nSystems programming is...",
+    );
+    expect(screen.getByLabelText(/tags/i)).toHaveValue(
+      "midterm, systems-programming",
+    );
+  });
+
+  it("labels the submit button 'Save' in edit mode", () => {
+    render(
+      <StudyGuideForm
+        mode="edit"
+        initial={makeStudyGuide()}
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument();
+  });
+
+  it("round-trips pre-filled tags back through submit unchanged", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    render(
+      <StudyGuideForm
+        mode="edit"
+        initial={makeStudyGuide()}
+        onSubmit={onSubmit}
+        onCancel={jest.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: ["midterm", "systems-programming"],
+        }),
+      ),
+    );
+  });
+});
+
+describe("StudyGuideForm / server error surface (AC5)", () => {
+  it("exposes a ref.setError that shows a field-level message", async () => {
+    const ref = createRef<StudyGuideFormHandle>();
+    render(
+      <StudyGuideForm
+        ref={ref}
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    // Simulates a caller projecting ApiError.body.details onto fields:
+    //   for (const d of err.body.details) ref.setError(d.field, d.message);
+    await act(async () => {
+      ref.current?.setError("title", "Title already taken");
+    });
+    await waitFor(() =>
+      expect(screen.getByText("Title already taken")).toBeInTheDocument(),
+    );
+  });
+});

--- a/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
@@ -3,11 +3,12 @@
  * with valid fields shapes the body correctly (AC1); edit-mode
  * pre-fills from `initial` (AC2); title/content below min-length
  * disables Save + shows inline error (AC3, AC4); Cancel callback
- * fires; tags are comma-split/trimmed on submit; and the imperative
- * `setError` hook surfaces server-side validation errors for AC5.
+ * fires; the imperative `setError` hook surfaces server-side
+ * validation errors for AC5. Also covers the tag-chip interactions
+ * (Enter commits, dedupe, Backspace pops last chip, X removes).
  */
 import { createRef } from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -45,22 +46,27 @@ function makeStudyGuide(
   } as StudyGuideDetailResponse;
 }
 
+async function typeTag(user: ReturnType<typeof userEvent.setup>, tag: string) {
+  const input = screen.getByRole("textbox", { name: /add a tag/i });
+  await user.type(input, `${tag}{Enter}`);
+}
+
 describe("StudyGuideForm / create mode", () => {
   it("submits the shaped body when valid fields are filled (AC1)", async () => {
+    const user = userEvent.setup();
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     render(
       <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
     );
-    await userEvent.type(screen.getByLabelText(/title/i), "Concurrency notes");
-    await userEvent.type(
+    await user.type(screen.getByLabelText(/title/i), "Concurrency notes");
+    await user.type(
       screen.getByLabelText(/content/i),
       "# Overview\n\nMutexes, semaphores, and monitors.",
     );
-    await userEvent.type(
-      screen.getByLabelText(/tags/i),
-      "concurrency, threads, systems",
-    );
-    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+    await typeTag(user, "concurrency");
+    await typeTag(user, "threads");
+    await typeTag(user, "systems");
+    await user.click(screen.getByRole("button", { name: /create/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith({
       title: "Concurrency notes",
@@ -69,31 +75,8 @@ describe("StudyGuideForm / create mode", () => {
     });
   });
 
-  it("trims whitespace around comma-separated tags", async () => {
-    const onSubmit = jest.fn().mockResolvedValue(undefined);
-    render(
-      <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
-    );
-    await userEvent.type(screen.getByLabelText(/title/i), "Title here");
-    await userEvent.type(
-      screen.getByLabelText(/content/i),
-      "Body long enough to pass validation threshold.",
-    );
-    await userEvent.type(
-      screen.getByLabelText(/tags/i),
-      "  midterm ,  concurrency  ,,  systems  ",
-    );
-    await userEvent.click(screen.getByRole("button", { name: /create/i }));
-    await waitFor(() =>
-      expect(onSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tags: ["midterm", "concurrency", "systems"],
-        }),
-      ),
-    );
-  });
-
   it("disables Save and shows inline error while title is below 3 chars (AC3)", async () => {
+    const user = userEvent.setup();
     render(
       <StudyGuideForm
         mode="create"
@@ -101,8 +84,8 @@ describe("StudyGuideForm / create mode", () => {
         onCancel={jest.fn()}
       />,
     );
-    await userEvent.type(screen.getByLabelText(/title/i), "Hi");
-    await userEvent.type(
+    await user.type(screen.getByLabelText(/title/i), "Hi");
+    await user.type(
       screen.getByLabelText(/content/i),
       "Body long enough to satisfy the min-length requirement.",
     );
@@ -115,6 +98,7 @@ describe("StudyGuideForm / create mode", () => {
   });
 
   it("disables Save and shows inline error while content is below 10 chars (AC4)", async () => {
+    const user = userEvent.setup();
     render(
       <StudyGuideForm
         mode="create"
@@ -122,8 +106,8 @@ describe("StudyGuideForm / create mode", () => {
         onCancel={jest.fn()}
       />,
     );
-    await userEvent.type(screen.getByLabelText(/title/i), "Valid title");
-    await userEvent.type(screen.getByLabelText(/content/i), "short");
+    await user.type(screen.getByLabelText(/title/i), "Valid title");
+    await user.type(screen.getByLabelText(/content/i), "short");
     expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
     await waitFor(() =>
       expect(
@@ -133,12 +117,114 @@ describe("StudyGuideForm / create mode", () => {
   });
 
   it("fires onCancel when Cancel is clicked", async () => {
+    const user = userEvent.setup();
     const onCancel = jest.fn();
     render(
       <StudyGuideForm mode="create" onSubmit={jest.fn()} onCancel={onCancel} />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("StudyGuideForm / tag chips", () => {
+  it("adds a chip when the user types and presses Enter", async () => {
+    const user = userEvent.setup();
+    render(
+      <StudyGuideForm
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await typeTag(user, "midterm");
+    const group = screen.getByRole("group", { name: /tags/i });
+    expect(within(group).getByText("midterm")).toBeInTheDocument();
+  });
+
+  it("normalizes to lowercase + trims whitespace", async () => {
+    const user = userEvent.setup();
+    render(
+      <StudyGuideForm
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await typeTag(user, "  MidTERM  ");
+    const group = screen.getByRole("group", { name: /tags/i });
+    expect(within(group).getByText("midterm")).toBeInTheDocument();
+    expect(within(group).queryByText("MidTERM")).not.toBeInTheDocument();
+  });
+
+  it("dedupes: re-adding an existing tag is a no-op and clears the input", async () => {
+    const user = userEvent.setup();
+    render(
+      <StudyGuideForm
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await typeTag(user, "midterm");
+    await typeTag(user, "midterm");
+    const group = screen.getByRole("group", { name: /tags/i });
+    // Only one chip; the duplicate Enter just clears the input.
+    expect(within(group).getAllByText("midterm")).toHaveLength(1);
+    const input = screen.getByRole("textbox", { name: /add a tag/i });
+    expect(input).toHaveValue("");
+  });
+
+  it("removes a chip when its X is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <StudyGuideForm
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await typeTag(user, "midterm");
+    await typeTag(user, "concurrency");
+    await user.click(screen.getByRole("button", { name: /remove midterm/i }));
+    const group = screen.getByRole("group", { name: /tags/i });
+    expect(within(group).queryByText("midterm")).not.toBeInTheDocument();
+    expect(within(group).getByText("concurrency")).toBeInTheDocument();
+  });
+
+  it("pops the last chip on Backspace when the draft input is empty", async () => {
+    const user = userEvent.setup();
+    render(
+      <StudyGuideForm
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await typeTag(user, "midterm");
+    await typeTag(user, "concurrency");
+    const input = screen.getByRole("textbox", { name: /add a tag/i });
+    input.focus();
+    await user.keyboard("{Backspace}");
+    const group = screen.getByRole("group", { name: /tags/i });
+    expect(within(group).queryByText("concurrency")).not.toBeInTheDocument();
+    expect(within(group).getByText("midterm")).toBeInTheDocument();
+  });
+
+  it("ignores empty / whitespace-only submits", async () => {
+    const user = userEvent.setup();
+    render(
+      <StudyGuideForm
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /add a tag/i });
+    await user.type(input, "   {Enter}");
+    const group = screen.getByRole("group", { name: /tags/i });
+    // No chip was added.
+    expect(within(group).queryAllByRole("button")).toHaveLength(0);
   });
 });
 
@@ -159,9 +245,9 @@ describe("StudyGuideForm / edit mode", () => {
     expect(screen.getByLabelText(/content/i)).toHaveValue(
       "# Chapter 1\n\nSystems programming is...",
     );
-    expect(screen.getByLabelText(/tags/i)).toHaveValue(
-      "midterm, systems-programming",
-    );
+    const group = screen.getByRole("group", { name: /tags/i });
+    expect(within(group).getByText("midterm")).toBeInTheDocument();
+    expect(within(group).getByText("systems-programming")).toBeInTheDocument();
   });
 
   it("labels the submit button 'Save' in edit mode", () => {
@@ -177,6 +263,7 @@ describe("StudyGuideForm / edit mode", () => {
   });
 
   it("round-trips pre-filled tags back through submit unchanged", async () => {
+    const user = userEvent.setup();
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     render(
       <StudyGuideForm
@@ -186,7 +273,7 @@ describe("StudyGuideForm / edit mode", () => {
         onCancel={jest.fn()}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { forwardRef, type ForwardedRef, useImperativeHandle } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type {
+  CreateStudyGuideRequest,
+  StudyGuideDetailResponse,
+  UpdateStudyGuideRequest,
+} from "@/lib/api/types";
+
+// Inline error copy lives on the schema so AC3/AC4 messages match
+// the ticket verbatim ("Title must be at least 3 characters" /
+// "Content must be at least 10 characters").
+const schema = z.object({
+  title: z.string().min(3, "Title must be at least 3 characters"),
+  content: z.string().min(10, "Content must be at least 10 characters"),
+  // Raw comma-separated user input; normalized to string[] on submit.
+  tagsText: z.string(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export type StudyGuideFormField = keyof FormValues;
+
+/**
+ * Imperative handle for AC5: callers that catch an ApiError with
+ * `status: "validation_error"` project its `details` onto field-level
+ * messages via `setError`. The form doesn't know about ApiError --
+ * the caller translates and calls this.
+ */
+export interface StudyGuideFormHandle {
+  setError: (field: StudyGuideFormField, message: string) => void;
+}
+
+interface StudyGuideFormProps {
+  mode: "create" | "edit";
+  /** Required when `mode === "edit"` -- provides defaults for the fields. */
+  initial?: StudyGuideDetailResponse;
+  /**
+   * Fires with the shaped API body. Caller handles success redirect +
+   * error toast; rejections propagate so the form's `isSubmitting`
+   * flag clears even on failure (see react-hook-form `handleSubmit`).
+   */
+  onSubmit: (
+    body: CreateStudyGuideRequest | UpdateStudyGuideRequest,
+  ) => Promise<void>;
+  onCancel: () => void;
+}
+
+export const StudyGuideForm = forwardRef<
+  StudyGuideFormHandle,
+  StudyGuideFormProps
+>(function StudyGuideForm(
+  { mode, initial, onSubmit, onCancel },
+  ref: ForwardedRef<StudyGuideFormHandle>,
+) {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    // onChange so the Save button can disable/enable reactively as the
+    // user types -- matches "Submit button disabled until required
+    // fields meet min length" (AC3/AC4).
+    mode: "onChange",
+    defaultValues: {
+      title: initial?.title ?? "",
+      content: initial?.content ?? "",
+      tagsText: (initial?.tags ?? []).join(", "),
+    },
+  });
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      setError: (field, message) => form.setError(field, { message }),
+    }),
+    [form],
+  );
+
+  const { isSubmitting, isValid } = form.formState;
+
+  const handleSubmit = async (values: FormValues) => {
+    const tags = values.tagsText
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+    await onSubmit({
+      title: values.title,
+      content: values.content,
+      tags,
+    });
+  };
+
+  const submitLabel = isSubmitting
+    ? mode === "create"
+      ? "Creating…"
+      : "Saving…"
+    : mode === "create"
+      ? "Create"
+      : "Save";
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Title</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="e.g. CPTS 322 Midterm Review"
+                  autoComplete="off"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="content"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Content</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Write your study guide in markdown…"
+                  rows={14}
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Markdown is supported. Rich-text editing lands later.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="tagsText"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Tags</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="midterm, concurrency, systems-programming"
+                  autoComplete="off"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Comma-separated. Used for search and recommendations.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={!isValid || isSubmitting}>
+            {submitLabel}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+});

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -1,10 +1,19 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { forwardRef, type ForwardedRef, useImperativeHandle } from "react";
+import { X } from "lucide-react";
+import {
+  forwardRef,
+  type ForwardedRef,
+  type KeyboardEvent,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -22,6 +31,7 @@ import type {
   StudyGuideDetailResponse,
   UpdateStudyGuideRequest,
 } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
 
 // Inline error copy lives on the schema so AC3/AC4 messages match
 // the ticket verbatim ("Title must be at least 3 characters" /
@@ -29,8 +39,7 @@ import type {
 const schema = z.object({
   title: z.string().min(3, "Title must be at least 3 characters"),
   content: z.string().min(10, "Content must be at least 10 characters"),
-  // Raw comma-separated user input; normalized to string[] on submit.
-  tagsText: z.string(),
+  tags: z.array(z.string()),
 });
 
 type FormValues = z.infer<typeof schema>;
@@ -78,7 +87,7 @@ export const StudyGuideForm = forwardRef<
     defaultValues: {
       title: initial?.title ?? "",
       content: initial?.content ?? "",
-      tagsText: (initial?.tags ?? []).join(", "),
+      tags: initial?.tags ?? [],
     },
   });
 
@@ -93,14 +102,10 @@ export const StudyGuideForm = forwardRef<
   const { isSubmitting, isValid } = form.formState;
 
   const handleSubmit = async (values: FormValues) => {
-    const tags = values.tagsText
-      .split(",")
-      .map((tag) => tag.trim())
-      .filter((tag) => tag.length > 0);
     await onSubmit({
       title: values.title,
       content: values.content,
-      tags,
+      tags: values.tags,
     });
   };
 
@@ -146,7 +151,8 @@ export const StudyGuideForm = forwardRef<
                 />
               </FormControl>
               <FormDescription>
-                Markdown is supported. Rich-text editing lands later.
+                Markdown supported. Rich editor + preview land with the
+                study-guide article renderer.
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -154,19 +160,20 @@ export const StudyGuideForm = forwardRef<
         />
         <FormField
           control={form.control}
-          name="tagsText"
+          name="tags"
           render={({ field }) => (
             <FormItem>
               <FormLabel>Tags</FormLabel>
               <FormControl>
-                <Input
-                  placeholder="midterm, concurrency, systems-programming"
-                  autoComplete="off"
-                  {...field}
+                <TagChipsInput
+                  value={field.value}
+                  onChange={field.onChange}
+                  disabled={isSubmitting}
                 />
               </FormControl>
               <FormDescription>
-                Comma-separated. Used for search and recommendations.
+                Type a tag and press Enter to add. Backspace on an empty input
+                removes the last tag. Used for search and recommendations.
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -189,3 +196,109 @@ export const StudyGuideForm = forwardRef<
     </Form>
   );
 });
+
+interface TagChipsInputProps {
+  value: string[];
+  onChange: (next: string[]) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Minimal tag chip input: type + Enter adds a chip, Backspace on an
+ * empty input removes the last chip, click X on a chip removes it.
+ * Values are trimmed + lowercased + deduped client-side to mirror the
+ * server's documented normalization (see CreateStudyGuideRequest docs
+ * in the generated OpenAPI types).
+ *
+ * Autocomplete from existing tags is deliberately out of scope until
+ * a `/api/tags/suggest`-style endpoint exists.
+ */
+function TagChipsInput({
+  value,
+  onChange,
+  disabled = false,
+  className,
+}: TagChipsInputProps) {
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const commit = () => {
+    const next = draft.trim().toLowerCase();
+    if (next === "") return;
+    if (value.includes(next)) {
+      setDraft("");
+      return;
+    }
+    onChange([...value, next]);
+    setDraft("");
+  };
+
+  const remove = (tag: string) => {
+    onChange(value.filter((existing) => existing !== tag));
+    inputRef.current?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commit();
+      return;
+    }
+    // Quality-of-life: backspace on empty input pops the last chip
+    // (matches the GitHub / Linear tag input convention).
+    if (event.key === "Backspace" && draft === "" && value.length > 0) {
+      event.preventDefault();
+      remove(value[value.length - 1]!);
+    }
+  };
+
+  return (
+    <div
+      role="group"
+      aria-label="Tags"
+      onClick={() => inputRef.current?.focus()}
+      className={cn(
+        "border-input focus-within:ring-ring flex flex-wrap items-center gap-1.5 rounded-md border bg-transparent px-2 py-1.5 focus-within:ring-2",
+        disabled && "cursor-not-allowed opacity-60",
+        className,
+      )}
+    >
+      {value.map((tag) => (
+        <Badge
+          key={tag}
+          variant="secondary"
+          className="gap-1 pl-2 pr-1 text-xs font-normal"
+        >
+          {tag}
+          <button
+            type="button"
+            aria-label={`Remove ${tag}`}
+            disabled={disabled}
+            onClick={(event) => {
+              event.stopPropagation();
+              remove(tag);
+            }}
+            className="hover:bg-muted-foreground/20 focus-visible:ring-ring -mr-0.5 inline-flex size-4 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-1 disabled:opacity-60"
+          >
+            <X className="size-3" aria-hidden />
+          </button>
+        </Badge>
+      ))}
+      <input
+        ref={inputRef}
+        type="text"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={commit}
+        disabled={disabled}
+        placeholder={
+          value.length === 0 ? "e.g. midterm, concurrency" : undefined
+        }
+        aria-label="Add a tag"
+        className="placeholder:text-muted-foreground min-w-[120px] flex-1 bg-transparent py-0.5 text-sm outline-none disabled:cursor-not-allowed"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes ASK-170.

## Summary

Tier B primitive that unblocks \`study-guides/new-page-wire-up\` (ASK-191) and \`study-guides/edit-page-wire-up\` (ASK-195). First form in the codebase to wire **react-hook-form + zodResolver + shadcn Form** end-to-end — sets the template for future forms.

- **Fields:** title (≥3 chars), content (≥10 chars, markdown textarea), tags (comma-separated, trimmed + filtered on submit).
- **Create + edit** share one component; \`mode\` switches label copy and button text, \`initial\` pre-fills every field in edit mode (AC2).
- **Save disables reactively** until title + content both pass validation (AC3/AC4) via react-hook-form's \`onChange\` mode.
- **Submit contract:** onSubmit gets the shaped \`CreateStudyGuideRequest | UpdateStudyGuideRequest\` body; caller owns success redirect + error toast. Rejections propagate so the form's \`isSubmitting\` clears on failure.
- **AC5 server errors:** component exposes an imperative ref (\`StudyGuideFormHandle\`) with \`setError(field, message)\` so callers can project \`ApiError.body.details\` onto field-level inline errors without baking server-error translation into the primitive.

## Test plan

- [x] \`pnpm jest lib/features/dashboard/study-guides/study-guide-form.test.tsx\` — 9/9 passing (all 5 ACs + edge cases)
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm eslint\` clean on new files
- [x] \`pnpm prettier --check\` clean on new files
- [x] Storybook stories render (Dashboard/StudyGuideForm: CreateEmpty / EditPrefilled / SlowSubmit / EditEmptyTags)
- [ ] Visual verification in Storybook after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New Study Guide form for creating and editing study guides with real-time validation
  * Form validates title (minimum 3 characters) and content (minimum 10 characters) with inline error messages
  * Built-in tag management supporting adding, removing, and automatic deduplication of tags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->