### PR TITLE
feat(web): wire up courses catalog page (ASK-193)

### DIFF
--- a/web/app/(dashboard)/courses/page.test.tsx
+++ b/web/app/(dashboard)/courses/page.test.tsx
@@ -1,0 +1,177 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import type {
+  CourseResponse,
+  ListCoursesQuery,
+  ListCoursesResponse,
+} from "../../../lib/api/types";
+
+import CoursesPage from "./page";
+
+jest.mock("../../../lib/api", () => ({
+  listCourses: jest.fn(),
+  listSchools: jest.fn(),
+  listMyEnrollments: jest.fn(),
+}));
+
+jest.mock("../../../lib/features/shared/toast/toast", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+import { listCourses, listMyEnrollments, listSchools } from "../../../lib/api";
+
+const listCoursesMock = listCourses as jest.MockedFunction<typeof listCourses>;
+const listSchoolsMock = listSchools as jest.MockedFunction<typeof listSchools>;
+const listEnrollmentsMock = listMyEnrollments as jest.MockedFunction<
+  typeof listMyEnrollments
+>;
+
+function makeCourse(overrides: Partial<CourseResponse> = {}): CourseResponse {
+  return {
+    id: `c-${Math.random().toString(36).slice(2, 8)}`,
+    school: {
+      id: "s-1",
+      name: "Atlas University",
+      acronym: "AU",
+      city: "Pullman",
+      state: "WA",
+      country: "US",
+    },
+    department: "CPTS",
+    number: "322",
+    title: "Systems Programming",
+    description: null,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeResponse(
+  courses: CourseResponse[],
+  next_cursor: string | null = null,
+): ListCoursesResponse {
+  return {
+    courses,
+    next_cursor,
+    has_more: next_cursor !== null,
+  };
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("CoursesPage (ASK-193)", () => {
+  beforeEach(() => {
+    listSchoolsMock.mockResolvedValue({
+      schools: [],
+      next_cursor: null,
+      has_more: false,
+    });
+    listEnrollmentsMock.mockResolvedValue({ enrollments: [] });
+    listCoursesMock.mockResolvedValue(makeResponse([]));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("renders course cards once the first page returns (AC1)", async () => {
+    listCoursesMock.mockResolvedValueOnce(
+      makeResponse([
+        makeCourse({
+          id: "c1",
+          department: "CPTS",
+          number: "322",
+          title: "Systems Programming",
+        }),
+        makeCourse({
+          id: "c2",
+          department: "MATH",
+          number: "216",
+          title: "Discrete Mathematics",
+        }),
+      ]),
+    );
+
+    render(<CoursesPage />);
+    await flushPromises();
+
+    expect(screen.getByText("CPTS 322")).toBeInTheDocument();
+    expect(screen.getByText("Systems Programming")).toBeInTheDocument();
+    expect(screen.getByText("MATH 216")).toBeInTheDocument();
+    expect(listCoursesMock).toHaveBeenCalledWith({});
+  });
+
+  it("refetches with q after the SearchInput debounce (AC2)", async () => {
+    jest.useFakeTimers();
+    listCoursesMock.mockResolvedValue(makeResponse([]));
+
+    render(<CoursesPage />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const search = screen.getByLabelText("Search courses") as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "algo" } });
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const queries = listCoursesMock.mock.calls.map(
+      (call) => call[0] as ListCoursesQuery,
+    );
+    expect(queries.some((q) => q?.q === "algo")).toBe(true);
+  });
+
+  it("appends results when Load more is clicked (AC3)", async () => {
+    listCoursesMock.mockResolvedValueOnce(
+      makeResponse(
+        [makeCourse({ id: "p1", number: "100", title: "Intro Page 1" })],
+        "cursor-1",
+      ),
+    );
+    listCoursesMock.mockResolvedValueOnce(
+      makeResponse(
+        [makeCourse({ id: "p2", number: "200", title: "Intro Page 2" })],
+        null,
+      ),
+    );
+
+    render(<CoursesPage />);
+    await flushPromises();
+
+    expect(screen.getByText("Intro Page 1")).toBeInTheDocument();
+
+    const loadMore = screen.getByRole("button", { name: /load more/i });
+    fireEvent.click(loadMore);
+    await flushPromises();
+
+    expect(screen.getByText("Intro Page 1")).toBeInTheDocument();
+    expect(screen.getByText("Intro Page 2")).toBeInTheDocument();
+    expect(listCoursesMock).toHaveBeenLastCalledWith({ cursor: "cursor-1" });
+  });
+
+  it("renders an EmptyState with Clear filters when zero results (AC4)", async () => {
+    listCoursesMock.mockResolvedValue(makeResponse([]));
+
+    render(<CoursesPage />);
+    await flushPromises();
+
+    expect(screen.getByText("No courses match")).toBeInTheDocument();
+    const clear = screen.getByRole("button", { name: /clear filters/i });
+    expect(clear).toBeInTheDocument();
+    fireEvent.click(clear);
+    await flushPromises();
+    expect(listCoursesMock).toHaveBeenLastCalledWith({});
+  });
+});

--- a/web/app/(dashboard)/courses/page.tsx
+++ b/web/app/(dashboard)/courses/page.tsx
@@ -1,15 +1,183 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SkeletonGrid } from "@/components/ui/skeleton-grid";
+import { listCourses, listMyEnrollments, listSchools } from "@/lib/api";
+import type {
+  ListCoursesQuery,
+  ListCoursesResponse,
+  SchoolResponse,
+} from "@/lib/api/types";
+import { CourseCard } from "@/lib/features/dashboard/courses/course-card";
+import { CourseSearchBar } from "@/lib/features/dashboard/courses/course-search-bar";
+import { toast } from "@/lib/features/shared/toast/toast";
+
+const GRID_CLASSES = "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3";
+
 export default function CoursesPage() {
+  const [query, setQuery] = useState<ListCoursesQuery>({});
+  const [data, setData] = useState<ListCoursesResponse | null>(null);
+  const [schools, setSchools] = useState<SchoolResponse[]>([]);
+  const [joinedCourseIds, setJoinedCourseIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.allSettled([
+      listSchools({ page_limit: 100 }),
+      listMyEnrollments(),
+    ]).then(([schoolsRes, enrollmentsRes]) => {
+      if (cancelled) return;
+      if (schoolsRes.status === "fulfilled") {
+        setSchools(schoolsRes.value.schools);
+      }
+      if (enrollmentsRes.status === "fulfilled") {
+        setJoinedCourseIds(
+          new Set(enrollmentsRes.value.enrollments.map((e) => e.course.id)),
+        );
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    listCourses(query)
+      .then((res) => {
+        if (cancelled) return;
+        setData(res);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load courses");
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [query]);
+
+  async function handleLoadMore() {
+    if (!data?.next_cursor || isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const next = await listCourses({
+        ...query,
+        cursor: data.next_cursor,
+      });
+      setData((prev) =>
+        prev
+          ? {
+              courses: [...prev.courses, ...next.courses],
+              next_cursor: next.next_cursor,
+              has_more: next.has_more,
+            }
+          : next,
+      );
+    } catch (err) {
+      toast.error(err);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }
+
+  const courses = data?.courses ?? [];
+  const showEmptyState =
+    !isLoading && !error && data !== null && courses.length === 0;
+
   return (
-    <section className="space-y-4">
-      <header>
+    <section className="space-y-6">
+      <header className="space-y-1.5">
         <h1 className="text-2xl font-semibold tracking-tight">
-          Browse Courses
+          Browse courses
         </h1>
         <p className="text-muted-foreground text-sm">
-          Discover available courses across your workspace.
+          Discover courses across schools, follow them, and start a study guide.
         </p>
       </header>
-      <div className="bg-muted/50 min-h-[60vh] rounded-xl" />
+
+      <CourseSearchBar value={query} onChange={setQuery} schools={schools} />
+
+      {error ? (
+        <EmptyState
+          title="Couldn't load courses"
+          body={error}
+          action={
+            <Button variant="outline" onClick={() => setQuery({ ...query })}>
+              Try again
+            </Button>
+          }
+        />
+      ) : isLoading && data === null ? (
+        <SkeletonGrid count={9} className={GRID_CLASSES} />
+      ) : showEmptyState ? (
+        <EmptyState
+          title="No courses match"
+          body="Try a different search or clear the filters."
+          action={
+            <Button variant="outline" onClick={() => setQuery({})}>
+              Clear filters
+            </Button>
+          }
+        />
+      ) : (
+        <>
+          <p aria-live="polite" className="text-muted-foreground text-sm">
+            {courses.length} course{courses.length === 1 ? "" : "s"}
+            {query.q ? ` matching "${query.q}"` : ""}
+          </p>
+
+          <div className={GRID_CLASSES}>
+            {courses.map((course) => (
+              <CourseCard
+                key={course.id}
+                course={course}
+                variant="tile"
+                rightSlot={
+                  joinedCourseIds.has(course.id) ? (
+                    <Badge variant="secondary">Joined</Badge>
+                  ) : undefined
+                }
+              />
+            ))}
+          </div>
+
+          {data?.has_more ? (
+            <div className="flex justify-center pt-2">
+              <Button
+                variant="outline"
+                onClick={handleLoadMore}
+                disabled={isLoadingMore}
+              >
+                {isLoadingMore ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" aria-hidden />
+                    Loading…
+                  </>
+                ) : (
+                  "Load more"
+                )}
+              </Button>
+            </div>
+          ) : null}
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the `/courses` stub with a real searchable, paginated catalog.
- Mount loads schools (for the search bar) and `listMyEnrollments` (for the Joined pill) in parallel via `Promise.allSettled` so transient failures degrade gracefully.
- Refetches whenever `query` changes — `CourseSearchBar` already debounces typed input, school/department selects fire immediately.
- Skeleton grid on first load; `EmptyState` with a Clear filters button on zero results; Load more outline button when `has_more`.

## Test plan
- [x] `pnpm test --testPathPatterns="courses/page"` — 4/4 ACs (cards render, debounced refetch with q, Load more appends, EmptyState + Clear filters)
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm exec eslint <new files>` clean
- [x] `pnpm exec prettier --check` clean
- [ ] Eyeball the page in dev — search "algo", pick a school, hit Load more

Closes ASK-193.