### PR TITLE
feat(web): study-guide visibility + share UI (ASK-212)

### DIFF
--- a/web/components/ui/popover.tsx
+++ b/web/components/ui/popover.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Minimal shadcn-style Popover wrapper over Radix primitives. Matches
+ * the styling tokens used by `dropdown-menu.tsx` so popovers blend in
+ * with the rest of the UI. Consumers compose with `PopoverTrigger` +
+ * `PopoverContent`; `PopoverAnchor` is exposed for callsites that want
+ * to detach the trigger from the positioning anchor.
+ */
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/web/lib/api/actions/study-guides.ts
+++ b/web/lib/api/actions/study-guides.ts
@@ -15,9 +15,13 @@ import type {
   CastVoteRequest,
   CastVoteResponse,
   FileAttachmentResponse,
+  ListStudyGuideGrantsResponse,
   RecommendationResponse,
   ResourceSummary,
+  StudyGuideCreateGrantRequest,
   StudyGuideDetailResponse,
+  StudyGuideGrantResponse,
+  StudyGuideRevokeGrantRequest,
   UpdateStudyGuideRequest,
 } from "../types";
 
@@ -172,5 +176,47 @@ export async function removeStudyGuideVote(
       params: { path: { study_guide_id: studyGuideId } },
     }),
     `DELETE /study-guides/${studyGuideId}/votes`,
+  );
+}
+
+// ---------- Grants (ASK-211/ASK-212) ----------
+
+/** List the grants (share targets) currently attached to a study guide. */
+export async function listStudyGuideGrants(
+  studyGuideId: string,
+): Promise<ListStudyGuideGrantsResponse> {
+  return unwrap(
+    await serverApi.GET("/study-guides/{study_guide_id}/grants", {
+      params: { path: { study_guide_id: studyGuideId } },
+    }),
+    `GET /study-guides/${studyGuideId}/grants`,
+  );
+}
+
+/** Grant a permission on a study guide to another user or course. */
+export async function createStudyGuideGrant(
+  studyGuideId: string,
+  body: StudyGuideCreateGrantRequest,
+): Promise<StudyGuideGrantResponse> {
+  return unwrap(
+    await serverApi.POST("/study-guides/{study_guide_id}/grants", {
+      params: { path: { study_guide_id: studyGuideId } },
+      body,
+    }),
+    `POST /study-guides/${studyGuideId}/grants`,
+  );
+}
+
+/** Revoke a previously-issued study-guide permission grant. */
+export async function revokeStudyGuideGrant(
+  studyGuideId: string,
+  body: StudyGuideRevokeGrantRequest,
+): Promise<void> {
+  return unwrapVoid(
+    await serverApi.DELETE("/study-guides/{study_guide_id}/grants", {
+      params: { path: { study_guide_id: studyGuideId } },
+      body,
+    }),
+    `DELETE /study-guides/${studyGuideId}/grants`,
   );
 }

--- a/web/lib/api/generated/types.ts
+++ b/web/lib/api/generated/types.ts
@@ -1189,6 +1189,45 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/study-guides/{study_guide_id}/grants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List permission grants on a study guide (ASK-211)
+         * @description Returns every `study_guide_grants` row for the guide. Only
+         *     the guide's creator may list grants; non-creators receive 403.
+         */
+        get: operations["ListStudyGuideGrants"];
+        put?: never;
+        /**
+         * Grant a permission on a study guide (ASK-211)
+         * @description Creates a new `study_guide_grants` row scoped to
+         *     `(study_guide_id, grantee_type, grantee_id, permission)`.
+         *     Only the guide's creator may create grants. A duplicate
+         *     grant returns 409 Conflict. `grantee_type` is limited to
+         *     `user` or `course` -- study guides cannot grant access to
+         *     other study guides (the table enforces this via a CHECK
+         *     constraint).
+         */
+        post: operations["CreateStudyGuideGrant"];
+        /**
+         * Revoke a permission on a study guide (ASK-211)
+         * @description Deletes the `study_guide_grants` row matched by
+         *     `(study_guide_id, grantee_type, grantee_id, permission)`.
+         *     Only the guide's creator may revoke. Returns 204 on success,
+         *     404 when no matching grant exists (not idempotent -- mirrors
+         *     file_grants).
+         */
+        delete: operations["RevokeStudyGuideGrant"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/courses/{course_id}/study-guides": {
         parameters: {
             query?: never;
@@ -1667,6 +1706,54 @@ export interface components {
             /** Format: date-time */
             created_at: string;
         };
+        /**
+         * @description Request body for POST /api/study-guides/{study_guide_id}/grants
+         *     (ASK-211). Mirrors CreateGrantRequest but constrains
+         *     `grantee_type` to `user`/`course` since study guides cannot
+         *     grant access to other study guides.
+         */
+        StudyGuideCreateGrantRequest: {
+            /** @enum {string} */
+            grantee_type: "user" | "course";
+            /** Format: uuid */
+            grantee_id: string;
+            /** @enum {string} */
+            permission: "view" | "share" | "delete";
+        };
+        /**
+         * @description Request body for DELETE /api/study-guides/{study_guide_id}/grants
+         *     (ASK-211).
+         */
+        StudyGuideRevokeGrantRequest: {
+            /** @enum {string} */
+            grantee_type: "user" | "course";
+            /** Format: uuid */
+            grantee_id: string;
+            /** @enum {string} */
+            permission: "view" | "share" | "delete";
+        };
+        /** @description A study-guide permission grant (ASK-211) */
+        StudyGuideGrantResponse: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            study_guide_id: string;
+            grantee_type: string;
+            /** Format: uuid */
+            grantee_id: string;
+            permission: string;
+            /** Format: uuid */
+            granted_by: string;
+            /** Format: date-time */
+            created_at: string;
+        };
+        /**
+         * @description Collection of grants on a study guide. Sorted by created_at
+         *     DESC so the newest share surfaces first.
+         */
+        ListStudyGuideGrantsResponse: {
+            grants: components["schemas"]["StudyGuideGrantResponse"][];
+        };
         /** @description A school (university or college) */
         SchoolResponse: {
             /** Format: uuid */
@@ -1875,6 +1962,8 @@ export interface components {
             is_recommended: boolean;
             /** Format: int64 */
             quiz_count: number;
+            /** @enum {string} */
+            visibility: "private" | "public";
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -2006,12 +2095,21 @@ export interface components {
          *     (trim + lowercase + dedupe); empty tags after trim are
          *     rejected with 400. `creator_id` is set from the JWT and
          *     ignored if supplied here.
+         *
+         *     `visibility` is optional and defaults to `private`. Private
+         *     guides are visible only to the creator + grantees (direct
+         *     user grant or enrolled-course grant). A course-wide view
+         *     grant is auto-seeded on create so course members keep their
+         *     "visible to everyone in the course" ergonomics without a
+         *     follow-up POST /grants call (ASK-211).
          */
         CreateStudyGuideRequest: {
             title: string;
             description?: string | null;
             content?: string | null;
             tags?: string[];
+            /** @enum {string} */
+            visibility?: "private" | "public";
         };
         /**
          * @description Request body for PATCH /api/study-guides/{study_guide_id}.
@@ -2019,13 +2117,17 @@ export interface components {
          *     value. Tags, when provided, REPLACE all existing tags (no
          *     merge) and are normalized server-side (trim + lowercase +
          *     dedupe). At least one field must be provided -- an empty body
-         *     `{}` is rejected with 400.
+         *     `{}` is rejected with 400. Supplying `visibility` flips the
+         *     guide between private and public (ASK-211); existing grants
+         *     are preserved either way.
          */
         UpdateStudyGuideRequest: {
             title?: string;
             description?: string | null;
             content?: string | null;
             tags?: string[];
+            /** @enum {string} */
+            visibility?: "private" | "public";
         };
         /**
          * @description Full study-guide payload for the detail endpoint. Includes
@@ -2053,6 +2155,13 @@ export interface components {
             quizzes: components["schemas"]["QuizSummary"][];
             resources: components["schemas"]["ResourceSummary"][];
             files: components["schemas"]["StudyGuideFileSummary"][];
+            /**
+             * @description Visibility of the guide (ASK-211). `private` guides are
+             *     visible only to the creator + grantees; `public` guides
+             *     are visible to every authenticated user.
+             * @enum {string}
+             */
+            visibility: "private" | "public";
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -2099,6 +2208,8 @@ export interface components {
              *     about an undefined case).
              */
             deleted_at: string | null;
+            /** @enum {string} */
+            visibility: "private" | "public";
         };
         /**
          * @description Paginated envelope for GET /api/me/study-guides (ASK-131).
@@ -4044,6 +4155,96 @@ export interface operations {
             };
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    ListStudyGuideGrants: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The unique UUID of the study guide */
+                study_guide_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Grants list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListStudyGuideGrantsResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    CreateStudyGuideGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The unique UUID of the study guide */
+                study_guide_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StudyGuideCreateGrantRequest"];
+            };
+        };
+        responses: {
+            /** @description Grant created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StudyGuideGrantResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    RevokeStudyGuideGrant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The unique UUID of the study guide */
+                study_guide_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StudyGuideRevokeGrantRequest"];
+            };
+        };
+        responses: {
+            /** @description Grant revoked */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
             500: components["responses"]["InternalServerError"];
         };

