### PR TITLE
feat(web): match courses tile to pencil design

### DIFF
--- a/web/app/(dashboard)/courses/page.tsx
+++ b/web/app/(dashboard)/courses/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { Check, Loader2 } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonGrid } from "@/components/ui/skeleton-grid";
@@ -150,9 +149,7 @@ export default function CoursesPage() {
                 course={course}
                 variant="tile"
                 rightSlot={
-                  joinedCourseIds.has(course.id) ? (
-                    <Badge variant="secondary">Joined</Badge>
-                  ) : undefined
+                  joinedCourseIds.has(course.id) ? <JoinedPill /> : undefined
                 }
               />
             ))}
@@ -179,5 +176,14 @@ export default function CoursesPage() {
         </>
       )}
     </section>
+  );
+}
+
+function JoinedPill() {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-md bg-orange-100 px-2 py-0.5 text-[11px] font-semibold text-orange-800">
+      <Check className="size-2.5 text-orange-700" aria-hidden={true} />
+      Joined
+    </span>
   );
 }

--- a/web/lib/features/dashboard/courses/course-card.test.tsx
+++ b/web/lib/features/dashboard/courses/course-card.test.tsx
@@ -86,11 +86,24 @@ describe("CourseCard / row variant", () => {
 describe("CourseCard / tile variant", () => {
   it("renders department, title, and school name", () => {
     render(<CourseCard course={makeCourse()} variant="tile" />);
+    expect(screen.getByText("CPTS 322")).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "CPTS 322" }),
+      screen.getByRole("heading", { name: "Systems Programming" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Systems Programming")).toBeInTheDocument();
     expect(screen.getByText("Washington State University")).toBeInTheDocument();
+  });
+
+  it("renders member and section counts when provided", () => {
+    render(
+      <CourseCard
+        course={makeCourse()}
+        variant="tile"
+        memberCount={248}
+        sectionCount={3}
+      />,
+    );
+    expect(screen.getByText("248")).toBeInTheDocument();
+    expect(screen.getByText(/3 sections/)).toBeInTheDocument();
   });
 
   it("links to /courses/{id} by default", () => {

--- a/web/lib/features/dashboard/courses/course-card.tsx
+++ b/web/lib/features/dashboard/courses/course-card.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { type ReactNode } from "react";
+import { ArrowRight, Layers, Users } from "lucide-react";
 
 import type { CourseResponse } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
@@ -16,6 +17,10 @@ interface CourseCardProps {
    * invalid `<a><button>` HTML structure.
    */
   rightSlot?: ReactNode;
+  /** Tile-only: aggregate enrolled members across all sections. */
+  memberCount?: number;
+  /** Tile-only: number of sections offered for this course. */
+  sectionCount?: number;
 }
 
 export function CourseCard({
@@ -23,6 +28,8 @@ export function CourseCard({
   variant,
   href,
   rightSlot,
+  memberCount,
+  sectionCount,
 }: CourseCardProps) {
   const destination = href ?? `/courses/${course.id}`;
   const code = `${course.department} ${course.number}`;
@@ -30,25 +37,25 @@ export function CourseCard({
   return (
     <div
       className={cn(
-        "group bg-card focus-within:ring-ring relative rounded-xl border transition-all",
+        "group bg-card focus-within:ring-ring relative rounded-[10px] border border-zinc-200 transition-all",
         "hover:shadow-md focus-within:ring-2",
       )}
     >
-      {/* Stretched link: invisible overlay that makes the whole card
-          clickable without nesting interactive children inside an <a>.
-          Content below sits at z-10 so visible text + rightSlot render
-          above it; non-interactive content is `pointer-events-none` so
-          clicks fall through to the Link, while rightSlot stays
-          click-receptive by default. */}
       <Link
         href={destination}
         aria-label={`${code} — ${course.title}`}
-        className="absolute inset-0 z-0 rounded-xl focus:outline-none"
+        className="absolute inset-0 z-0 rounded-[10px] focus:outline-none"
       />
       {variant === "row" ? (
         <RowVariant course={course} code={code} rightSlot={rightSlot} />
       ) : (
-        <TileVariant course={course} code={code} rightSlot={rightSlot} />
+        <TileVariant
+          course={course}
+          code={code}
+          rightSlot={rightSlot}
+          memberCount={memberCount}
+          sectionCount={sectionCount}
+        />
       )}
     </div>
   );
@@ -63,10 +70,6 @@ function RowVariant({
   code: string;
   rightSlot?: ReactNode;
 }) {
-  // The flex container is pointer-events-none so clicks on padding or
-  // the gap between text and slot fall through to the overlay Link
-  // (rather than dying on this empty wrapper). Only the slot wrapper
-  // re-enables pointer events so it can own its own click.
   return (
     <div className="pointer-events-none flex items-center gap-3 p-3">
       <div className="relative z-10 min-w-0 flex-1">
@@ -91,30 +94,71 @@ function TileVariant({
   course,
   code,
   rightSlot,
+  memberCount,
+  sectionCount,
 }: {
   course: CourseResponse;
   code: string;
   rightSlot?: ReactNode;
+  memberCount?: number;
+  sectionCount?: number;
 }) {
-  // Same dead-zone fix as RowVariant -- see comment above.
+  const hasFooterMetrics =
+    typeof memberCount === "number" || typeof sectionCount === "number";
+
   return (
-    <div className="pointer-events-none p-4">
-      <div className="relative z-10 space-y-1.5">
-        <h3 className="text-foreground text-base font-semibold leading-tight">
+    <div className="pointer-events-none flex min-h-[180px] flex-col gap-2.5 px-5 pb-4 pt-[18px]">
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-foreground font-mono text-[13px] font-semibold tracking-[-0.2px]">
           {code}
-        </h3>
-        <p className="text-foreground line-clamp-2 text-sm leading-snug">
-          {course.title}
-        </p>
-        <p className="text-muted-foreground truncate text-xs">
-          {course.school.name}
-        </p>
+        </span>
+        {rightSlot ? (
+          <div className="pointer-events-auto relative z-10 shrink-0">
+            {rightSlot}
+          </div>
+        ) : null}
       </div>
-      {rightSlot ? (
-        <div className="pointer-events-auto absolute right-3 top-3 z-10">
-          {rightSlot}
+
+      <h3 className="text-foreground line-clamp-2 text-[15px] font-semibold leading-[1.35] tracking-[-0.2px]">
+        {course.title}
+      </h3>
+
+      <p className="truncate text-[13px] text-zinc-500">{course.school.name}</p>
+
+      <div className="flex-1" />
+
+      {hasFooterMetrics ? (
+        <>
+          <div className="h-px w-full bg-zinc-100" />
+          <div className="flex items-center justify-between pt-1.5">
+            <div className="flex items-center gap-3.5 text-[12px] font-medium text-zinc-600">
+              {typeof memberCount === "number" ? (
+                <span className="flex items-center gap-1.5">
+                  <Users className="size-3 text-zinc-400" aria-hidden={true} />
+                  {memberCount}
+                </span>
+              ) : null}
+              {typeof sectionCount === "number" ? (
+                <span className="flex items-center gap-1.5">
+                  <Layers className="size-3 text-zinc-400" aria-hidden={true} />
+                  {sectionCount} {sectionCount === 1 ? "section" : "sections"}
+                </span>
+              ) : null}
+            </div>
+            <ArrowRight
+              className="size-3.5 text-zinc-400 transition-transform group-hover:translate-x-0.5"
+              aria-hidden={true}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="flex justify-end">
+          <ArrowRight
+            className="size-3.5 text-zinc-400 transition-transform group-hover:translate-x-0.5"
+            aria-hidden={true}
+          />
         </div>
-      ) : null}
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Redesign `CourseCard` tile to match the Pencil catalog spec (mono code top-left, course title as visible h3, school subline, divider + arrow footer with optional members / sections metrics).
- Inline the Joined state as an orange pill (`bg-orange-100` / `text-orange-800` / lucide `check`) matching the design — replaces the generic shadcn Badge previously passed via `rightSlot`.
- New optional `memberCount` / `sectionCount` props on `CourseCard`. When neither is supplied (current state — the list endpoint does not return aggregates), the footer collapses to an arrow-only row so the catalog does not render an orphan divider.

## Test plan
- [x] `pnpm exec jest lib/features/dashboard/courses/course-card.test.tsx` — 8 tests pass (added coverage for the metric props; tile heading assertion now targets the course title).
- [x] `pnpm exec jest courses/page` — 4 ASK-193 acceptance tests still pass.
- [x] `pnpm exec eslint` + `tsc --noEmit` clean on the touched files.
- [x] Manual: `make dev` against staging API, `/courses` renders the new tile with the joined pill on enrolled courses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Course card tiles now optionally display member count and section count with corresponding visual icons when these metrics are available
  * Redesigned "Joined" indicator with an improved check icon presentation for better visual feedback

* **Tests**
  * Expanded test coverage for course card component to validate the display of newly added metrics and updated indicator styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->