### PR TITLE
feat(db): study-guide visibility + grants schema (ASK-207 phase 1)

### DIFF
--- a/migrations/sql/20260424192951_add_study_guide_visibility_and_grants.down.sql
+++ b/migrations/sql/20260424192951_add_study_guide_visibility_and_grants.down.sql
@@ -1,0 +1,7 @@
+-- Reverse ASK-207.
+
+DROP INDEX IF EXISTS idx_study_guide_grants_sg_id;
+DROP INDEX IF EXISTS idx_study_guide_grants_grantee_perm_guide;
+DROP TABLE IF EXISTS study_guide_grants;
+ALTER TABLE study_guides DROP COLUMN IF EXISTS visibility;
+DROP TYPE IF EXISTS study_guide_visibility;

--- a/migrations/sql/20260424192951_add_study_guide_visibility_and_grants.up.sql
+++ b/migrations/sql/20260424192951_add_study_guide_visibility_and_grants.up.sql
@@ -1,0 +1,37 @@
+-- ASK-207: study-guide visibility + grants.
+--
+-- Introduces the same grant pattern used by file_grants (ASK-122) to
+-- study guides. The viewer can access a guide if the guide is public,
+-- they're the creator, or a matching study_guide_grants row exists.
+
+CREATE TYPE study_guide_visibility AS ENUM ('private', 'public');
+
+ALTER TABLE study_guides
+  ADD COLUMN visibility study_guide_visibility NOT NULL DEFAULT 'private';
+
+CREATE TABLE study_guide_grants (
+  id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  study_guide_id UUID         NOT NULL REFERENCES study_guides(id) ON DELETE CASCADE,
+  grantee_type   grantee_type NOT NULL,
+  grantee_id     UUID         NOT NULL,
+  permission     permission   NOT NULL DEFAULT 'view',
+  granted_by     UUID         NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  UNIQUE (study_guide_id, grantee_type, grantee_id, permission),
+  CHECK (grantee_type IN ('user', 'course'))
+);
+
+CREATE INDEX idx_study_guide_grants_grantee_perm_guide
+  ON study_guide_grants(grantee_type, grantee_id, permission, study_guide_id);
+
+CREATE INDEX idx_study_guide_grants_sg_id
+  ON study_guide_grants(study_guide_id);
+
+-- Backfill: every existing (non-deleted) guide gets a 'course' view
+-- grant scoped to its current course_id so current readers don't
+-- lose access when the visibility filter flips on. Creators are
+-- always able to view regardless of grants -- no backfill needed.
+INSERT INTO study_guide_grants (study_guide_id, grantee_type, grantee_id, permission, granted_by)
+SELECT sg.id, 'course'::grantee_type, sg.course_id, 'view'::permission, sg.creator_id
+FROM study_guides sg
+WHERE sg.deleted_at IS NULL;


### PR DESCRIPTION
## Summary
Schema-only migration adding the parallel grant machinery from \`file_grants\` to study guides. First of two PRs — service-layer visibility enforcement + grants CRUD endpoint land in phase 2.

**What changes:**
- \`study_guides.visibility\` ENUM('private','public') column, defaults \`'private'\`.
- New \`study_guide_grants\` table mirroring \`file_grants\` (unique on \`(sg_id, grantee_type, grantee_id, permission)\`, \`CHECK (grantee_type IN ('user','course'))\`).
- Two indexes — viewer-lookup + sg-lookup — matching file_grants' index shape.
- Backfill: every existing non-deleted SG gets a \`course\` view grant scoped to its primary \`course_id\` so current readers don't regress when the visibility filter flips on in phase 2.

**Safety:** No Go code reads these tables yet. Existing \`GetStudyGuideDetail\` / list queries are unchanged. Backfill preserves today's implicit "visible to course members" behavior. Phase 2 flips the filter + adds the grants handler + SG-visibility read paths.

## Test plan
- [ ] \`make migrate-up ENV=dev\` (needs your infisical login — couldn't run from this session)
- [ ] \`make migrate-up ENV=stage\`
- [ ] Verify backfill: \`SELECT count(*) FROM study_guide_grants WHERE grantee_type='course'\` matches \`SELECT count(*) FROM study_guides WHERE deleted_at IS NULL\`
- [ ] Verify visibility defaulted correctly: \`SELECT visibility, count(*) FROM study_guides GROUP BY visibility\` — all \`private\` initially

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Study guides now include visibility controls to manage access, defaulting to private
  * Added permission system to grant specific users or courses access to study guides
  * Existing study guides automatically configured with appropriate access settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->