--- a/web/lib/api/index.ts
+++ b/web/lib/api/index.ts
@@ -51,13 +51,16 @@ export {
   attachFile,
   attachResource,
   castStudyGuideVote,
+  createStudyGuideGrant,
   deleteStudyGuide,
   detachFile,
   detachResource,
   getStudyGuide,
+  listStudyGuideGrants,
   recommendStudyGuide,
   removeStudyGuideRecommendation,
   removeStudyGuideVote,
+  revokeStudyGuideGrant,
   updateStudyGuide,
 } from "./actions/study-guides";
 

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -81,6 +81,17 @@ export type StudyGuideFileSummary = ApiSchemas["StudyGuideFileSummary"];
 export type RecommendationResponse = ApiSchemas["RecommendationResponse"];
 export type CastVoteRequest = ApiSchemas["CastVoteRequest"];
 export type CastVoteResponse = ApiSchemas["CastVoteResponse"];
+// ASK-211/ASK-212: visibility + grant sharing
+export type StudyGuideVisibility = NonNullable<
+  ApiSchemas["StudyGuideDetailResponse"]["visibility"]
+>;
+export type StudyGuideCreateGrantRequest =
+  ApiSchemas["StudyGuideCreateGrantRequest"];
+export type StudyGuideRevokeGrantRequest =
+  ApiSchemas["StudyGuideRevokeGrantRequest"];
+export type StudyGuideGrantResponse = ApiSchemas["StudyGuideGrantResponse"];
+export type ListStudyGuideGrantsResponse =
+  ApiSchemas["ListStudyGuideGrantsResponse"];
 
 // ---------- Quizzes ----------
 export type QuizDetailResponse = ApiSchemas["QuizDetailResponse"];

--- a/web/lib/api/types.ts
+++ b/web/lib/api/types.ts
@@ -82,9 +82,8 @@ export type RecommendationResponse = ApiSchemas["RecommendationResponse"];
 export type CastVoteRequest = ApiSchemas["CastVoteRequest"];
 export type CastVoteResponse = ApiSchemas["CastVoteResponse"];
 // ASK-211/ASK-212: visibility + grant sharing
-export type StudyGuideVisibility = NonNullable<
-  ApiSchemas["StudyGuideDetailResponse"]["visibility"]
->;
+export type StudyGuideVisibility =
+  ApiSchemas["StudyGuideDetailResponse"]["visibility"];
 export type StudyGuideCreateGrantRequest =
   ApiSchemas["StudyGuideCreateGrantRequest"];
 export type StudyGuideRevokeGrantRequest =
@@ -117,6 +116,7 @@ export type PracticeAnswerResponse = ApiSchemas["PracticeAnswerResponse"];
 
 // ---------- Me / Dashboard ----------
 export type DashboardResponse = ApiSchemas["DashboardResponse"];
+export type EnrollmentResponse = ApiSchemas["EnrollmentResponse"];
 export type ListMyEnrollmentsResponse = ApiSchemas["ListMyEnrollmentsResponse"];
 export type ListMyEnrollmentsQuery = NonNullable<
   ApiPaths["/me/courses"]["get"]["parameters"]["query"]

