### PR TITLE
feat(web): course search bar primitive (ASK-181)

### DIFF
--- a/web/components/ui/search-input.stories.tsx
+++ b/web/components/ui/search-input.stories.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { SearchInput } from "./search-input";
+
+const meta: Meta<typeof SearchInput> = {
+  title: "UI/SearchInput",
+  component: SearchInput,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          'Generic search primitive: icon-prefixed `<input type="search">` with an optional trailing clear button. Controlled — the consumer owns state and can debounce externally with `useDebouncedValue`.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[380px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SearchInput>;
+
+function Controlled({
+  initial = "",
+  clearable = false,
+}: {
+  initial?: string;
+  clearable?: boolean;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <SearchInput
+      placeholder="Search courses…"
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onClear={clearable ? () => setValue("") : undefined}
+    />
+  );
+}
+
+export const Empty: Story = {
+  render: () => <Controlled />,
+};
+
+export const WithValue: Story = {
+  render: () => <Controlled initial="algorithms" />,
+};
+
+export const Clearable: Story = {
+  render: () => <Controlled initial="algorithms" clearable />,
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <SearchInput
+      placeholder="Search courses…"
+      value="algorithms"
+      onChange={() => {}}
+      disabled
+    />
+  ),
+};

--- a/web/components/ui/search-input.test.tsx
+++ b/web/components/ui/search-input.test.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { SearchInput } from "./search-input";
+
+function ControlledHarness(props: {
+  initial?: string;
+  withClear?: boolean;
+  clearLabel?: string;
+}) {
+  const [value, setValue] = useState(props.initial ?? "");
+  return (
+    <SearchInput
+      placeholder="Search…"
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onClear={props.withClear ? () => setValue("") : undefined}
+      clearLabel={props.clearLabel}
+    />
+  );
+}
+
+describe("SearchInput", () => {
+  it("renders a controlled search input that reflects typed values", () => {
+    render(<ControlledHarness />);
+    const input = screen.getByPlaceholderText("Search…") as HTMLInputElement;
+    expect(input.type).toBe("text");
+    expect(input.getAttribute("role")).toBe("searchbox");
+    fireEvent.change(input, { target: { value: "algo" } });
+    expect(input.value).toBe("algo");
+  });
+
+  it("hides the clear button when value is empty even if onClear is provided", () => {
+    render(<ControlledHarness withClear />);
+    expect(
+      screen.queryByRole("button", { name: "Clear search" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the clear button when onClear is omitted (uncleardable mode)", () => {
+    render(<ControlledHarness initial="algo" />);
+    expect(
+      screen.queryByRole("button", { name: "Clear search" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the clear button when value is non-empty and clears on click", () => {
+    render(<ControlledHarness initial="algo" withClear />);
+    const input = screen.getByPlaceholderText("Search…") as HTMLInputElement;
+    const clear = screen.getByRole("button", { name: "Clear search" });
+    fireEvent.click(clear);
+    expect(input.value).toBe("");
+    expect(
+      screen.queryByRole("button", { name: "Clear search" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("honors a custom clearLabel for localization", () => {
+    render(
+      <ControlledHarness initial="algo" withClear clearLabel="Effacer" />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Effacer" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/components/ui/search-input.test.tsx
+++ b/web/components/ui/search-input.test.tsx
@@ -57,11 +57,7 @@ describe("SearchInput", () => {
   });
 
   it("honors a custom clearLabel for localization", () => {
-    render(
-      <ControlledHarness initial="algo" withClear clearLabel="Effacer" />,
-    );
-    expect(
-      screen.getByRole("button", { name: "Effacer" }),
-    ).toBeInTheDocument();
+    render(<ControlledHarness initial="algo" withClear clearLabel="Effacer" />);
+    expect(screen.getByRole("button", { name: "Effacer" })).toBeInTheDocument();
   });
 });

--- a/web/components/ui/search-input.tsx
+++ b/web/components/ui/search-input.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import { Search, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export interface SearchInputProps
+  extends Omit<React.ComponentProps<"input">, "type"> {
+  containerClassName?: string;
+  onClear?: () => void;
+  clearLabel?: string;
+}
+
+function SearchInput({
+  className,
+  containerClassName,
+  onClear,
+  clearLabel = "Clear search",
+  value,
+  disabled,
+  ...props
+}: SearchInputProps) {
+  const hasValue =
+    typeof value === "string" ? value.length > 0 : value != null;
+  const showClear = onClear != null && hasValue && !disabled;
+
+  return (
+    <div
+      data-slot="search-input"
+      role="group"
+      data-disabled={disabled ? "true" : undefined}
+      className={cn(
+        "border-input dark:bg-input/30 relative flex h-9 w-full min-w-0 items-center gap-2 rounded-md border bg-transparent pr-1.5 pl-3 shadow-xs transition-[color,box-shadow]",
+        "has-[input:focus-visible]:border-ring has-[input:focus-visible]:ring-ring/50 has-[input:focus-visible]:ring-[3px]",
+        "has-[input[aria-invalid=true]]:border-destructive has-[input[aria-invalid=true]]:ring-destructive/20 dark:has-[input[aria-invalid=true]]:ring-destructive/40",
+        "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+        containerClassName,
+      )}
+    >
+      <Search
+        aria-hidden
+        className="text-muted-foreground pointer-events-none size-4 shrink-0"
+      />
+      {/* type="text" (not "search") avoids a duplicate native webkit clear "x" alongside our own. */}
+      <input
+        type="text"
+        role="searchbox"
+        value={value}
+        disabled={disabled}
+        data-slot="input"
+        className={cn(
+          "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground text-foreground h-full min-w-0 flex-1 bg-transparent text-base outline-none disabled:cursor-not-allowed md:text-sm",
+          className,
+        )}
+        {...props}
+      />
+      {showClear ? (
+        <button
+          type="button"
+          aria-label={clearLabel}
+          onClick={onClear}
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 inline-flex size-6 shrink-0 items-center justify-center rounded focus-visible:ring-[3px] focus-visible:outline-none"
+        >
+          <X aria-hidden className="size-3.5" />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export { SearchInput };

--- a/web/components/ui/search-input.tsx
+++ b/web/components/ui/search-input.tsx
@@ -3,8 +3,10 @@ import { Search, X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
-export interface SearchInputProps
-  extends Omit<React.ComponentProps<"input">, "type"> {
+export interface SearchInputProps extends Omit<
+  React.ComponentProps<"input">,
+  "type"
+> {
   containerClassName?: string;
   onClear?: () => void;
   clearLabel?: string;
@@ -19,8 +21,7 @@ function SearchInput({
   disabled,
   ...props
 }: SearchInputProps) {
-  const hasValue =
-    typeof value === "string" ? value.length > 0 : value != null;
+  const hasValue = typeof value === "string" ? value.length > 0 : value != null;
   const showClear = onClear != null && hasValue && !disabled;
 
   return (

--- a/web/hooks/use-debounced-value.test.tsx
+++ b/web/hooks/use-debounced-value.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useDebouncedValue } from "./use-debounced-value";
+
+describe("useDebouncedValue", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns the initial value synchronously on first render", () => {
+    const { result } = renderHook(() => useDebouncedValue("hello", 250));
+    expect(result.current).toBe("hello");
+  });
+
+  it("only commits the latest value after the delay elapses", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useDebouncedValue(value, 250),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "ab" });
+    rerender({ value: "abc" });
+    expect(result.current).toBe("a");
+
+    act(() => {
+      jest.advanceTimersByTime(249);
+    });
+    expect(result.current).toBe("a");
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe("abc");
+  });
+
+  it("resets the timer on every change so rapid input never flushes early", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: number }) => useDebouncedValue(value, 100),
+      { initialProps: { value: 0 } },
+    );
+
+    rerender({ value: 1 });
+    act(() => {
+      jest.advanceTimersByTime(80);
+    });
+    rerender({ value: 2 });
+    act(() => {
+      jest.advanceTimersByTime(80);
+    });
+    expect(result.current).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(20);
+    });
+    expect(result.current).toBe(2);
+  });
+});

--- a/web/hooks/use-debounced-value.ts
+++ b/web/hooks/use-debounced-value.ts
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = React.useState(value);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/web/lib/features/dashboard/courses/course-search-bar.stories.tsx
+++ b/web/lib/features/dashboard/courses/course-search-bar.stories.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import type { ListCoursesQuery, SchoolResponse } from "@/lib/api/types";
+
+import { CourseSearchBar } from "./course-search-bar";
+
+const SCHOOLS: SchoolResponse[] = [
+  {
+    id: "s_preview_1",
+    name: "Washington State University",
+    acronym: "WSU",
+    city: "Pullman",
+    state: "WA",
+    country: "US",
+    created_at: "2026-04-20T10:00:00Z",
+  },
+  {
+    id: "s_preview_2",
+    name: "University of Washington",
+    acronym: "UW",
+    city: "Seattle",
+    state: "WA",
+    country: "US",
+    created_at: "2026-04-20T10:00:00Z",
+  },
+];
+
+const meta: Meta<typeof CourseSearchBar> = {
+  title: "Dashboard/CourseSearchBar",
+  component: CourseSearchBar,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Search + filter row for the course catalog and onboarding flow. Search input debounces by 250ms; school + department selects emit immediately. Built on the generic SearchInput primitive and useDebouncedValue hook, so the same controls compose into other surfaces (file picker, study-guide search) later.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CourseSearchBar>;
+
+function Controlled({
+  initial = {},
+  departments,
+}: {
+  initial?: ListCoursesQuery;
+  departments?: readonly string[];
+}) {
+  const [value, setValue] = useState<ListCoursesQuery>(initial);
+  return (
+    <div className="space-y-2">
+      <CourseSearchBar
+        value={value}
+        onChange={setValue}
+        schools={SCHOOLS}
+        departments={departments}
+      />
+      <pre className="text-muted-foreground bg-muted/40 rounded-md border p-2 text-xs">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <Controlled />,
+};
+
+export const WithDepartments: Story = {
+  render: () => <Controlled departments={["CPTS", "MATH", "PHYS", "ENGL"]} />,
+};
+
+export const Prefilled: Story = {
+  render: () => (
+    <Controlled
+      initial={{ q: "algorithms", school_id: "s_preview_1" }}
+      departments={["CPTS", "MATH"]}
+    />
+  ),
+};

--- a/web/lib/features/dashboard/courses/course-search-bar.test.tsx
+++ b/web/lib/features/dashboard/courses/course-search-bar.test.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import type { ListCoursesQuery, SchoolResponse } from "@/lib/api/types";
+
+import { CourseSearchBar } from "./course-search-bar";
+
+const SCHOOLS: SchoolResponse[] = [
+  {
+    id: "11111111-1111-1111-1111-111111111111",
+    name: "Atlas University",
+    acronym: "AU",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "22222222-2222-2222-2222-222222222222",
+    name: "Bay State College",
+    acronym: "BSC",
+    created_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+function Harness({
+  initial = {},
+  onChangeSpy,
+  departments,
+}: {
+  initial?: ListCoursesQuery;
+  onChangeSpy: jest.Mock;
+  departments?: readonly string[];
+}) {
+  const [value, setValue] = useState<ListCoursesQuery>(initial);
+  return (
+    <CourseSearchBar
+      value={value}
+      onChange={(next) => {
+        onChangeSpy(next);
+        setValue(next);
+      }}
+      schools={SCHOOLS}
+      departments={departments}
+    />
+  );
+}
+
+describe("CourseSearchBar", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("debounces typed input and emits q after 250ms (AC1)", () => {
+    const onChangeSpy = jest.fn();
+    render(<Harness onChangeSpy={onChangeSpy} />);
+    const input = screen.getByLabelText("Search courses") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "algo" } });
+    expect(onChangeSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(249);
+    });
+    expect(onChangeSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith({ q: "algo" });
+  });
+
+  it("emits school_id immediately when a school is picked (AC2)", () => {
+    const onChangeSpy = jest.fn();
+    render(<Harness initial={{ q: "algo" }} onChangeSpy={onChangeSpy} />);
+    const select = screen.getByLabelText(
+      "Filter by school",
+    ) as HTMLSelectElement;
+
+    fireEvent.change(select, { target: { value: SCHOOLS[1].id } });
+
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith({
+      q: "algo",
+      school_id: SCHOOLS[1].id,
+    });
+  });
+
+  it("clears school_id when 'All schools' is chosen", () => {
+    const onChangeSpy = jest.fn();
+    render(
+      <Harness
+        initial={{ school_id: SCHOOLS[0].id }}
+        onChangeSpy={onChangeSpy}
+      />,
+    );
+    const select = screen.getByLabelText(
+      "Filter by school",
+    ) as HTMLSelectElement;
+    expect(select.value).toBe(SCHOOLS[0].id);
+
+    fireEvent.change(select, { target: { value: "__all__" } });
+    expect(onChangeSpy).toHaveBeenCalledWith({ school_id: undefined });
+  });
+
+  it("emits q: undefined (not empty string) when the search is cleared (AC3)", () => {
+    const onChangeSpy = jest.fn();
+    render(<Harness initial={{ q: "algo" }} onChangeSpy={onChangeSpy} />);
+    const input = screen.getByLabelText("Search courses") as HTMLInputElement;
+    expect(input.value).toBe("algo");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    expect(input.value).toBe("");
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    const [arg] = onChangeSpy.mock.calls[0];
+    expect(arg).toEqual({ q: undefined });
+    expect(Object.prototype.hasOwnProperty.call(arg, "q")).toBe(true);
+    expect(arg.q).toBeUndefined();
+  });
+
+  it("renders department filter only when departments are provided", () => {
+    const onChangeSpy = jest.fn();
+    const { rerender } = render(<Harness onChangeSpy={onChangeSpy} />);
+    expect(screen.queryByLabelText("Filter by department")).toBeNull();
+
+    rerender(
+      <Harness onChangeSpy={onChangeSpy} departments={["CPTS", "MATH"]} />,
+    );
+    const dept = screen.getByLabelText(
+      "Filter by department",
+    ) as HTMLSelectElement;
+    fireEvent.change(dept, { target: { value: "CPTS" } });
+    expect(onChangeSpy).toHaveBeenCalledWith({ department: "CPTS" });
+  });
+});

--- a/web/lib/features/dashboard/courses/course-search-bar.tsx
+++ b/web/lib/features/dashboard/courses/course-search-bar.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { SearchInput } from "@/components/ui/search-input";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import type { ListCoursesQuery, SchoolResponse } from "@/lib/api/types";
+import { cn } from "@/lib/utils";
+
+const ALL = "__all__";
+const DEBOUNCE_MS = 250;
+
+export interface CourseSearchBarProps {
+  value: ListCoursesQuery;
+  onChange: (next: ListCoursesQuery) => void;
+  schools: readonly SchoolResponse[];
+  departments?: readonly string[];
+  className?: string;
+}
+
+export function CourseSearchBar({
+  value,
+  onChange,
+  schools,
+  departments,
+  className,
+}: CourseSearchBarProps) {
+  const [q, setQ] = useState(value.q ?? "");
+  const debouncedQ = useDebouncedValue(q, DEBOUNCE_MS);
+
+  // Refs let the debounce-emit effect depend only on `debouncedQ`;
+  // including `value`/`onChange` in deps would loop every render.
+  const onChangeRef = useRef(onChange);
+  const valueRef = useRef(value);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+    valueRef.current = value;
+  });
+
+  useEffect(() => {
+    const trimmed = debouncedQ.trim();
+    const nextQ = trimmed === "" ? undefined : trimmed;
+    if (nextQ === (valueRef.current.q ?? undefined)) return;
+    onChangeRef.current({ ...valueRef.current, q: nextQ });
+  }, [debouncedQ]);
+
+  function handleSchoolChange(next: string) {
+    onChange({
+      ...value,
+      school_id: next === ALL ? undefined : next,
+    });
+  }
+
+  function handleDepartmentChange(next: string) {
+    onChange({
+      ...value,
+      department: next === ALL ? undefined : next,
+    });
+  }
+
+  const filterClasses =
+    "border-input bg-transparent text-foreground focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 h-9 rounded-md border px-3 py-1 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50";
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-2 sm:flex-row sm:items-center",
+        className,
+      )}
+    >
+      <SearchInput
+        placeholder="Search courses"
+        value={q}
+        onChange={(event) => setQ(event.target.value)}
+        onClear={q === "" ? undefined : () => setQ("")}
+        aria-label="Search courses"
+      />
+      <select
+        aria-label="Filter by school"
+        value={value.school_id ?? ALL}
+        onChange={(event) => handleSchoolChange(event.target.value)}
+        className={cn(filterClasses, "sm:w-56")}
+      >
+        <option value={ALL}>All schools</option>
+        {schools.map((school) => (
+          <option key={school.id} value={school.id}>
+            {school.name}
+          </option>
+        ))}
+      </select>
+      {departments && departments.length > 0 ? (
+        <select
+          aria-label="Filter by department"
+          value={value.department ?? ALL}
+          onChange={(event) => handleDepartmentChange(event.target.value)}
+          className={cn(filterClasses, "sm:w-44")}
+        >
+          <option value={ALL}>All departments</option>
+          {departments.map((dept) => (
+            <option key={dept} value={dept}>
+              {dept}
+            </option>
+          ))}
+        </select>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Generic `SearchInput` primitive in `components/ui/`, built on the shadcn InputGroup composition (group owns border + focus ring; bare `<input>` is a flex sibling) so leading/trailing slots compose without padding hacks.
- `useDebouncedValue` hook in `hooks/` — also a drop-in for the inline debounce in `grants-manager.tsx` (follow-up).
- `CourseSearchBar` composes both: search input (debounced 250ms) + school select + optional department select, controlled over `ListCoursesQuery`. Used by ASK-193 (catalog page) and ASK-200 (onboarding flow).

Note: `<input type="text" role="searchbox">` is intentional — `type="search"` injects a webkit-native clear "x" that duplicates ours.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm exec eslint <new files>` clean
- [x] `pnpm test --testPathPatterns="(search-input|use-debounced-value|course-search-bar)"` — 13/13 passing, all 3 ASK-181 ACs covered (debounced q, immediate school_id, q→undefined on clear)
- [ ] Eyeball Storybook stories: `UI/SearchInput`, `Dashboard/CourseSearchBar`

Closes ASK-181.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a search input component with optional clear button functionality
  * Added a course search bar enabling users to filter courses by school, department, and search query with debounced search optimization

* **Tests**
  * Added comprehensive test coverage for search input and course search bar components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->