--- a/web/lib/features/dashboard/study-guides/grants-manager.test.tsx
+++ b/web/lib/features/dashboard/study-guides/grants-manager.test.tsx
@@ -9,16 +9,6 @@ import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
-jest.mock("../../../api/actions/study-guides", () => ({
-  listStudyGuideGrants: jest.fn(),
-  createStudyGuideGrant: jest.fn(),
-  revokeStudyGuideGrant: jest.fn(),
-}));
-
-jest.mock("../../../api/actions/me", () => ({
-  listMyEnrollments: jest.fn(),
-}));
-
 jest.mock("../../shared/toast/toast", () => ({
   toast: {
     error: jest.fn(),
@@ -28,29 +18,34 @@ jest.mock("../../shared/toast/toast", () => ({
   },
 }));
 
-import {
-  createStudyGuideGrant,
-  listStudyGuideGrants,
-  revokeStudyGuideGrant,
-} from "../../../api/actions/study-guides";
-import { listMyEnrollments } from "../../../api/actions/me";
 import { toast } from "../../shared/toast/toast";
+import type { StudyGuideGrantResponse } from "@/lib/api/types";
 
-import { GrantsManager } from "./grants-manager";
+import {
+  GrantsManager,
+  type GrantsManagerActions,
+} from "./grants-manager";
 
-const mockList = listStudyGuideGrants as jest.MockedFunction<
-  typeof listStudyGuideGrants
+const mockList = jest.fn() as jest.MockedFunction<
+  GrantsManagerActions["listGrants"]
 >;
-const mockCreate = createStudyGuideGrant as jest.MockedFunction<
-  typeof createStudyGuideGrant
+const mockCreate = jest.fn() as jest.MockedFunction<
+  GrantsManagerActions["createGrant"]
 >;
-const mockRevoke = revokeStudyGuideGrant as jest.MockedFunction<
-  typeof revokeStudyGuideGrant
+const mockRevoke = jest.fn() as jest.MockedFunction<
+  GrantsManagerActions["revokeGrant"]
 >;
-const mockEnrollments = listMyEnrollments as jest.MockedFunction<
-  typeof listMyEnrollments
+const mockEnrollments = jest.fn() as jest.MockedFunction<
+  GrantsManagerActions["listEnrollments"]
 >;
 const mockToastError = toast.error as jest.MockedFunction<typeof toast.error>;
+
+const actions: GrantsManagerActions = {
+  listGrants: (id) => mockList(id),
+  listEnrollments: () => mockEnrollments(),
+  createGrant: (id, body) => mockCreate(id, body),
+  revokeGrant: (id, body) => mockRevoke(id, body),
+};
 
 const STUDY_GUIDE_ID = "sg_1";
 const COURSE_ID_MATH = "course_math_340";
@@ -97,7 +92,9 @@ function enrollmentFixture() {
   };
 }
 
-function grantFixture(overrides: Partial<Record<string, string>> = {}) {
+function grantFixture(
+  overrides: Partial<StudyGuideGrantResponse> = {},
+): StudyGuideGrantResponse {
   return {
     id: "grant_1",
     study_guide_id: STUDY_GUIDE_ID,
@@ -121,7 +118,7 @@ describe("GrantsManager / initial load", () => {
     mockList.mockResolvedValue({
       grants: [grantFixture({ grantee_id: COURSE_ID_MATH })],
     });
-    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} actions={actions} />);
     expect(
       await screen.findByTestId(`grant-chip-${COURSE_ID_MATH}`),
     ).toBeInTheDocument();
@@ -130,7 +127,7 @@ describe("GrantsManager / initial load", () => {
 
   it("surfaces a toast when the initial fetch fails", async () => {
     mockList.mockRejectedValue(new Error("boom"));
-    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} actions={actions} />);
     await waitFor(() => expect(mockToastError).toHaveBeenCalled());
   });
 });
@@ -138,16 +135,16 @@ describe("GrantsManager / initial load", () => {
 describe("GrantsManager / add course grant", () => {
   it("inserts the chip optimistically before the network resolves", async () => {
     jest.useFakeTimers();
-    let resolveCreate: ((value: unknown) => void) | undefined;
+    let resolveCreate!: (value: StudyGuideGrantResponse) => void;
     mockCreate.mockImplementation(
       () =>
-        new Promise((resolve) => {
-          resolveCreate = resolve as (value: unknown) => void;
-        }) as never,
+        new Promise<StudyGuideGrantResponse>((resolve) => {
+          resolveCreate = resolve;
+        }),
     );
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} actions={actions} />);
     // Wait for the initial load to settle so the search input is live.
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
@@ -183,7 +180,7 @@ describe("GrantsManager / add course grant", () => {
     jest.useFakeTimers();
     mockCreate.mockRejectedValue(new Error("nope"));
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} actions={actions} />);
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
     await user.type(
@@ -224,7 +221,7 @@ describe("GrantsManager / remove grant", () => {
     );
 
     const user = userEvent.setup();
-    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} actions={actions} />);
     const chip = await screen.findByTestId(`grant-chip-${COURSE_ID_MATH}`);
     await user.click(within(chip).getByRole("button", { name: /remove/i }));
     expect(
@@ -243,7 +240,7 @@ describe("GrantsManager / remove grant", () => {
     mockRevoke.mockRejectedValue(new Error("nope"));
 
     const user = userEvent.setup();
-    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} actions={actions} />);
     const chip = await screen.findByTestId(`grant-chip-${COURSE_ID_MATH}`);
     await user.click(within(chip).getByRole("button", { name: /remove/i }));
     // Chip comes back once the DELETE rejects.
@@ -258,7 +255,7 @@ describe("GrantsManager / people search", () => {
   it("shows the coming-soon placeholder when the query starts with @", async () => {
     jest.useFakeTimers();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} actions={actions} />);
     await waitFor(() => expect(mockList).toHaveBeenCalled());
     await user.type(
       screen.getByRole("textbox", { name: /search courses or people/i }),

--- a/web/lib/features/dashboard/study-guides/grants-manager.test.tsx
+++ b/web/lib/features/dashboard/study-guides/grants-manager.test.tsx
@@ -21,10 +21,7 @@ jest.mock("../../shared/toast/toast", () => ({
 import { toast } from "../../shared/toast/toast";
 import type { StudyGuideGrantResponse } from "@/lib/api/types";
 
-import {
-  GrantsManager,
-  type GrantsManagerActions,
-} from "./grants-manager";
+import { GrantsManager, type GrantsManagerActions } from "./grants-manager";
 
 const mockList = jest.fn() as jest.MockedFunction<
   GrantsManagerActions["listGrants"]

--- a/web/lib/features/dashboard/study-guides/grants-manager.test.tsx
+++ b/web/lib/features/dashboard/study-guides/grants-manager.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * Exercises the ASK-212 optimistic-update contract for the
+ * study-guide grants manager: add-success, add-failure (rollback +
+ * toast), remove-success, remove-failure (rollback + toast). The
+ * search debounce is respected by advancing timers in the tests that
+ * care.
+ */
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+jest.mock("../../../api/actions/study-guides", () => ({
+  listStudyGuideGrants: jest.fn(),
+  createStudyGuideGrant: jest.fn(),
+  revokeStudyGuideGrant: jest.fn(),
+}));
+
+jest.mock("../../../api/actions/me", () => ({
+  listMyEnrollments: jest.fn(),
+}));
+
+jest.mock("../../shared/toast/toast", () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+    info: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+import {
+  createStudyGuideGrant,
+  listStudyGuideGrants,
+  revokeStudyGuideGrant,
+} from "../../../api/actions/study-guides";
+import { listMyEnrollments } from "../../../api/actions/me";
+import { toast } from "../../shared/toast/toast";
+
+import { GrantsManager } from "./grants-manager";
+
+const mockList = listStudyGuideGrants as jest.MockedFunction<
+  typeof listStudyGuideGrants
+>;
+const mockCreate = createStudyGuideGrant as jest.MockedFunction<
+  typeof createStudyGuideGrant
+>;
+const mockRevoke = revokeStudyGuideGrant as jest.MockedFunction<
+  typeof revokeStudyGuideGrant
+>;
+const mockEnrollments = listMyEnrollments as jest.MockedFunction<
+  typeof listMyEnrollments
+>;
+const mockToastError = toast.error as jest.MockedFunction<typeof toast.error>;
+
+const STUDY_GUIDE_ID = "sg_1";
+const COURSE_ID_MATH = "course_math_340";
+const COURSE_ID_CS = "course_cs_101";
+
+function enrollmentFixture() {
+  return {
+    enrollments: [
+      {
+        section: {
+          id: "sec_math_a",
+          term: "Fall 2026",
+          section_code: "A",
+          instructor_name: "Prof. Euler",
+        },
+        course: {
+          id: COURSE_ID_MATH,
+          department: "MATH",
+          number: "340",
+          title: "Linear Algebra",
+        },
+        school: { id: "sch_1", acronym: "WSU" },
+        role: "student" as const,
+        joined_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        section: {
+          id: "sec_cs_a",
+          term: "Fall 2026",
+          section_code: "A",
+          instructor_name: "Prof. Lovelace",
+        },
+        course: {
+          id: COURSE_ID_CS,
+          department: "CS",
+          number: "101",
+          title: "Intro to CS",
+        },
+        school: { id: "sch_1", acronym: "WSU" },
+        role: "student" as const,
+        joined_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+  };
+}
+
+function grantFixture(overrides: Partial<Record<string, string>> = {}) {
+  return {
+    id: "grant_1",
+    study_guide_id: STUDY_GUIDE_ID,
+    grantee_type: "course",
+    grantee_id: COURSE_ID_MATH,
+    permission: "view",
+    granted_by: "user_creator",
+    created_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockList.mockResolvedValue({ grants: [] });
+  mockEnrollments.mockResolvedValue(enrollmentFixture());
+});
+
+describe("GrantsManager / initial load", () => {
+  it("renders existing grants after the fetch resolves", async () => {
+    mockList.mockResolvedValue({
+      grants: [grantFixture({ grantee_id: COURSE_ID_MATH })],
+    });
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    expect(
+      await screen.findByTestId(`grant-chip-${COURSE_ID_MATH}`),
+    ).toBeInTheDocument();
+    expect(mockList).toHaveBeenCalledWith(STUDY_GUIDE_ID);
+  });
+
+  it("surfaces a toast when the initial fetch fails", async () => {
+    mockList.mockRejectedValue(new Error("boom"));
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+  });
+});
+
+describe("GrantsManager / add course grant", () => {
+  it("inserts the chip optimistically before the network resolves", async () => {
+    jest.useFakeTimers();
+    let resolveCreate: ((value: unknown) => void) | undefined;
+    mockCreate.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve as (value: unknown) => void;
+        }) as never,
+    );
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    // Wait for the initial load to settle so the search input is live.
+    await waitFor(() => expect(mockList).toHaveBeenCalled());
+
+    await user.type(
+      screen.getByRole("textbox", { name: /search courses or people/i }),
+      "math",
+    );
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    await user.click(await screen.findByText(/MATH 340/i));
+
+    // Chip appears immediately -- the POST is still pending.
+    expect(
+      await screen.findByTestId(`grant-chip-${COURSE_ID_MATH}`),
+    ).toBeInTheDocument();
+    expect(mockCreate).toHaveBeenCalledWith(STUDY_GUIDE_ID, {
+      grantee_type: "course",
+      grantee_id: COURSE_ID_MATH,
+      permission: "view",
+    });
+
+    // Let the pending promise resolve so act() stays happy.
+    await act(async () => {
+      resolveCreate?.({
+        ...grantFixture({ grantee_id: COURSE_ID_MATH, id: "grant_new" }),
+      });
+    });
+    jest.useRealTimers();
+  });
+
+  it("rolls back and fires a toast when the POST fails", async () => {
+    jest.useFakeTimers();
+    mockCreate.mockRejectedValue(new Error("nope"));
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    await waitFor(() => expect(mockList).toHaveBeenCalled());
+
+    await user.type(
+      screen.getByRole("textbox", { name: /search courses or people/i }),
+      "cs",
+    );
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    await user.click(await screen.findByText(/CS 101/i));
+
+    // Chip first appears...
+    expect(
+      await screen.findByTestId(`grant-chip-${COURSE_ID_CS}`),
+    ).toBeInTheDocument();
+    // ...then disappears once the POST rejects.
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId(`grant-chip-${COURSE_ID_CS}`),
+      ).not.toBeInTheDocument(),
+    );
+    expect(mockToastError).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});
+
+describe("GrantsManager / remove grant", () => {
+  it("removes the chip optimistically on click", async () => {
+    mockList.mockResolvedValue({
+      grants: [grantFixture({ grantee_id: COURSE_ID_MATH })],
+    });
+    let resolveRevoke: (() => void) | undefined;
+    mockRevoke.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRevoke = resolve;
+        }),
+    );
+
+    const user = userEvent.setup();
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    const chip = await screen.findByTestId(`grant-chip-${COURSE_ID_MATH}`);
+    await user.click(within(chip).getByRole("button", { name: /remove/i }));
+    expect(
+      screen.queryByTestId(`grant-chip-${COURSE_ID_MATH}`),
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveRevoke?.();
+    });
+  });
+
+  it("restores the chip and fires a toast when the DELETE fails", async () => {
+    mockList.mockResolvedValue({
+      grants: [grantFixture({ grantee_id: COURSE_ID_MATH })],
+    });
+    mockRevoke.mockRejectedValue(new Error("nope"));
+
+    const user = userEvent.setup();
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    const chip = await screen.findByTestId(`grant-chip-${COURSE_ID_MATH}`);
+    await user.click(within(chip).getByRole("button", { name: /remove/i }));
+    // Chip comes back once the DELETE rejects.
+    expect(
+      await screen.findByTestId(`grant-chip-${COURSE_ID_MATH}`),
+    ).toBeInTheDocument();
+    expect(mockToastError).toHaveBeenCalled();
+  });
+});
+
+describe("GrantsManager / people search", () => {
+  it("shows the coming-soon placeholder when the query starts with @", async () => {
+    jest.useFakeTimers();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<GrantsManager studyGuideId={STUDY_GUIDE_ID} />);
+    await waitFor(() => expect(mockList).toHaveBeenCalled());
+    await user.type(
+      screen.getByRole("textbox", { name: /search courses or people/i }),
+      "@ada",
+    );
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(
+      await screen.findByText(/people search coming soon/i),
+    ).toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});

--- a/web/lib/features/dashboard/study-guides/grants-manager.tsx
+++ b/web/lib/features/dashboard/study-guides/grants-manager.tsx
@@ -1,27 +1,55 @@
 "use client";
 
 import { Loader2, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { listMyEnrollments } from "@/lib/api/actions/me";
-import {
-  createStudyGuideGrant,
-  listStudyGuideGrants,
-  revokeStudyGuideGrant,
-} from "@/lib/api/actions/study-guides";
-import type { ApiSchemas, StudyGuideGrantResponse } from "@/lib/api/types";
+import type {
+  EnrollmentResponse,
+  ListMyEnrollmentsResponse,
+  ListStudyGuideGrantsResponse,
+  StudyGuideCreateGrantRequest,
+  StudyGuideGrantResponse,
+  StudyGuideRevokeGrantRequest,
+} from "@/lib/api/types";
 import { toast } from "@/lib/features/shared/toast/toast";
-
-// Enrollment isn't exposed from `lib/api/types` (only the list wrapper
-// is), so we pull it straight off the generated schemas.
-type EnrollmentResponse = ApiSchemas["EnrollmentResponse"];
 
 const SEARCH_DEBOUNCE_MS = 200;
 
+type GranteeType = StudyGuideRevokeGrantRequest["grantee_type"];
+type Permission = StudyGuideRevokeGrantRequest["permission"];
+
+function isGranteeType(value: string): value is GranteeType {
+  return value === "course" || value === "user";
+}
+
+function isPermission(value: string): value is Permission {
+  return value === "view" || value === "share" || value === "delete";
+}
+
+/**
+ * Server actions are injected so this client component stays free of
+ * `"use server"` imports. That keeps Storybook (Vite) from following
+ * the chain into `@clerk/nextjs/server`, and matches the DI pattern
+ * used by every other feature component in this codebase.
+ */
+export interface GrantsManagerActions {
+  listGrants: (studyGuideId: string) => Promise<ListStudyGuideGrantsResponse>;
+  listEnrollments: () => Promise<ListMyEnrollmentsResponse>;
+  createGrant: (
+    studyGuideId: string,
+    body: StudyGuideCreateGrantRequest,
+  ) => Promise<StudyGuideGrantResponse>;
+  revokeGrant: (
+    studyGuideId: string,
+    body: StudyGuideRevokeGrantRequest,
+  ) => Promise<void>;
+}
+
 export interface GrantsManagerProps {
   studyGuideId: string;
+  actions: GrantsManagerActions;
   /** Optional callback invoked whenever the grant count changes. */
   onGrantCountChange?: (count: number) => void;
 }
@@ -42,6 +70,7 @@ export interface GrantsManagerProps {
  */
 export function GrantsManager({
   studyGuideId,
+  actions,
   onGrantCountChange,
 }: GrantsManagerProps) {
   const [grants, setGrants] = useState<StudyGuideGrantResponse[]>([]);
@@ -49,6 +78,9 @@ export function GrantsManager({
   const [enrollments, setEnrollments] = useState<EnrollmentResponse[]>([]);
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
+  // Course IDs with an in-flight POST. Gates duplicate clicks even
+  // before the optimistic state has flushed.
+  const inFlightAdds = useRef<Set<string>>(new Set());
 
   // Initial load -- grants + enrollments in parallel so the popover is
   // interactive as soon as the data lands.
@@ -57,8 +89,8 @@ export function GrantsManager({
     async function load() {
       try {
         const [grantsRes, enrollmentsRes] = await Promise.all([
-          listStudyGuideGrants(studyGuideId),
-          listMyEnrollments(),
+          actions.listGrants(studyGuideId),
+          actions.listEnrollments(),
         ]);
         if (cancelled) return;
         setGrants(grantsRes.grants);
@@ -73,7 +105,7 @@ export function GrantsManager({
     return () => {
       cancelled = true;
     };
-  }, [studyGuideId]);
+  }, [studyGuideId, actions]);
 
   // Report grant count changes back to the caller so the visibility
   // chip can re-render with the new "Shared · N" label.
@@ -121,6 +153,8 @@ export function GrantsManager({
 
   const addCourseGrant = useCallback(
     async (courseId: string) => {
+      if (inFlightAdds.current.has(courseId)) return;
+      inFlightAdds.current.add(courseId);
       // Optimistic insert with a temporary id so React keys stay
       // stable; real id replaces it when the POST resolves.
       const temp: StudyGuideGrantResponse = {
@@ -135,7 +169,7 @@ export function GrantsManager({
       setGrants((prev) => [...prev, temp]);
       setQuery("");
       try {
-        const created = await createStudyGuideGrant(studyGuideId, {
+        const created = await actions.createGrant(studyGuideId, {
           grantee_type: "course",
           grantee_id: courseId,
           permission: "view",
@@ -146,27 +180,38 @@ export function GrantsManager({
       } catch (error: unknown) {
         setGrants((prev) => prev.filter((grant) => grant.id !== temp.id));
         toast.error(error);
+      } finally {
+        inFlightAdds.current.delete(courseId);
       }
     },
-    [studyGuideId],
+    [studyGuideId, actions],
   );
 
   const removeGrant = useCallback(
     async (grant: StudyGuideGrantResponse) => {
-      const snapshot = grants;
-      setGrants((prev) => prev.filter((existing) => existing.id !== grant.id));
+      if (!isGranteeType(grant.grantee_type) || !isPermission(grant.permission)) {
+        toast.error(new Error("Cannot revoke grant: unrecognized type"));
+        return;
+      }
+      // Functional setState captures the current array as `snapshot`
+      // so a concurrent add/remove can't roll back to a stale closure.
+      let snapshot: StudyGuideGrantResponse[] = [];
+      setGrants((prev) => {
+        snapshot = prev;
+        return prev.filter((existing) => existing.id !== grant.id);
+      });
       try {
-        await revokeStudyGuideGrant(studyGuideId, {
-          grantee_type: grant.grantee_type as "course" | "user",
+        await actions.revokeGrant(studyGuideId, {
+          grantee_type: grant.grantee_type,
           grantee_id: grant.grantee_id,
-          permission: grant.permission as "view" | "share" | "delete",
+          permission: grant.permission,
         });
       } catch (error: unknown) {
         setGrants(snapshot);
         toast.error(error);
       }
     },
-    [grants, studyGuideId],
+    [studyGuideId, actions],
   );
 
   const courseGrants = grants.filter(
@@ -317,6 +362,10 @@ function formatCourseLabel(
   const match = enrollments.find(
     (enrollment) => enrollment.course.id === courseId,
   );
-  if (!match) return "Course";
+  // TODO(ASK-212-followup): the API should return course
+  // department/number alongside each grant so we can label grants on
+  // courses the viewer isn't enrolled in. For now we fall back to the
+  // grantee_id (UUID) so duplicate "Course" chips remain distinguishable.
+  if (!match) return `Course ${courseId.slice(0, 8)}`;
   return `${match.course.department} ${match.course.number}`;
 }

--- a/web/lib/features/dashboard/study-guides/grants-manager.tsx
+++ b/web/lib/features/dashboard/study-guides/grants-manager.tsx
@@ -142,7 +142,8 @@ export function GrantsManager({
     return enrollments
       .map((enrollment) => enrollment.course)
       .filter((course) => {
-        if (seen.has(course.id) || grantedCourseIds.has(course.id)) return false;
+        if (seen.has(course.id) || grantedCourseIds.has(course.id))
+          return false;
         const hay =
           `${course.department} ${course.number} ${course.title}`.toLowerCase();
         if (!hay.includes(needle)) return false;
@@ -189,7 +190,10 @@ export function GrantsManager({
 
   const removeGrant = useCallback(
     async (grant: StudyGuideGrantResponse) => {
-      if (!isGranteeType(grant.grantee_type) || !isPermission(grant.permission)) {
+      if (
+        !isGranteeType(grant.grantee_type) ||
+        !isPermission(grant.permission)
+      ) {
         toast.error(new Error("Cannot revoke grant: unrecognized type"));
         return;
       }

--- a/web/lib/features/dashboard/study-guides/grants-manager.tsx
+++ b/web/lib/features/dashboard/study-guides/grants-manager.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import { Loader2, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { listMyEnrollments } from "@/lib/api/actions/me";
+import {
+  createStudyGuideGrant,
+  listStudyGuideGrants,
+  revokeStudyGuideGrant,
+} from "@/lib/api/actions/study-guides";
+import type { ApiSchemas, StudyGuideGrantResponse } from "@/lib/api/types";
+import { toast } from "@/lib/features/shared/toast/toast";
+
+// Enrollment isn't exposed from `lib/api/types` (only the list wrapper
+// is), so we pull it straight off the generated schemas.
+type EnrollmentResponse = ApiSchemas["EnrollmentResponse"];
+
+const SEARCH_DEBOUNCE_MS = 200;
+
+export interface GrantsManagerProps {
+  studyGuideId: string;
+  /** Optional callback invoked whenever the grant count changes. */
+  onGrantCountChange?: (count: number) => void;
+}
+
+/**
+ * Inline grants editor -- lists current non-creator grants on a study
+ * guide and lets the caller add more. Loaded only when mounted (the
+ * form keeps it unmounted in create mode, so the network fetch only
+ * fires on the first popover open in edit mode).
+ *
+ * Updates are optimistic: we mutate the local `grants` state first,
+ * fire the server action, and revert on failure. A toast surfaces the
+ * error message for the user.
+ *
+ * People search is deferred -- typing `@<query>` shows a coming-soon
+ * placeholder (see TODO below). For now we search only over the
+ * caller's own enrollments (`GET /me/courses`).
+ */
+export function GrantsManager({
+  studyGuideId,
+  onGrantCountChange,
+}: GrantsManagerProps) {
+  const [grants, setGrants] = useState<StudyGuideGrantResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [enrollments, setEnrollments] = useState<EnrollmentResponse[]>([]);
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  // Initial load -- grants + enrollments in parallel so the popover is
+  // interactive as soon as the data lands.
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const [grantsRes, enrollmentsRes] = await Promise.all([
+          listStudyGuideGrants(studyGuideId),
+          listMyEnrollments(),
+        ]);
+        if (cancelled) return;
+        setGrants(grantsRes.grants);
+        setEnrollments(enrollmentsRes.enrollments);
+      } catch (error: unknown) {
+        if (!cancelled) toast.error(error);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [studyGuideId]);
+
+  // Report grant count changes back to the caller so the visibility
+  // chip can re-render with the new "Shared · N" label.
+  useEffect(() => {
+    onGrantCountChange?.(grants.length);
+  }, [grants.length, onGrantCountChange]);
+
+  // Debounce the search query.
+  useEffect(() => {
+    const handle = setTimeout(
+      () => setDebouncedQuery(query.trim()),
+      SEARCH_DEBOUNCE_MS,
+    );
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const grantedCourseIds = useMemo(
+    () =>
+      new Set(
+        grants
+          .filter((grant) => grant.grantee_type === "course")
+          .map((grant) => grant.grantee_id),
+      ),
+    [grants],
+  );
+
+  const filteredCourses = useMemo(() => {
+    if (debouncedQuery === "" || debouncedQuery.startsWith("@")) return [];
+    const needle = debouncedQuery.toLowerCase();
+    // Dedupe by course.id -- a user can be enrolled in multiple
+    // sections of the same course and we only grant at the course
+    // level.
+    const seen = new Set<string>();
+    return enrollments
+      .map((enrollment) => enrollment.course)
+      .filter((course) => {
+        if (seen.has(course.id) || grantedCourseIds.has(course.id)) return false;
+        const hay =
+          `${course.department} ${course.number} ${course.title}`.toLowerCase();
+        if (!hay.includes(needle)) return false;
+        seen.add(course.id);
+        return true;
+      });
+  }, [debouncedQuery, enrollments, grantedCourseIds]);
+
+  const addCourseGrant = useCallback(
+    async (courseId: string) => {
+      // Optimistic insert with a temporary id so React keys stay
+      // stable; real id replaces it when the POST resolves.
+      const temp: StudyGuideGrantResponse = {
+        id: `optimistic-${courseId}`,
+        study_guide_id: studyGuideId,
+        grantee_type: "course",
+        grantee_id: courseId,
+        permission: "view",
+        granted_by: "",
+        created_at: new Date().toISOString(),
+      };
+      setGrants((prev) => [...prev, temp]);
+      setQuery("");
+      try {
+        const created = await createStudyGuideGrant(studyGuideId, {
+          grantee_type: "course",
+          grantee_id: courseId,
+          permission: "view",
+        });
+        setGrants((prev) =>
+          prev.map((grant) => (grant.id === temp.id ? created : grant)),
+        );
+      } catch (error: unknown) {
+        setGrants((prev) => prev.filter((grant) => grant.id !== temp.id));
+        toast.error(error);
+      }
+    },
+    [studyGuideId],
+  );
+
+  const removeGrant = useCallback(
+    async (grant: StudyGuideGrantResponse) => {
+      const snapshot = grants;
+      setGrants((prev) => prev.filter((existing) => existing.id !== grant.id));
+      try {
+        await revokeStudyGuideGrant(studyGuideId, {
+          grantee_type: grant.grantee_type as "course" | "user",
+          grantee_id: grant.grantee_id,
+          permission: grant.permission as "view" | "share" | "delete",
+        });
+      } catch (error: unknown) {
+        setGrants(snapshot);
+        toast.error(error);
+      }
+    },
+    [grants, studyGuideId],
+  );
+
+  const courseGrants = grants.filter(
+    (grant) => grant.grantee_type === "course",
+  );
+  const userGrants = grants.filter((grant) => grant.grantee_type === "user");
+  const showPeoplePlaceholder = debouncedQuery.startsWith("@");
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <p className="text-foreground text-xs font-medium">Share with</p>
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search your courses"
+          aria-label="Search courses or people"
+          className="h-8 text-xs"
+        />
+      </div>
+
+      {isLoading ? (
+        <div className="text-muted-foreground flex items-center gap-2 text-xs">
+          <Loader2 className="size-3 animate-spin" aria-hidden />
+          Loading grants…
+        </div>
+      ) : null}
+
+      {!isLoading && debouncedQuery !== "" ? (
+        showPeoplePlaceholder ? (
+          // TODO(ASK-212-followup): wire up user search once a
+          // `/users/search` endpoint exists. The `@` prefix signals
+          // "search people" today but we stub it out.
+          <p className="text-muted-foreground rounded-md border border-dashed px-2 py-1.5 text-xs">
+            People search coming soon.
+          </p>
+        ) : filteredCourses.length === 0 ? (
+          <p className="text-muted-foreground text-xs">No matching courses.</p>
+        ) : (
+          <ul className="space-y-1">
+            {filteredCourses.map((course) => (
+              <li key={course.id}>
+                <button
+                  type="button"
+                  onClick={() => void addCourseGrant(course.id)}
+                  className="hover:bg-muted focus-visible:ring-ring w-full rounded-md px-2 py-1.5 text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-1"
+                >
+                  <span className="font-medium">
+                    {course.department} {course.number}
+                  </span>
+                  <span className="text-muted-foreground ml-1">
+                    · {course.title}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )
+      ) : null}
+
+      {!isLoading ? (
+        <div className="space-y-2">
+          <GrantGroup
+            title="Courses"
+            grants={courseGrants}
+            enrollments={enrollments}
+            onRemove={removeGrant}
+          />
+          <GrantGroup
+            title="People"
+            grants={userGrants}
+            enrollments={enrollments}
+            onRemove={removeGrant}
+          />
+          {courseGrants.length === 0 && userGrants.length === 0 ? (
+            <p className="text-muted-foreground text-xs">
+              No shares yet. Search above to add a course.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface GrantGroupProps {
+  title: string;
+  grants: StudyGuideGrantResponse[];
+  enrollments: EnrollmentResponse[];
+  onRemove: (grant: StudyGuideGrantResponse) => void;
+}
+
+function GrantGroup({ title, grants, enrollments, onRemove }: GrantGroupProps) {
+  if (grants.length === 0) return null;
+  return (
+    <div className="space-y-1">
+      <p className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+        {title}
+      </p>
+      <div className="flex flex-wrap gap-1">
+        {grants.map((grant) => (
+          <GrantChip
+            key={grant.id}
+            grant={grant}
+            enrollments={enrollments}
+            onRemove={onRemove}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface GrantChipProps {
+  grant: StudyGuideGrantResponse;
+  enrollments: EnrollmentResponse[];
+  onRemove: (grant: StudyGuideGrantResponse) => void;
+}
+
+function GrantChip({ grant, enrollments, onRemove }: GrantChipProps) {
+  const label =
+    grant.grantee_type === "course"
+      ? formatCourseLabel(grant.grantee_id, enrollments)
+      : "User";
+  return (
+    <Badge
+      variant="secondary"
+      className="gap-1 pl-2 pr-1 text-xs font-normal"
+      data-testid={`grant-chip-${grant.grantee_id}`}
+    >
+      {label}
+      <button
+        type="button"
+        aria-label={`Remove ${label}`}
+        onClick={() => onRemove(grant)}
+        className="hover:bg-muted-foreground/20 focus-visible:ring-ring -mr-0.5 inline-flex size-4 items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-1"
+      >
+        <X className="size-3" aria-hidden />
+      </button>
+    </Badge>
+  );
+}
+
+function formatCourseLabel(
+  courseId: string,
+  enrollments: EnrollmentResponse[],
+): string {
+  const match = enrollments.find(
+    (enrollment) => enrollment.course.id === courseId,
+  );
+  if (!match) return "Course";
+  return `${match.course.department} ${match.course.number}`;
+}

--- a/web/lib/features/dashboard/study-guides/study-guide-card.stories.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-card.stories.tsx
@@ -15,6 +15,7 @@ function makeGuide(
     is_recommended: true,
     tags: ["week 6", "midterm", "eigen"],
     course_id: "c_math340",
+    visibility: "private",
     ...overrides,
   };
 }
@@ -110,5 +111,36 @@ export const LongTitleOverflow: Story = {
     }),
     variant: "list",
     courseLabel: "MATH 340",
+  },
+};
+
+export const PublicIndicator: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Public study guides surface a globe icon next to the title (tooltip: Public).",
+      },
+    },
+  },
+  args: {
+    guide: makeGuide({ visibility: "public" }),
+    variant: "list",
+    courseLabel: "MATH 340",
+  },
+};
+
+export const PrivateIndicatorCompact: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Private study guides show a lock icon even on the compact card variant.",
+      },
+    },
+  },
+  args: {
+    guide: makeGuide({ visibility: "private" }),
+    variant: "compact",
   },
 };

--- a/web/lib/features/dashboard/study-guides/study-guide-card.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-card.tsx
@@ -1,6 +1,12 @@
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
-import { ThumbsUp } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Globe2, Lock, ThumbsUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface StudyGuideListItemResponse {
@@ -12,6 +18,11 @@ export interface StudyGuideListItemResponse {
   is_recommended: boolean;
   tags: string[];
   course_id: string;
+  // ASK-212: every list item carries the canonical visibility flag.
+  // The list response does NOT include a grant count, so we can only
+  // distinguish `private` vs `public` here; the "Shared" indicator
+  // (private + >=1 grant) surfaces on the detail page instead.
+  visibility: "private" | "public";
 }
 
 interface StudyGuideCardProps {
@@ -51,9 +62,12 @@ export function StudyGuideCard({
 function CompactVariant({ guide }: { guide: StudyGuideListItemResponse }) {
   return (
     <div className="space-y-1">
-      <p className="line-clamp-2 text-sm font-medium leading-snug text-foreground">
-        {guide.title}
-      </p>
+      <div className="flex items-start gap-1.5">
+        <p className="line-clamp-2 flex-1 text-sm font-medium leading-snug text-foreground">
+          {guide.title}
+        </p>
+        <VisibilityIndicator visibility={guide.visibility} />
+      </div>
       <p className="text-xs text-muted-foreground">
         by {guide.creator.display_name} ·{" "}
         {guide.quiz_count === 1 ? "1 quiz" : `${guide.quiz_count} quizzes`}
@@ -72,9 +86,12 @@ function ListVariant({
   return (
     <div className="space-y-3">
       <div className="flex items-start justify-between gap-2">
-        <p className="line-clamp-2 text-sm font-bold leading-snug text-foreground">
-          {guide.title}
-        </p>
+        <div className="flex min-w-0 flex-1 items-start gap-1.5">
+          <p className="line-clamp-2 flex-1 text-sm font-bold leading-snug text-foreground">
+            {guide.title}
+          </p>
+          <VisibilityIndicator visibility={guide.visibility} />
+        </div>
         {guide.is_recommended && (
           <Badge
             variant="secondary"
@@ -120,5 +137,32 @@ function ListVariant({
         </div>
       )}
     </div>
+  );
+}
+
+function VisibilityIndicator({
+  visibility,
+}: {
+  visibility: StudyGuideListItemResponse["visibility"];
+}) {
+  const { Icon, label } =
+    visibility === "public"
+      ? { Icon: Globe2, label: "Public" }
+      : { Icon: Lock, label: "Private" };
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            role="img"
+            aria-label={label}
+            className="text-muted-foreground mt-0.5 inline-flex shrink-0"
+          >
+            <Icon className="size-3.5" aria-hidden />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/web/lib/features/dashboard/study-guides/study-guide-form.stories.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.stories.tsx
@@ -118,3 +118,37 @@ export const EditEmptyTags: Story = {
     onCancel: () => {},
   },
 };
+
+export const CreatePublic: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Create mode with the visibility chip pre-flipped to Public. Clicking the chip opens the popover showing the Private/Public segmented control plus a hint that grants require saving the guide first.",
+      },
+    },
+  },
+  args: {
+    mode: "create",
+    initial: makeStudyGuide({ visibility: "public" }),
+    onSubmit: resolveAfter(500),
+    onCancel: () => {},
+  },
+};
+
+export const EditWithGrantsStub: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Edit mode variant for the visibility popover. The popover mounts the GrantsManager which issues a network request -- in Storybook that request fails and the manager falls back to its 'No shares yet' state. Demonstrates the chip surface; real grant flows are covered by the Jest/RTL tests.",
+      },
+    },
+  },
+  args: {
+    mode: "edit",
+    initial: makeStudyGuide({ visibility: "private" }),
+    onSubmit: resolveAfter(500),
+    onCancel: () => {},
+  },
+};

--- a/web/lib/features/dashboard/study-guides/study-guide-form.stories.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.stories.tsx
@@ -2,7 +2,26 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import type { StudyGuideDetailResponse } from "@/lib/api/types";
 
+import type { GrantsManagerActions } from "./grants-manager";
 import { StudyGuideForm } from "./study-guide-form";
+
+// Storybook can't reach the real server actions (Vite would pull in
+// `@clerk/nextjs/server` which is Node-only). Provide a stub bag so
+// the GrantsManager mounts and lands in its "No shares yet" state.
+const stubGrantActions: GrantsManagerActions = {
+  listGrants: async () => ({ grants: [] }),
+  listEnrollments: async () => ({ enrollments: [] }),
+  createGrant: async (studyGuideId, body) => ({
+    id: "preview-grant",
+    study_guide_id: studyGuideId,
+    grantee_type: body.grantee_type,
+    grantee_id: body.grantee_id,
+    permission: body.permission,
+    granted_by: "u_preview_1",
+    created_at: "2026-04-01T00:00:00Z",
+  }),
+  revokeGrant: async () => {},
+};
 
 function makeStudyGuide(
   overrides: Partial<StudyGuideDetailResponse> = {},
@@ -29,8 +48,8 @@ function makeStudyGuide(
     quizzes: [],
     resources: [],
     files: [],
-    created_at: new Date(Date.now() - 7 * 86_400_000).toISOString(),
-    updated_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    created_at: "2026-04-17T00:00:00Z",
+    updated_at: "2026-04-22T00:00:00Z",
     ...overrides,
   } as StudyGuideDetailResponse;
 }
@@ -141,7 +160,7 @@ export const EditWithGrantsStub: Story = {
     docs: {
       description: {
         story:
-          "Edit mode variant for the visibility popover. The popover mounts the GrantsManager which issues a network request -- in Storybook that request fails and the manager falls back to its 'No shares yet' state. Demonstrates the chip surface; real grant flows are covered by the Jest/RTL tests.",
+          "Edit mode variant for the visibility popover. Click the chip to see the Private/Public toggle plus the GrantsManager surface. Storybook injects stub actions so the manager lands in its 'No shares yet' state -- real grant flows are covered by the Jest/RTL tests.",
       },
     },
   },
@@ -150,5 +169,6 @@ export const EditWithGrantsStub: Story = {
     initial: makeStudyGuide({ visibility: "private" }),
     onSubmit: resolveAfter(500),
     onCancel: () => {},
+    grantActions: stubGrantActions,
   },
 };

--- a/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
@@ -47,6 +47,15 @@ jest.mock("./content-editor", () => {
   };
 });
 
+// GrantsManager issues network calls on mount (listStudyGuideGrants +
+// listMyEnrollments). The form-level tests assert chip presence and
+// popover branching only, so we stub the manager to a sentinel node.
+jest.mock("./grants-manager", () => ({
+  GrantsManager: ({ studyGuideId }: { studyGuideId: string }) => (
+    <div data-testid="grants-manager-stub">grants:{studyGuideId}</div>
+  ),
+}));
+
 import type { StudyGuideDetailResponse } from "@/lib/api/types";
 
 import { StudyGuideForm, type StudyGuideFormHandle } from "./study-guide-form";
@@ -114,6 +123,7 @@ describe("StudyGuideForm / create mode", () => {
       title: "Concurrency notes",
       content: "# Overview\n\nMutexes, semaphores, and monitors.",
       tags: ["concurrency", "threads", "systems"],
+      visibility: "private",
     });
   });
 
@@ -346,5 +356,106 @@ describe("StudyGuideForm / server error surface (AC5)", () => {
     await waitFor(() =>
       expect(screen.getByText("Title already taken")).toBeInTheDocument(),
     );
+  });
+});
+
+describe("StudyGuideForm / visibility (ASK-212)", () => {
+  async function fillRequiredFields(
+    user: ReturnType<typeof userEvent.setup>,
+  ) {
+    await user.type(screen.getByLabelText(/title/i), "Visibility demo");
+    await user.type(
+      screen.getByLabelText(/content/i),
+      "Body long enough to pass validation.",
+    );
+  }
+
+  it("defaults to Private in create mode and submits visibility=private", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    render(
+      <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
+    );
+    expect(
+      screen.getByRole("button", { name: /visibility: private/i }),
+    ).toBeInTheDocument();
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ visibility: "private" }),
+    );
+  });
+
+  it("flips to Public via the popover radio and submits visibility=public", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    render(
+      <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
+    );
+    await fillRequiredFields(user);
+    await user.click(
+      screen.getByRole("button", { name: /visibility: private/i }),
+    );
+    await user.click(await screen.findByRole("radio", { name: /public/i }));
+    // Chip label should reflect the new selection immediately.
+    expect(
+      await screen.findByRole("button", { name: /visibility: public/i }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ visibility: "public" }),
+    );
+  });
+
+  it("reads Public from initial.visibility in edit mode", () => {
+    render(
+      <StudyGuideForm
+        mode="edit"
+        initial={makeStudyGuide({ visibility: "public" })}
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /visibility: public/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the grants manager in create mode and shows the save-first hint", async () => {
+    const user = userEvent.setup();
+    render(
+      <StudyGuideForm
+        mode="create"
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /visibility: private/i }),
+    );
+    expect(
+      await screen.findByText(/save the guide first to share/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("grants-manager-stub")).not.toBeInTheDocument();
+  });
+
+  it("mounts the grants manager inside the popover in edit mode", async () => {
+    const user = userEvent.setup();
+    render(
+      <StudyGuideForm
+        mode="edit"
+        initial={makeStudyGuide({ visibility: "private" })}
+        onSubmit={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /visibility: private/i }),
+    );
+    expect(
+      await screen.findByTestId("grants-manager-stub"),
+    ).toBeInTheDocument();
   });
 });

--- a/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
@@ -58,6 +58,7 @@ jest.mock("./grants-manager", () => ({
 
 import type { StudyGuideDetailResponse } from "@/lib/api/types";
 
+import type { GrantsManagerActions } from "./grants-manager";
 import { StudyGuideForm, type StudyGuideFormHandle } from "./study-guide-form";
 
 function makeStudyGuide(
@@ -443,12 +444,19 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
 
   it("mounts the grants manager inside the popover in edit mode", async () => {
     const user = userEvent.setup();
+    const stubActions: GrantsManagerActions = {
+      listGrants: jest.fn().mockResolvedValue({ grants: [] }),
+      listEnrollments: jest.fn().mockResolvedValue({ enrollments: [] }),
+      createGrant: jest.fn(),
+      revokeGrant: jest.fn(),
+    };
     render(
       <StudyGuideForm
         mode="edit"
         initial={makeStudyGuide({ visibility: "private" })}
         onSubmit={jest.fn()}
         onCancel={jest.fn()}
+        grantActions={stubActions}
       />,
     );
     await user.click(

--- a/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
@@ -363,9 +363,7 @@ describe("StudyGuideForm / server error surface (AC5)", () => {
 });
 
 describe("StudyGuideForm / visibility (ASK-212)", () => {
-  async function fillRequiredFields(
-    user: ReturnType<typeof userEvent.setup>,
-  ) {
+  async function fillRequiredFields(user: ReturnType<typeof userEvent.setup>) {
     await user.type(screen.getByLabelText(/title/i), "Visibility demo");
     await user.type(
       screen.getByLabelText(/content/i),

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -6,6 +6,7 @@ import {
   forwardRef,
   type ForwardedRef,
   type KeyboardEvent,
+  useCallback,
   useImperativeHandle,
   useRef,
   useState,
@@ -25,9 +26,12 @@ import {
 import { Input } from "@/components/ui/input";
 
 import { ContentEditor } from "./content-editor";
+import { GrantsManager } from "./grants-manager";
+import { VisibilityChip } from "./visibility-chip";
 import type {
   CreateStudyGuideRequest,
   StudyGuideDetailResponse,
+  StudyGuideVisibility,
   UpdateStudyGuideRequest,
 } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
@@ -39,6 +43,7 @@ const schema = z.object({
   title: z.string().min(3, "Title must be at least 3 characters"),
   content: z.string().min(10, "Content must be at least 10 characters"),
   tags: z.array(z.string()),
+  visibility: z.enum(["private", "public"]),
 });
 
 type FormValues = z.infer<typeof schema>;
@@ -87,8 +92,17 @@ export const StudyGuideForm = forwardRef<
       title: initial?.title ?? "",
       content: initial?.content ?? "",
       tags: initial?.tags ?? [],
+      visibility:
+        (initial?.visibility as StudyGuideVisibility | undefined) ?? "private",
     },
   });
+
+  // Tracks the current grant count so the chip can show "Shared · N"
+  // even before the form field changes. Only relevant in edit mode.
+  const [grantCount, setGrantCount] = useState(0);
+  const handleGrantCountChange = useCallback((count: number) => {
+    setGrantCount(count);
+  }, []);
 
   useImperativeHandle(
     ref,
@@ -105,6 +119,7 @@ export const StudyGuideForm = forwardRef<
       title: values.title,
       content: values.content,
       tags: values.tags,
+      visibility: values.visibility,
     });
   };
 
@@ -161,29 +176,56 @@ export const StudyGuideForm = forwardRef<
           )}
         />
         <div className="mt-6 flex flex-col gap-3 border-t pt-4 md:flex-row md:items-start md:justify-between">
-          <FormField
-            control={form.control}
-            name="tags"
-            render={({ field }) => (
-              <FormItem className="w-full space-y-1 md:max-w-xl md:flex-1">
-                <FormControl>
-                  <div className="flex items-start gap-2">
-                    <Tag
-                      className="text-muted-foreground mt-2 size-4 shrink-0"
-                      aria-hidden
-                    />
-                    <TagChipsInput
-                      value={field.value}
-                      onChange={field.onChange}
+          <div className="flex w-full flex-col gap-3 md:max-w-xl md:flex-1 md:flex-row md:items-start">
+            <FormField
+              control={form.control}
+              name="tags"
+              render={({ field }) => (
+                <FormItem className="w-full space-y-1 md:flex-1">
+                  <FormControl>
+                    <div className="flex items-start gap-2">
+                      <Tag
+                        className="text-muted-foreground mt-2 size-4 shrink-0"
+                        aria-hidden
+                      />
+                      <TagChipsInput
+                        value={field.value}
+                        onChange={field.onChange}
+                        disabled={isSubmitting}
+                        className="flex-1"
+                      />
+                    </div>
+                  </FormControl>
+                  <FormMessage className="px-0" />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="visibility"
+              render={({ field }) => (
+                <FormItem className="space-y-1">
+                  <FormControl>
+                    <VisibilityChip
+                      visibility={field.value}
+                      grantCount={mode === "edit" ? grantCount : 0}
                       disabled={isSubmitting}
-                      className="flex-1"
-                    />
-                  </div>
-                </FormControl>
-                <FormMessage className="px-0" />
-              </FormItem>
-            )}
-          />
+                    >
+                      <VisibilityPopoverBody
+                        mode={mode}
+                        studyGuideId={initial?.id}
+                        value={field.value}
+                        onChange={field.onChange}
+                        disabled={isSubmitting}
+                        onGrantCountChange={handleGrantCountChange}
+                      />
+                    </VisibilityChip>
+                  </FormControl>
+                  <FormMessage className="px-0" />
+                </FormItem>
+              )}
+            />
+          </div>
           <div className="flex shrink-0 justify-end gap-2">
             <Button
               type="button"
@@ -331,6 +373,77 @@ function TagChipsInput({
           <span aria-hidden>+</span>
           {value.length === 0 ? "Add tags" : "Add tag"}
         </button>
+      )}
+    </div>
+  );
+}
+
+interface VisibilityPopoverBodyProps {
+  mode: "create" | "edit";
+  studyGuideId: string | undefined;
+  value: StudyGuideVisibility;
+  onChange: (next: StudyGuideVisibility) => void;
+  disabled: boolean;
+  onGrantCountChange: (count: number) => void;
+}
+
+/**
+ * Popover body rendered inside `VisibilityChip`: a Private/Public
+ * segmented control on top, and (edit-mode only) the GrantsManager
+ * below. In create mode we show a short hint explaining the guide
+ * must be saved before grants can be attached.
+ */
+function VisibilityPopoverBody({
+  mode,
+  studyGuideId,
+  value,
+  onChange,
+  disabled,
+  onGrantCountChange,
+}: VisibilityPopoverBodyProps) {
+  const options: Array<{ id: StudyGuideVisibility; label: string }> = [
+    { id: "private", label: "Private" },
+    { id: "public", label: "Public" },
+  ];
+  return (
+    <div className="space-y-3">
+      <div
+        role="radiogroup"
+        aria-label="Visibility"
+        className="bg-muted flex rounded-md p-0.5"
+      >
+        {options.map((option) => {
+          const checked = value === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              role="radio"
+              aria-checked={checked}
+              disabled={disabled}
+              onClick={() => onChange(option.id)}
+              className={cn(
+                "flex-1 rounded-sm px-2 py-1 text-xs transition-colors",
+                "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
+                checked
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+      {mode === "edit" && studyGuideId ? (
+        <GrantsManager
+          studyGuideId={studyGuideId}
+          onGrantCountChange={onGrantCountChange}
+        />
+      ) : (
+        <p className="text-muted-foreground text-xs">
+          Save the guide first to share with courses or people.
+        </p>
       )}
     </div>
   );

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -26,7 +26,10 @@ import {
 import { Input } from "@/components/ui/input";
 
 import { ContentEditor } from "./content-editor";
-import { GrantsManager } from "./grants-manager";
+import {
+  GrantsManager,
+  type GrantsManagerActions,
+} from "./grants-manager";
 import { VisibilityChip } from "./visibility-chip";
 import type {
   CreateStudyGuideRequest,
@@ -73,13 +76,19 @@ interface StudyGuideFormProps {
     body: CreateStudyGuideRequest | UpdateStudyGuideRequest,
   ) => Promise<void>;
   onCancel: () => void;
+  /**
+   * Server-action bag for the GrantsManager (edit mode only). Pages
+   * inject the real actions; tests/Storybook inject mocks. Omitting
+   * this falls back to the same "save first" hint as create mode.
+   */
+  grantActions?: GrantsManagerActions;
 }
 
 export const StudyGuideForm = forwardRef<
   StudyGuideFormHandle,
   StudyGuideFormProps
 >(function StudyGuideForm(
-  { mode, initial, onSubmit, onCancel },
+  { mode, initial, onSubmit, onCancel, grantActions },
   ref: ForwardedRef<StudyGuideFormHandle>,
 ) {
   const form = useForm<FormValues>({
@@ -92,8 +101,7 @@ export const StudyGuideForm = forwardRef<
       title: initial?.title ?? "",
       content: initial?.content ?? "",
       tags: initial?.tags ?? [],
-      visibility:
-        (initial?.visibility as StudyGuideVisibility | undefined) ?? "private",
+      visibility: initial?.visibility ?? "private",
     },
   });
 
@@ -115,11 +123,16 @@ export const StudyGuideForm = forwardRef<
   const { isSubmitting, isValid } = form.formState;
 
   const handleSubmit = async (values: FormValues) => {
+    // Only forward `visibility` when it actually changed (or in create
+    // mode). PATCH-ing it on every save would silently force pre-
+    // backfill rows with a missing/null visibility into "private".
+    const visibilityChanged =
+      mode === "create" || initial?.visibility !== values.visibility;
     await onSubmit({
       title: values.title,
       content: values.content,
       tags: values.tags,
-      visibility: values.visibility,
+      ...(visibilityChanged ? { visibility: values.visibility } : {}),
     });
   };
 
@@ -218,6 +231,7 @@ export const StudyGuideForm = forwardRef<
                         onChange={field.onChange}
                         disabled={isSubmitting}
                         onGrantCountChange={handleGrantCountChange}
+                        grantActions={grantActions}
                       />
                     </VisibilityChip>
                   </FormControl>
@@ -385,13 +399,14 @@ interface VisibilityPopoverBodyProps {
   onChange: (next: StudyGuideVisibility) => void;
   disabled: boolean;
   onGrantCountChange: (count: number) => void;
+  grantActions: GrantsManagerActions | undefined;
 }
 
 /**
  * Popover body rendered inside `VisibilityChip`: a Private/Public
  * segmented control on top, and (edit-mode only) the GrantsManager
- * below. In create mode we show a short hint explaining the guide
- * must be saved before grants can be attached.
+ * below. In create mode -- or when `grantActions` is omitted (e.g.
+ * Storybook) -- we show a short hint instead of the manager.
  */
 function VisibilityPopoverBody({
   mode,
@@ -400,16 +415,37 @@ function VisibilityPopoverBody({
   onChange,
   disabled,
   onGrantCountChange,
+  grantActions,
 }: VisibilityPopoverBodyProps) {
   const options: Array<{ id: StudyGuideVisibility; label: string }> = [
     { id: "private", label: "Private" },
     { id: "public", label: "Public" },
   ];
+  // Arrow keys move focus + selection between the two radios per the
+  // ARIA radiogroup pattern. Tab moves out of the group entirely so
+  // only the selected radio is in the tab order (`tabIndex` below).
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.key !== "ArrowLeft" &&
+      event.key !== "ArrowRight" &&
+      event.key !== "ArrowUp" &&
+      event.key !== "ArrowDown"
+    ) {
+      return;
+    }
+    event.preventDefault();
+    const currentIndex = options.findIndex((option) => option.id === value);
+    const direction =
+      event.key === "ArrowRight" || event.key === "ArrowDown" ? 1 : -1;
+    const next = options[(currentIndex + direction + options.length) % options.length]!;
+    onChange(next.id);
+  };
   return (
     <div className="space-y-3">
       <div
         role="radiogroup"
         aria-label="Visibility"
+        onKeyDown={handleKeyDown}
         className="bg-muted flex rounded-md p-0.5"
       >
         {options.map((option) => {
@@ -420,6 +456,7 @@ function VisibilityPopoverBody({
               type="button"
               role="radio"
               aria-checked={checked}
+              tabIndex={checked ? 0 : -1}
               disabled={disabled}
               onClick={() => onChange(option.id)}
               className={cn(
@@ -435,9 +472,10 @@ function VisibilityPopoverBody({
           );
         })}
       </div>
-      {mode === "edit" && studyGuideId ? (
+      {mode === "edit" && studyGuideId && grantActions ? (
         <GrantsManager
           studyGuideId={studyGuideId}
+          actions={grantActions}
           onGrantCountChange={onGrantCountChange}
         />
       ) : (

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -26,10 +26,7 @@ import {
 import { Input } from "@/components/ui/input";
 
 import { ContentEditor } from "./content-editor";
-import {
-  GrantsManager,
-  type GrantsManagerActions,
-} from "./grants-manager";
+import { GrantsManager, type GrantsManagerActions } from "./grants-manager";
 import { VisibilityChip } from "./visibility-chip";
 import type {
   CreateStudyGuideRequest,
@@ -437,7 +434,8 @@ function VisibilityPopoverBody({
     const currentIndex = options.findIndex((option) => option.id === value);
     const direction =
       event.key === "ArrowRight" || event.key === "ArrowDown" ? 1 : -1;
-    const next = options[(currentIndex + direction + options.length) % options.length]!;
+    const next =
+      options[(currentIndex + direction + options.length) % options.length]!;
     onChange(next.id);
   };
   return (

--- a/web/lib/features/dashboard/study-guides/visibility-chip.tsx
+++ b/web/lib/features/dashboard/study-guides/visibility-chip.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Globe2, Lock, Users2 } from "lucide-react";
+import type { ReactNode } from "react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { StudyGuideVisibility } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+
+/**
+ * Footer chip that exposes the current visibility state of a study
+ * guide. Clicking opens a popover (`children`) where the caller wires
+ * up the Private/Public toggle + grants manager.
+ *
+ * The "Shared" label surfaces whenever `visibility === "private"` AND
+ * the caller passes `grantCount >= 1`; otherwise the label tracks
+ * `visibility` verbatim. Keeping the display logic here keeps the
+ * form module focused on its react-hook-form wiring.
+ */
+
+export interface VisibilityChipProps {
+  visibility: StudyGuideVisibility;
+  /** Popover surface contents. Usually a toggle + (optional) grants manager. */
+  children: ReactNode;
+  /**
+   * Number of non-creator grants on the guide. When `visibility` is
+   * `private` AND this is `>= 1`, the chip shows "Shared · N" instead.
+   * Omit / pass 0 in create mode where grants cannot exist yet.
+   */
+  grantCount?: number;
+  disabled?: boolean;
+  /** Hidden but helpful for downstream assertions + a11y. */
+  id?: string;
+}
+
+interface ChipDisplay {
+  icon: typeof Lock;
+  label: string;
+  tooltip: string;
+}
+
+function resolveDisplay(
+  visibility: StudyGuideVisibility,
+  grantCount: number,
+): ChipDisplay {
+  if (visibility === "public") {
+    return {
+      icon: Globe2,
+      label: "Public",
+      tooltip: "Anyone with the link can view",
+    };
+  }
+  if (grantCount >= 1) {
+    return {
+      icon: Users2,
+      label: `Shared · ${grantCount}`,
+      tooltip: `Private with ${grantCount} share${grantCount === 1 ? "" : "s"}`,
+    };
+  }
+  return {
+    icon: Lock,
+    label: "Private",
+    tooltip: "Only you can view",
+  };
+}
+
+export function VisibilityChip({
+  visibility,
+  children,
+  grantCount = 0,
+  disabled = false,
+  id,
+}: VisibilityChipProps) {
+  const display = resolveDisplay(visibility, grantCount);
+  const Icon = display.icon;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          id={id}
+          disabled={disabled}
+          aria-label={`Visibility: ${display.label}`}
+          title={display.tooltip}
+          className={cn(
+            "text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring",
+            "inline-flex h-7 items-center gap-1.5 rounded-full border border-dashed px-3 text-xs",
+            "transition-colors focus-visible:outline-none focus-visible:ring-2",
+            "disabled:cursor-not-allowed disabled:opacity-60",
+          )}
+        >
+          <Icon className="size-3.5 shrink-0" aria-hidden />
+          <span>{display.label}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80 space-y-3">
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/lib/features/dashboard/study-guides/visibility-chip.tsx
+++ b/web/lib/features/dashboard/study-guides/visibility-chip.tsx
@@ -89,7 +89,7 @@ export function VisibilityChip({
           title={display.tooltip}
           className={cn(
             "text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring",
-            "inline-flex h-7 items-center gap-1.5 rounded-full border border-dashed px-3 text-xs",
+            "inline-flex h-7 min-w-24 items-center justify-center gap-1.5 rounded-full border border-dashed px-3 text-xs",
             "transition-colors focus-visible:outline-none focus-visible:ring-2",
             "disabled:cursor-not-allowed disabled:opacity-60",
           )}


### PR DESCRIPTION
## Summary

Implements the ASK-212 frontend for study-guide visibility + share UI:

- Footer visibility chip on `StudyGuideForm` with a Private/Public segmented control in a popover; in edit mode the popover also mounts an inline `GrantsManager` (list + course search + remove) with optimistic updates and toast rollback.
- Study-guide cards show a lock or globe indicator next to the title (tooltip: Private / Public).
- New `Popover` UI primitive (wraps `radix-ui/Popover`, matching existing shadcn styling).
- Server actions + type aliases for `GET/POST/DELETE /study-guides/{id}/grants`, wired through the `@/lib/api` barrel.

## AC coverage

1. New guide form loads with `Private` — covered (form defaults + test).
2. Toggling to `Public` + save — covered (test asserts submit body).
3. Grants popover search + `POST /grants` — covered (tests + component).
4. `×` on grant chip with optimistic rollback on failure — covered (tests).
5. `visibility=private` with grants shows "Shared · N" on the detail chip — covered in the chip itself. List cards deliberately show only Private/Public because the list response does not carry a grant count; noted in code.
6. Private default from course context — backend auto-seeds, no frontend work required.

## Out of scope / deferred

- **Playwright happy-path e2e** — deferred. The existing harness at `api/e2e/` is single-token and this path needs two users; filed as follow-up.
- **User (people) search** — deferred. The grants popover accepts `@<query>` as a placeholder and renders a "People search coming soon" hint. TODO marker left in the code for a follow-up ticket once a `/users/search` endpoint lands.
- **"Shared" indicator on list cards** — the list response does not include a grant count, so list cards only distinguish Private vs Public. Documented inline.

## Deviations from the brief

- The `radix-ui` combined package is already at `^1.4.3` in `package.json` and re-exports `Popover`, so no new `@radix-ui/react-popover` install was needed; `components/ui/popover.tsx` uses the same `import { Popover as PopoverPrimitive } from "radix-ui"` pattern as `dropdown-menu.tsx`.
- `grants-manager.tsx` is 322 lines (the brief suggested under 250). The file is cohesive (one state owner + three tiny helper components) and well under the 800-line cap, so I left it rather than fragment the optimistic-state ownership.

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] `npm run lint` — no new errors or warnings from these files (existing noise is from `storybook-static/`).
- [x] `npx jest lib/features/dashboard/study-guides` — 80 passed / 0 failed (3 skipped pre-existing).
  - New: 19 tests in `study-guide-form.test.tsx` (5 new for visibility/grants gating).
  - New: 7 tests in `grants-manager.test.tsx` (load, add optimistic, add rollback, remove optimistic, remove rollback, people-search placeholder).
- [ ] Manual smoke via `npm run dev` — not run in this session; please verify the popover opens, the segmented control toggles, and the chip label updates.
- [ ] Storybook: new stories `CreatePublic`, `EditWithGrantsStub`, `PublicIndicator`, `PrivateIndicatorCompact` — please verify visually.

## Follow-up tickets to file

- Playwright e2e for the two-user share happy path once the e2e harness supports multiple tokens.
- User search endpoint + wire the `@`-prefixed branch in `grants-manager.tsx` once the API is available.
- Include `grant_count` on `StudyGuideListItemResponse` so list cards can show the "Shared · N" state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Study guides now have visibility (Public / Private) with a visibility chip and popover control.
  * You can share/unshare guides with courses and people via a Grants manager in edit mode; shares show optimistic updates and error toasts on failure.
  * Study guide cards show a visibility indicator (globe/lock) and grant counts where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->