### PR TITLE
feat(web): course detail page (ASK-197)

### DIFF
--- a/web/app/(dashboard)/courses/[courseId]/page.test.tsx
+++ b/web/app/(dashboard)/courses/[courseId]/page.test.tsx
@@ -33,6 +33,14 @@ const notFoundMock = jest.fn(() => {
 
 jest.mock("next/navigation", () => ({
   notFound: () => notFoundMock(),
+  useRouter: () => ({
+    refresh: jest.fn(),
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn(),
+  }),
 }));
 
 import {

--- a/web/app/(dashboard)/courses/[courseId]/page.test.tsx
+++ b/web/app/(dashboard)/courses/[courseId]/page.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * ASK-197 acceptance tests for the course detail page.
+ *
+ * Server Components return a Promise<ReactElement>; we await the page
+ * function directly and feed the resolved JSX into RTL `render`. The
+ * `@/lib/api` actions and `next/navigation` `notFound` are mocked at
+ * the module level so the test owns every API response and the 404
+ * branch can assert without needing the real error boundary.
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { ApiError } from "@/lib/api/errors";
+import type {
+  CourseDetailResponse,
+  ListMyEnrollmentsResponse,
+  ListStudyGuidesResponse,
+} from "@/lib/api/types";
+
+import CourseDetailPage from "./page";
+
+jest.mock("../../../../lib/api", () => ({
+  getCourse: jest.fn(),
+  listCourseStudyGuides: jest.fn(),
+  listMyEnrollments: jest.fn(),
+  joinSection: jest.fn(),
+  leaveSection: jest.fn(),
+}));
+
+const notFoundMock = jest.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+
+jest.mock("next/navigation", () => ({
+  notFound: () => notFoundMock(),
+}));
+
+import {
+  getCourse,
+  listCourseStudyGuides,
+  listMyEnrollments,
+} from "../../../../lib/api";
+
+const getCourseMock = getCourse as jest.MockedFunction<typeof getCourse>;
+const listGuidesMock = listCourseStudyGuides as jest.MockedFunction<
+  typeof listCourseStudyGuides
+>;
+const listEnrollmentsMock = listMyEnrollments as jest.MockedFunction<
+  typeof listMyEnrollments
+>;
+
+const SECTION_A = "11111111-1111-1111-1111-111111111111";
+const SECTION_B = "22222222-2222-2222-2222-222222222222";
+
+function makeCourse(
+  overrides: Partial<CourseDetailResponse> = {},
+): CourseDetailResponse {
+  return {
+    id: "c_preview_1",
+    school: {
+      id: "s_preview_1",
+      name: "Washington State University",
+      acronym: "WSU",
+      city: "Pullman",
+      state: "WA",
+      country: "US",
+    },
+    department: "CPTS",
+    number: "322",
+    title: "Systems Programming",
+    description: null,
+    created_at: "2026-04-20T10:00:00Z",
+    sections: [
+      {
+        id: SECTION_A,
+        term: "Spring 2026",
+        section_code: "01",
+        instructor_name: "Dr. Aragoneses",
+        member_count: 47,
+      },
+      {
+        id: SECTION_B,
+        term: "Spring 2026",
+        section_code: "02",
+        instructor_name: "Dr. Williams",
+        member_count: 38,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeGuides(count: number = 0): ListStudyGuidesResponse {
+  return {
+    study_guides: Array.from({ length: count }).map((_, i) => ({
+      id: `g_${i}`,
+      title: `Guide ${i + 1}`,
+      description: null,
+      tags: [],
+      creator: {
+        id: `u_${i}`,
+        first_name: "Sarah",
+        last_name: "K.",
+      },
+      course_id: "c_preview_1",
+      vote_score: 10,
+      view_count: 0,
+      is_recommended: false,
+      quiz_count: 0,
+      visibility: "public",
+      created_at: "2026-04-20T10:00:00Z",
+      updated_at: "2026-04-20T10:00:00Z",
+    })),
+    next_cursor: null,
+    has_more: false,
+  };
+}
+
+function makeEnrollments(sectionId?: string): ListMyEnrollmentsResponse {
+  if (!sectionId) return { enrollments: [] };
+  return {
+    enrollments: [
+      {
+        section: {
+          id: sectionId,
+          term: "Spring 2026",
+          section_code: "01",
+          instructor_name: "Dr. Aragoneses",
+        },
+        course: {
+          id: "c_preview_1",
+          department: "CPTS",
+          number: "322",
+          title: "Systems Programming",
+        },
+        school: { id: "s_preview_1", acronym: "WSU" },
+        role: "student",
+        joined_at: "2026-04-20T10:00:00Z",
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+async function renderPage() {
+  const ui = await CourseDetailPage({
+    params: Promise.resolve({ courseId: "c_preview_1" }),
+  });
+  render(ui);
+}
+
+describe("CourseDetailPage (ASK-197)", () => {
+  it("renders course header with title, school, and metadata (AC1)", async () => {
+    getCourseMock.mockResolvedValue(makeCourse());
+    listGuidesMock.mockResolvedValue(makeGuides(2));
+    listEnrollmentsMock.mockResolvedValue(makeEnrollments());
+
+    await renderPage();
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Systems Programming" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("CPTS 322")).toBeInTheDocument();
+    expect(screen.getByText("Washington State University")).toBeInTheDocument();
+    expect(screen.getByText(/85 enrolled/)).toBeInTheDocument();
+    expect(screen.getByText(/2 sections/)).toBeInTheDocument();
+  });
+
+  it("shows section picker with Join controls when not enrolled (AC2 not-enrolled half)", async () => {
+    getCourseMock.mockResolvedValue(makeCourse());
+    listGuidesMock.mockResolvedValue(makeGuides(2));
+    listEnrollmentsMock.mockResolvedValue(makeEnrollments());
+
+    await renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: "Pick a section" }),
+    ).toBeInTheDocument();
+    const joinButtons = screen.getAllByRole("button", { name: "Join" });
+    expect(joinButtons).toHaveLength(2);
+  });
+
+  it("renders enrolled banner + Enrolled control for the joined section (AC2)", async () => {
+    getCourseMock.mockResolvedValue(makeCourse());
+    listGuidesMock.mockResolvedValue(makeGuides(2));
+    listEnrollmentsMock.mockResolvedValue(makeEnrollments(SECTION_A));
+
+    await renderPage();
+
+    expect(screen.getByText(/You.*re in/i)).toBeInTheDocument();
+    expect(screen.getByText("Section 01")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Study guides/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'No study guides yet' empty state when enrolled and zero guides (AC3)", async () => {
+    getCourseMock.mockResolvedValue(makeCourse());
+    listGuidesMock.mockResolvedValue(makeGuides(0));
+    listEnrollmentsMock.mockResolvedValue(makeEnrollments(SECTION_A));
+
+    await renderPage();
+
+    expect(screen.getByText("No study guides yet")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Create one/i })).toHaveAttribute(
+      "href",
+      "/study-guides/new?course=c_preview_1",
+    );
+  });
+
+  it("renders 'No sections offered' when course has zero sections (AC4)", async () => {
+    getCourseMock.mockResolvedValue(makeCourse({ sections: [] }));
+    listGuidesMock.mockResolvedValue(makeGuides(0));
+    listEnrollmentsMock.mockResolvedValue(makeEnrollments());
+
+    await renderPage();
+
+    expect(screen.getByText("No sections offered")).toBeInTheDocument();
+  });
+
+  it("triggers notFound() when getCourse returns 404 (AC5)", async () => {
+    const apiErr = new ApiError(
+      "GET /courses/c_preview_1 failed: 404",
+      { status: 404 } as unknown as Response,
+      null,
+    );
+    getCourseMock.mockRejectedValue(apiErr);
+    listGuidesMock.mockResolvedValue(makeGuides(0));
+    listEnrollmentsMock.mockResolvedValue(makeEnrollments());
+
+    await expect(renderPage()).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/app/(dashboard)/courses/[courseId]/page.tsx
+++ b/web/app/(dashboard)/courses/[courseId]/page.tsx
@@ -12,7 +12,15 @@
  *   - Enrolled: section status banner + study-guide grid (the body).
  *   - Not enrolled: "Pick a section" picker + dimmed study-guide teaser.
  */
-import { ArrowRightLeft, Lock, Plus, UserRound, Users } from "lucide-react";
+import {
+  ArrowRightLeft,
+  BookOpen,
+  CalendarOff,
+  Lock,
+  Plus,
+  UserRound,
+  Users,
+} from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -127,30 +135,32 @@ function EnrolledBanner({
 }) {
   const sectionLabel = sectionCode ? `Section ${sectionCode}` : "your section";
   return (
-    <div className="flex flex-wrap items-center justify-between gap-4 rounded-[10px] border border-stone-200 bg-stone-50 px-3 py-3">
+    <div className="border-border bg-muted/40 flex flex-wrap items-center justify-between gap-4 rounded-[10px] border px-3 py-3">
       <div className="flex min-w-0 items-center gap-3.5">
         <span
-          className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-800"
+          className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg"
           aria-hidden={true}
         >
           <UserRound className="size-4" />
         </span>
         <div className="flex min-w-0 flex-col gap-0.5">
           <p className="flex flex-wrap items-center gap-x-1.5 text-[13px]">
-            <span className="text-zinc-600">You&rsquo;re in</span>
-            <span className="font-mono font-semibold text-zinc-950">
+            <span className="text-muted-foreground">You&rsquo;re in</span>
+            <span className="text-foreground font-mono font-semibold">
               {sectionLabel}
             </span>
             {instructor ? (
               <>
-                <span className="text-zinc-400" aria-hidden={true}>
+                <span className="text-muted-foreground/50" aria-hidden={true}>
                   ·
                 </span>
-                <span className="font-medium text-zinc-800">{instructor}</span>
+                <span className="text-foreground font-medium">
+                  {instructor}
+                </span>
               </>
             ) : null}
           </p>
-          <p className="text-[12px] text-zinc-500">{term}</p>
+          <p className="text-muted-foreground text-[12px]">{term}</p>
         </div>
       </div>
       <div className="flex items-center gap-3">
@@ -179,24 +189,25 @@ function SectionPicker({
   if (sections.length === 0) {
     return (
       <EmptyState
+        icon={<CalendarOff className="size-8" aria-hidden={true} />}
         title="No sections offered"
         body="This course has no current section offerings. Check back next term."
-        className="rounded-[10px] border border-zinc-200"
+        className="border-border bg-muted/30 rounded-[10px] border py-12"
       />
     );
   }
   return (
     <div className="flex flex-col gap-3.5">
       <div className="flex flex-col gap-1.5">
-        <h2 className="text-[18px] font-semibold leading-tight tracking-[-0.3px] text-zinc-950">
+        <h2 className="text-foreground text-[18px] font-semibold leading-tight tracking-[-0.3px]">
           Pick a section
         </h2>
-        <p className="text-[13px] text-zinc-600">
+        <p className="text-muted-foreground text-[13px]">
           Join a section to access study guides for this course. You&rsquo;ll
           only see what your section is sharing.
         </p>
       </div>
-      <div className="flex flex-col divide-y divide-zinc-100 rounded-[10px] border border-zinc-200 bg-white">
+      <div className="divide-border bg-card border-border flex flex-col divide-y rounded-[10px] border">
         {sections.map((section) => (
           <SectionRow
             key={section.id}
@@ -222,14 +233,14 @@ function StudyGuidesSection({
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div className="flex flex-col gap-1.5">
           <div className="flex items-center gap-3">
-            <h2 className="text-[22px] font-semibold leading-tight tracking-[-0.4px] text-zinc-950">
+            <h2 className="text-foreground text-[22px] font-semibold leading-tight tracking-[-0.4px]">
               Study guides
             </h2>
-            <span className="rounded-md bg-zinc-100 px-2 py-0.5 font-mono text-[12px] font-semibold text-zinc-600">
+            <span className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 font-mono text-[12px] font-semibold">
               {studyGuides.length}
             </span>
           </div>
-          <p className="text-[13px] text-zinc-600">
+          <p className="text-muted-foreground text-[13px]">
             Browse what your classmates have written, or start your own.
           </p>
         </div>
@@ -243,6 +254,7 @@ function StudyGuidesSection({
 
       {studyGuides.length === 0 ? (
         <EmptyState
+          icon={<BookOpen className="size-8" aria-hidden={true} />}
           title="No study guides yet"
           body="Be the first to share notes, an outline, or a cheat sheet with your section."
           action={
@@ -252,7 +264,7 @@ function StudyGuidesSection({
               </Link>
             </Button>
           }
-          className="rounded-[10px] border border-zinc-200"
+          className="border-border bg-muted/30 rounded-[10px] border py-14"
         />
       ) : (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -279,19 +291,19 @@ function StudyGuidesTeaser({
   }
   const previews = studyGuides.slice(0, 3);
   const lockedCount = Math.max(studyGuides.length - previews.length, 0);
-  const opacities = ["opacity-55", "opacity-45", "opacity-30"];
+  const opacities = ["opacity-60", "opacity-40", "opacity-25"];
   return (
     <div className="flex flex-col gap-3.5">
       <div className="flex flex-col gap-1.5">
         <div className="flex items-center gap-3">
-          <h2 className="text-[22px] font-semibold leading-tight tracking-[-0.4px] text-zinc-500">
+          <h2 className="text-muted-foreground text-[22px] font-semibold leading-tight tracking-[-0.4px]">
             Study guides
           </h2>
-          <span className="rounded-md bg-zinc-100 px-2 py-0.5 font-mono text-[12px] font-semibold text-zinc-500">
+          <span className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 font-mono text-[12px] font-semibold">
             {studyGuides.length}
           </span>
         </div>
-        <p className="text-[13px] text-zinc-400">
+        <p className="text-muted-foreground/80 text-[13px]">
           You&rsquo;ll see what your section is sharing once you join.
         </p>
       </div>
@@ -300,15 +312,18 @@ function StudyGuidesTeaser({
         aria-hidden={true}
       >
         {previews.map((guide, index) => (
-          <div key={guide.id} className={opacities[index] ?? "opacity-30"}>
+          <div key={guide.id} className={opacities[index] ?? "opacity-25"}>
             <StudyGuideCard guide={toCardItem(guide)} variant="list" />
           </div>
         ))}
       </div>
       {lockedCount > 0 ? (
-        <p className="flex items-center justify-center gap-1.5 pt-1 text-[13px] font-medium text-zinc-500">
-          <Lock className="size-3.5 text-zinc-400" aria-hidden={true} />+{" "}
-          {lockedCount} more {lockedCount === 1 ? "guide" : "guides"} locked
+        <p className="text-muted-foreground flex items-center justify-center gap-1.5 pt-1 text-[13px] font-medium">
+          <Lock
+            className="text-muted-foreground/60 size-3.5"
+            aria-hidden={true}
+          />
+          + {lockedCount} more {lockedCount === 1 ? "guide" : "guides"} locked
         </p>
       ) : null}
     </div>

--- a/web/app/(dashboard)/courses/[courseId]/page.tsx
+++ b/web/app/(dashboard)/courses/[courseId]/page.tsx
@@ -1,0 +1,333 @@
+/**
+ * Course detail page (ASK-197).
+ *
+ * Server Component. Fetches course detail, sections, study guides, and
+ * the caller's enrollments in parallel; the enrollment list lets us
+ * pre-resolve per-section membership without an N+1 of `checkMembership`
+ * round-trips. A 404 from `getCourse` triggers the dashboard not-found
+ * boundary; any other failure bubbles to the dashboard error boundary.
+ *
+ * The page renders one of two states based on whether the caller is in a
+ * section of this course:
+ *   - Enrolled: section status banner + study-guide grid (the body).
+ *   - Not enrolled: "Pick a section" picker + dimmed study-guide teaser.
+ */
+import { ArrowRightLeft, Lock, Plus, UserRound, Users } from "lucide-react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { getCourse, listCourseStudyGuides, listMyEnrollments } from "@/lib/api";
+import { ApiError } from "@/lib/api/errors";
+import type {
+  SectionSummary,
+  StudyGuideListItemResponse,
+} from "@/lib/api/types";
+import { CourseDetailHeader } from "@/lib/features/dashboard/courses/course-detail-header";
+import { SectionRow } from "@/lib/features/dashboard/courses/section-row";
+import {
+  StudyGuideCard,
+  type StudyGuideListItemResponse as StudyGuideCardListItem,
+} from "@/lib/features/dashboard/study-guides/study-guide-card";
+
+interface PageProps {
+  params: Promise<{ courseId: string }>;
+}
+
+export default async function CourseDetailPage({ params }: PageProps) {
+  const { courseId } = await params;
+
+  // Sections come embedded on `CourseDetailResponse`, so we don't also
+  // hit `listCourseSections` -- the dedicated endpoint adds `course_id`
+  // and `created_at` that this page doesn't render. Enrollments power
+  // per-section membership without an N+1 of `checkMembership` calls.
+  const [course, studyGuidesRes, enrollments] = await Promise.all([
+    getCourseOr404(courseId),
+    listCourseStudyGuides(courseId),
+    listMyEnrollments(),
+  ]);
+
+  const sectionIds = new Set(course.sections.map((s) => s.id));
+  const myEnrollmentInCourse =
+    enrollments.enrollments.find((e) => sectionIds.has(e.section.id)) ?? null;
+
+  const enrolledCount = course.sections.reduce(
+    (acc, s) => acc + s.member_count,
+    0,
+  );
+  const studyGuides = studyGuidesRes.study_guides;
+  const isEnrolled = Boolean(myEnrollmentInCourse);
+
+  return (
+    <section className="mx-auto flex w-full max-w-[1184px] flex-col gap-7 px-10 py-8">
+      <CourseDetailHeader
+        course={course}
+        enrolledCount={enrolledCount}
+        studyGuidesCount={studyGuides.length}
+        termLabel={myEnrollmentInCourse?.section.term}
+        trailingActions={
+          isEnrolled && myEnrollmentInCourse ? (
+            <Button asChild variant="outline" className="h-9">
+              <Link
+                href={`/courses/${course.id}/sections/${myEnrollmentInCourse.section.id}/members`}
+              >
+                <Users className="size-4" aria-hidden={true} />
+                Members
+              </Link>
+            </Button>
+          ) : null
+        }
+      />
+
+      {isEnrolled && myEnrollmentInCourse ? (
+        <>
+          <EnrolledBanner
+            courseId={course.id}
+            sectionId={myEnrollmentInCourse.section.id}
+            sectionCode={myEnrollmentInCourse.section.section_code}
+            instructor={myEnrollmentInCourse.section.instructor_name}
+            term={myEnrollmentInCourse.section.term}
+          />
+          <StudyGuidesSection courseId={course.id} studyGuides={studyGuides} />
+        </>
+      ) : (
+        <>
+          <SectionPicker courseId={course.id} sections={course.sections} />
+          <StudyGuidesTeaser studyGuides={studyGuides} />
+        </>
+      )}
+    </section>
+  );
+}
+
+async function getCourseOr404(courseId: string) {
+  try {
+    return await getCourse(courseId);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+}
+
+function EnrolledBanner({
+  courseId,
+  sectionId,
+  sectionCode,
+  instructor,
+  term,
+}: {
+  courseId: string;
+  sectionId: string;
+  sectionCode: string | null | undefined;
+  instructor: string | null | undefined;
+  term: string;
+}) {
+  const sectionLabel = sectionCode ? `Section ${sectionCode}` : "your section";
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4 rounded-[10px] border border-stone-200 bg-stone-50 px-3 py-3">
+      <div className="flex min-w-0 items-center gap-3.5">
+        <span
+          className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-800"
+          aria-hidden={true}
+        >
+          <UserRound className="size-4" />
+        </span>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <p className="flex flex-wrap items-center gap-x-1.5 text-[13px]">
+            <span className="text-zinc-600">You&rsquo;re in</span>
+            <span className="font-mono font-semibold text-zinc-950">
+              {sectionLabel}
+            </span>
+            {instructor ? (
+              <>
+                <span className="text-zinc-400" aria-hidden={true}>
+                  ·
+                </span>
+                <span className="font-medium text-zinc-800">{instructor}</span>
+              </>
+            ) : null}
+          </p>
+          <p className="text-[12px] text-zinc-500">{term}</p>
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        <Button asChild variant="ghost" size="sm" className="h-8">
+          <Link href={`/courses/${courseId}/sections/${sectionId}/members`}>
+            <Users className="size-3.5" aria-hidden={true} />
+            Section roster
+          </Link>
+        </Button>
+        <Button variant="ghost" size="sm" className="h-8">
+          <ArrowRightLeft className="size-3.5" aria-hidden={true} />
+          Switch
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SectionPicker({
+  courseId,
+  sections,
+}: {
+  courseId: string;
+  sections: SectionSummary[];
+}) {
+  if (sections.length === 0) {
+    return (
+      <EmptyState
+        title="No sections offered"
+        body="This course has no current section offerings. Check back next term."
+        className="rounded-[10px] border border-zinc-200"
+      />
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3.5">
+      <div className="flex flex-col gap-1.5">
+        <h2 className="text-[18px] font-semibold leading-tight tracking-[-0.3px] text-zinc-950">
+          Pick a section
+        </h2>
+        <p className="text-[13px] text-zinc-600">
+          Join a section to access study guides for this course. You&rsquo;ll
+          only see what your section is sharing.
+        </p>
+      </div>
+      <div className="flex flex-col divide-y divide-zinc-100 rounded-[10px] border border-zinc-200 bg-white">
+        {sections.map((section) => (
+          <SectionRow
+            key={section.id}
+            courseId={courseId}
+            section={section}
+            initialMembership="not-member"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StudyGuidesSection({
+  courseId,
+  studyGuides,
+}: {
+  courseId: string;
+  studyGuides: StudyGuideListItemResponse[];
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-3">
+            <h2 className="text-[22px] font-semibold leading-tight tracking-[-0.4px] text-zinc-950">
+              Study guides
+            </h2>
+            <span className="rounded-md bg-zinc-100 px-2 py-0.5 font-mono text-[12px] font-semibold text-zinc-600">
+              {studyGuides.length}
+            </span>
+          </div>
+          <p className="text-[13px] text-zinc-600">
+            Browse what your classmates have written, or start your own.
+          </p>
+        </div>
+        <Button asChild className="h-9">
+          <Link href={`/study-guides/new?course=${courseId}`}>
+            <Plus className="size-4" aria-hidden={true} />
+            New guide
+          </Link>
+        </Button>
+      </div>
+
+      {studyGuides.length === 0 ? (
+        <EmptyState
+          title="No study guides yet"
+          body="Be the first to share notes, an outline, or a cheat sheet with your section."
+          action={
+            <Button asChild>
+              <Link href={`/study-guides/new?course=${courseId}`}>
+                Create one
+              </Link>
+            </Button>
+          }
+          className="rounded-[10px] border border-zinc-200"
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {studyGuides.map((guide) => (
+            <StudyGuideCard
+              key={guide.id}
+              guide={toCardItem(guide)}
+              variant="list"
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StudyGuidesTeaser({
+  studyGuides,
+}: {
+  studyGuides: StudyGuideListItemResponse[];
+}) {
+  if (studyGuides.length === 0) {
+    return null;
+  }
+  const previews = studyGuides.slice(0, 3);
+  const lockedCount = Math.max(studyGuides.length - previews.length, 0);
+  const opacities = ["opacity-55", "opacity-45", "opacity-30"];
+  return (
+    <div className="flex flex-col gap-3.5">
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center gap-3">
+          <h2 className="text-[22px] font-semibold leading-tight tracking-[-0.4px] text-zinc-500">
+            Study guides
+          </h2>
+          <span className="rounded-md bg-zinc-100 px-2 py-0.5 font-mono text-[12px] font-semibold text-zinc-500">
+            {studyGuides.length}
+          </span>
+        </div>
+        <p className="text-[13px] text-zinc-400">
+          You&rsquo;ll see what your section is sharing once you join.
+        </p>
+      </div>
+      <div
+        className="pointer-events-none grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        aria-hidden={true}
+      >
+        {previews.map((guide, index) => (
+          <div key={guide.id} className={opacities[index] ?? "opacity-30"}>
+            <StudyGuideCard guide={toCardItem(guide)} variant="list" />
+          </div>
+        ))}
+      </div>
+      {lockedCount > 0 ? (
+        <p className="flex items-center justify-center gap-1.5 pt-1 text-[13px] font-medium text-zinc-500">
+          <Lock className="size-3.5 text-zinc-400" aria-hidden={true} />+{" "}
+          {lockedCount} more {lockedCount === 1 ? "guide" : "guides"} locked
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function toCardItem(guide: StudyGuideListItemResponse): StudyGuideCardListItem {
+  const displayName =
+    `${guide.creator.first_name} ${guide.creator.last_name}`.trim() ||
+    "Unknown author";
+  return {
+    id: guide.id,
+    title: guide.title,
+    creator: { display_name: displayName },
+    vote_score: guide.vote_score,
+    quiz_count: guide.quiz_count,
+    is_recommended: guide.is_recommended,
+    tags: guide.tags,
+    course_id: guide.course_id,
+    visibility: guide.visibility,
+  };
+}

--- a/web/app/(dashboard)/courses/[courseId]/page.tsx
+++ b/web/app/(dashboard)/courses/[courseId]/page.tsx
@@ -39,6 +39,8 @@ import {
   type StudyGuideListItemResponse as StudyGuideCardListItem,
 } from "@/lib/features/dashboard/study-guides/study-guide-card";
 
+import { SetDashboardBreadcrumb } from "../../dashboard-breadcrumb-context";
+
 interface PageProps {
   params: Promise<{ courseId: string }>;
 }
@@ -67,8 +69,11 @@ export default async function CourseDetailPage({ params }: PageProps) {
   const studyGuides = studyGuidesRes.study_guides;
   const isEnrolled = Boolean(myEnrollmentInCourse);
 
+  const breadcrumbLabel = `${course.department} ${course.number}`;
+
   return (
     <section className="mx-auto flex w-full max-w-[1184px] flex-col gap-7 px-10 py-8">
+      <SetDashboardBreadcrumb label={breadcrumbLabel} />
       <CourseDetailHeader
         course={course}
         enrolledCount={enrolledCount}
@@ -337,6 +342,7 @@ function toCardItem(guide: StudyGuideListItemResponse): StudyGuideCardListItem {
   return {
     id: guide.id,
     title: guide.title,
+    description: guide.description,
     creator: { display_name: displayName },
     vote_score: guide.vote_score,
     quiz_count: guide.quiz_count,
@@ -344,5 +350,6 @@ function toCardItem(guide: StudyGuideListItemResponse): StudyGuideCardListItem {
     tags: guide.tags,
     course_id: guide.course_id,
     visibility: guide.visibility,
+    updated_at: guide.updated_at,
   };
 }

--- a/web/app/(dashboard)/courses/page.tsx
+++ b/web/app/(dashboard)/courses/page.tsx
@@ -5,14 +5,16 @@ import { Check, Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
-import { SkeletonGrid } from "@/components/ui/skeleton-grid";
 import { listCourses, listMyEnrollments, listSchools } from "@/lib/api";
 import type {
   ListCoursesQuery,
   ListCoursesResponse,
   SchoolResponse,
 } from "@/lib/api/types";
-import { CourseCard } from "@/lib/features/dashboard/courses/course-card";
+import {
+  CourseCard,
+  CourseCardSkeleton,
+} from "@/lib/features/dashboard/courses/course-card";
 import { CourseSearchBar } from "@/lib/features/dashboard/courses/course-search-bar";
 import { toast } from "@/lib/features/shared/toast/toast";
 
@@ -124,7 +126,11 @@ export default function CoursesPage() {
           }
         />
       ) : isLoading && data === null ? (
-        <SkeletonGrid count={9} className={GRID_CLASSES} />
+        <div className={GRID_CLASSES} aria-busy="true" aria-live="polite">
+          {Array.from({ length: 9 }).map((_, i) => (
+            <CourseCardSkeleton key={i} />
+          ))}
+        </div>
       ) : showEmptyState ? (
         <EmptyState
           title="No courses match"

--- a/web/app/(dashboard)/dashboard-breadcrumb-context.tsx
+++ b/web/app/(dashboard)/dashboard-breadcrumb-context.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Lets a page tell the dashboard breadcrumb what to show for its
+ * current segment. The default `DashboardBreadcrumb` only sees the
+ * URL, so dynamic routes like `/courses/[courseId]` would otherwise
+ * surface the raw UUID. Pages render `<SetDashboardBreadcrumb
+ * label="CPTS 322" />` which writes into this context for the
+ * lifetime of the route.
+ */
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+interface BreadcrumbContextValue {
+  currentLabel: string | null;
+  setCurrentLabel: (label: string | null) => void;
+}
+
+const noop = () => undefined;
+
+const DashboardBreadcrumbContext = createContext<BreadcrumbContextValue>({
+  currentLabel: null,
+  setCurrentLabel: noop,
+});
+
+export function DashboardBreadcrumbProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [currentLabel, setCurrentLabel] = useState<string | null>(null);
+  const value = useMemo(
+    () => ({ currentLabel, setCurrentLabel }),
+    [currentLabel],
+  );
+  return (
+    <DashboardBreadcrumbContext.Provider value={value}>
+      {children}
+    </DashboardBreadcrumbContext.Provider>
+  );
+}
+
+export function useDashboardBreadcrumb() {
+  return useContext(DashboardBreadcrumbContext);
+}
+
+/**
+ * Drop this into a page (server or client) to override the trailing
+ * breadcrumb label. Cleans up on unmount so a stale label never
+ * leaks to a sibling route.
+ */
+export function SetDashboardBreadcrumb({ label }: { label: string }) {
+  const { setCurrentLabel } = useDashboardBreadcrumb();
+  useEffect(() => {
+    setCurrentLabel(label);
+    return () => setCurrentLabel(null);
+  }, [label, setCurrentLabel]);
+  return null;
+}

--- a/web/app/(dashboard)/dashboard-breadcrumb.tsx
+++ b/web/app/(dashboard)/dashboard-breadcrumb.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Fragment } from "react";
 import { usePathname } from "next/navigation";
 import { useDashboardCommonCopy } from "@/lib/features/dashboard/i18n/common/common-copy-provider";
 import { DASHBOARD_ROUTES } from "@/lib/features/dashboard/navigation/routes";
@@ -7,9 +8,13 @@ import { DASHBOARD_ROUTES } from "@/lib/features/dashboard/navigation/routes";
 import {
   Breadcrumb,
   BreadcrumbItem,
+  BreadcrumbLink,
   BreadcrumbList,
   BreadcrumbPage,
+  BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+
+import { useDashboardBreadcrumb } from "./dashboard-breadcrumb-context";
 
 function segmentToLabel(segment: string) {
   return segment
@@ -19,31 +24,12 @@ function segmentToLabel(segment: string) {
     .join(" ");
 }
 
-function getBreadcrumbLabel(
-  pathname: string,
-  labels: Record<string, string>,
-  homeFallback: string,
-) {
-  const matchedCopy = labels[pathname];
-
-  if (matchedCopy) {
-    return matchedCopy;
-  }
-
-  const segments = pathname.split("/").filter(Boolean);
-
-  if (!segments.length) {
-    return homeFallback;
-  }
-
-  return segmentToLabel(segments[segments.length - 1]);
-}
-
 export function DashboardBreadcrumb() {
   const copy = useDashboardCommonCopy();
   const pathname = usePathname();
+  const { currentLabel } = useDashboardBreadcrumb();
 
-  const breadcrumbLabelByPath: Record<string, string> = {
+  const labelByPath: Record<string, string> = {
     [DASHBOARD_ROUTES.home]: copy.breadcrumb.home,
     [DASHBOARD_ROUTES.courses]: copy.breadcrumb.browseCourses,
     [DASHBOARD_ROUTES.myCourses]: copy.breadcrumb.myCourses,
@@ -55,18 +41,51 @@ export function DashboardBreadcrumb() {
     [DASHBOARD_ROUTES.saved]: copy.breadcrumb.starred,
   };
 
-  const label = getBreadcrumbLabel(
-    pathname,
-    breadcrumbLabelByPath,
-    copy.breadcrumb.home,
-  );
+  const segments = pathname.split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    return (
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbPage>{copy.breadcrumb.home}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    );
+  }
+
+  // Build the trail. For each segment we want a label and an href.
+  // The last segment renders as `BreadcrumbPage` (not a link); the
+  // rest are clickable links back up the tree. Page-provided labels
+  // (via context) take precedence on the trailing segment so a
+  // dynamic route like `/courses/[uuid]` shows the human label
+  // instead of the raw UUID.
+  const items = segments.map((segment, index) => {
+    const isLast = index === segments.length - 1;
+    const href = "/" + segments.slice(0, index + 1).join("/");
+    const labelFromCopy = labelByPath[href];
+    const label = isLast
+      ? (currentLabel ?? labelFromCopy ?? segmentToLabel(segment))
+      : (labelFromCopy ?? segmentToLabel(segment));
+    return { href, label, isLast };
+  });
 
   return (
     <Breadcrumb>
       <BreadcrumbList>
-        <BreadcrumbItem>
-          <BreadcrumbPage>{label}</BreadcrumbPage>
-        </BreadcrumbItem>
+        {items.map((item, index) => (
+          <Fragment key={item.href}>
+            {index > 0 ? <BreadcrumbSeparator /> : null}
+            <BreadcrumbItem>
+              {item.isLast ? (
+                <BreadcrumbPage>{item.label}</BreadcrumbPage>
+              ) : (
+                <BreadcrumbLink href={item.href}>{item.label}</BreadcrumbLink>
+              )}
+            </BreadcrumbItem>
+          </Fragment>
+        ))}
       </BreadcrumbList>
     </Breadcrumb>
   );

--- a/web/app/(dashboard)/layout.tsx
+++ b/web/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import { AppSidebar } from "@/lib/features/dashboard/sidebar";
 import { DashboardBreadcrumb } from "./dashboard-breadcrumb";
+import { DashboardBreadcrumbProvider } from "./dashboard-breadcrumb-context";
 import { Separator } from "@/components/ui/separator";
 import { DashboardCommonCopyProvider } from "@/lib/features/dashboard/i18n/common/common-copy-provider";
 import { getDashboardCommonDictionary } from "@/lib/features/dashboard/i18n/common/get-common-dictionary";
@@ -23,23 +24,25 @@ export default async function DashboardLayout({
   return (
     <TooltipProvider>
       <DashboardCommonCopyProvider copy={commonCopy}>
-        <SidebarProvider>
-          <AppSidebar />
-          <SidebarInset className="h-screen overflow-y-auto">
-            <header className="bg-background/95 sticky top-0 z-20 flex h-16 shrink-0 items-center gap-2 border-b backdrop-blur supports-backdrop-filter:bg-background/80 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-              <div className="flex items-center gap-2 px-4">
-                <SidebarTrigger className="-ml-1" />
-                <Separator
-                  orientation="vertical"
-                  className="mr-2 data-[orientation=vertical]:h-4"
-                />
-                <DashboardBreadcrumb />
-              </div>
-            </header>
-            <main className="flex flex-1 flex-col gap-4 p-4">{children}</main>
-          </SidebarInset>
-        </SidebarProvider>
-        <ToastProvider />
+        <DashboardBreadcrumbProvider>
+          <SidebarProvider>
+            <AppSidebar />
+            <SidebarInset className="h-screen overflow-y-auto">
+              <header className="bg-background/95 sticky top-0 z-20 flex h-16 shrink-0 items-center gap-2 border-b backdrop-blur supports-backdrop-filter:bg-background/80 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+                <div className="flex items-center gap-2 px-4">
+                  <SidebarTrigger className="-ml-1" />
+                  <Separator
+                    orientation="vertical"
+                    className="mr-2 data-[orientation=vertical]:h-4"
+                  />
+                  <DashboardBreadcrumb />
+                </div>
+              </header>
+              <main className="flex flex-1 flex-col gap-4 p-4">{children}</main>
+            </SidebarInset>
+          </SidebarProvider>
+          <ToastProvider />
+        </DashboardBreadcrumbProvider>
       </DashboardCommonCopyProvider>
     </TooltipProvider>
   );

--- a/web/lib/features/dashboard/courses/course-card.tsx
+++ b/web/lib/features/dashboard/courses/course-card.tsx
@@ -2,8 +2,18 @@ import Link from "next/link";
 import { type ReactNode } from "react";
 import { ArrowRight, Layers, Users } from "lucide-react";
 
+import { Skeleton } from "@/components/ui/skeleton";
 import type { CourseResponse } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
+
+// Shared shell so the skeleton renders in the exact same outer
+// shape as the real card. Any change to padding / radius / border
+// here flows to both the populated card and the loading state, so
+// the two never drift.
+const TILE_SHELL_CLASSES =
+  "group bg-card focus-within:ring-ring relative rounded-[10px] border border-zinc-200 transition-all";
+const TILE_INNER_CLASSES =
+  "flex min-h-[180px] flex-col gap-2.5 px-5 pb-4 pt-[18px]";
 
 interface CourseCardProps {
   course: CourseResponse;
@@ -36,10 +46,7 @@ export function CourseCard({
 
   return (
     <div
-      className={cn(
-        "group bg-card focus-within:ring-ring relative rounded-[10px] border border-zinc-200 transition-all",
-        "hover:shadow-md focus-within:ring-2",
-      )}
+      className={cn(TILE_SHELL_CLASSES, "hover:shadow-md focus-within:ring-2")}
     >
       <Link
         href={destination}
@@ -57,6 +64,30 @@ export function CourseCard({
           sectionCount={sectionCount}
         />
       )}
+    </div>
+  );
+}
+
+/**
+ * Loading placeholder that mirrors {@link CourseCard}'s tile shape.
+ * Lives next to the real card so the two share `TILE_SHELL_CLASSES`
+ * + `TILE_INNER_CLASSES` and can't drift apart silently.
+ */
+export function CourseCardSkeleton() {
+  return (
+    <div className={TILE_SHELL_CLASSES} aria-hidden={true}>
+      <div className={cn(TILE_INNER_CLASSES, "pointer-events-none")}>
+        <div className="flex items-start justify-between gap-2">
+          <Skeleton className="h-3.5 w-16" />
+        </div>
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/5" />
+        <Skeleton className="h-3.5 w-2/5" />
+        <div className="flex-1" />
+        <div className="flex justify-end">
+          <Skeleton className="size-3.5 rounded-full" />
+        </div>
+      </div>
     </div>
   );
 }
@@ -107,7 +138,7 @@ function TileVariant({
     typeof memberCount === "number" || typeof sectionCount === "number";
 
   return (
-    <div className="pointer-events-none flex min-h-[180px] flex-col gap-2.5 px-5 pb-4 pt-[18px]">
+    <div className={cn(TILE_INNER_CLASSES, "pointer-events-none")}>
       <div className="flex items-start justify-between gap-2">
         <span className="text-foreground font-mono text-[13px] font-semibold tracking-[-0.2px]">
           {code}

--- a/web/lib/features/dashboard/courses/course-detail-header.tsx
+++ b/web/lib/features/dashboard/courses/course-detail-header.tsx
@@ -1,0 +1,102 @@
+import { Calendar, FileText, Layers, Share2, Star, Users } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { CourseDetailResponse } from "@/lib/api/types";
+
+interface CourseDetailHeaderProps {
+  course: CourseDetailResponse;
+  /** Total enrolled across sections — `sum(section.member_count)`. */
+  enrolledCount: number;
+  studyGuidesCount: number;
+  /** Optional term label rendered next to the dept code (e.g. "Spring 2026"). */
+  termLabel?: string;
+  /** Optional formatted "Last updated" string. */
+  lastUpdatedLabel?: string;
+  /** Optional trailing action(s) placed next to Star + Share. */
+  trailingActions?: ReactNode;
+}
+
+export function CourseDetailHeader({
+  course,
+  enrolledCount,
+  studyGuidesCount,
+  termLabel,
+  lastUpdatedLabel,
+  trailingActions,
+}: CourseDetailHeaderProps) {
+  const code = `${course.department} ${course.number}`;
+  const sectionsCount = course.sections.length;
+
+  return (
+    <header className="flex flex-col gap-3.5">
+      <div className="flex items-start justify-between gap-6">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex items-center gap-2.5">
+            <span className="text-foreground font-mono text-[13px] font-semibold tracking-[-0.2px]">
+              {code}
+            </span>
+            {termLabel ? (
+              <>
+                <span
+                  className="size-[3px] rounded-full bg-zinc-300"
+                  aria-hidden={true}
+                />
+                <span className="text-[13px] text-zinc-500">{termLabel}</span>
+              </>
+            ) : null}
+          </div>
+          <h1 className="text-foreground text-[30px] font-semibold leading-[1.15] tracking-[-0.6px]">
+            {course.title}
+          </h1>
+          <p className="text-[14px] text-zinc-600">{course.school.name}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            aria-label="Favorite"
+            className="size-9"
+          >
+            <Star className="size-4" aria-hidden={true} />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            aria-label="Share"
+            className="size-9"
+          >
+            <Share2 className="size-4" aria-hidden={true} />
+          </Button>
+          {trailingActions}
+        </div>
+      </div>
+
+      <div className="h-px w-full bg-zinc-200" />
+
+      <div className="flex flex-wrap items-center gap-x-[18px] gap-y-2 text-[13px] font-medium text-zinc-600">
+        <span className="flex items-center gap-1.5">
+          <Users className="size-3.5 text-zinc-400" aria-hidden={true} />
+          {enrolledCount.toLocaleString()} enrolled
+        </span>
+        <span className="flex items-center gap-1.5">
+          <Layers className="size-3.5 text-zinc-400" aria-hidden={true} />
+          {sectionsCount} {sectionsCount === 1 ? "section" : "sections"}
+        </span>
+        <span className="flex items-center gap-1.5">
+          <FileText className="size-3.5 text-zinc-400" aria-hidden={true} />
+          {studyGuidesCount}{" "}
+          {studyGuidesCount === 1 ? "study guide" : "study guides"}
+        </span>
+        {lastUpdatedLabel ? (
+          <span className="flex items-center gap-1.5">
+            <Calendar className="size-3.5 text-zinc-400" aria-hidden={true} />
+            {lastUpdatedLabel}
+          </span>
+        ) : null}
+      </div>
+    </header>
+  );
+}

--- a/web/lib/features/dashboard/courses/course-detail-header.tsx
+++ b/web/lib/features/dashboard/courses/course-detail-header.tsx
@@ -39,17 +39,21 @@ export function CourseDetailHeader({
             {termLabel ? (
               <>
                 <span
-                  className="size-[3px] rounded-full bg-zinc-300"
+                  className="bg-border size-[3px] rounded-full"
                   aria-hidden={true}
                 />
-                <span className="text-[13px] text-zinc-500">{termLabel}</span>
+                <span className="text-muted-foreground text-[13px]">
+                  {termLabel}
+                </span>
               </>
             ) : null}
           </div>
           <h1 className="text-foreground text-[30px] font-semibold leading-[1.15] tracking-[-0.6px]">
             {course.title}
           </h1>
-          <p className="text-[14px] text-zinc-600">{course.school.name}</p>
+          <p className="text-muted-foreground text-[14px]">
+            {course.school.name}
+          </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <Button
@@ -74,25 +78,37 @@ export function CourseDetailHeader({
         </div>
       </div>
 
-      <div className="h-px w-full bg-zinc-200" />
+      <div className="bg-border h-px w-full" />
 
-      <div className="flex flex-wrap items-center gap-x-[18px] gap-y-2 text-[13px] font-medium text-zinc-600">
+      <div className="text-muted-foreground flex flex-wrap items-center gap-x-[18px] gap-y-2 text-[13px] font-medium">
         <span className="flex items-center gap-1.5">
-          <Users className="size-3.5 text-zinc-400" aria-hidden={true} />
+          <Users
+            className="text-muted-foreground/60 size-3.5"
+            aria-hidden={true}
+          />
           {enrolledCount.toLocaleString()} enrolled
         </span>
         <span className="flex items-center gap-1.5">
-          <Layers className="size-3.5 text-zinc-400" aria-hidden={true} />
+          <Layers
+            className="text-muted-foreground/60 size-3.5"
+            aria-hidden={true}
+          />
           {sectionsCount} {sectionsCount === 1 ? "section" : "sections"}
         </span>
         <span className="flex items-center gap-1.5">
-          <FileText className="size-3.5 text-zinc-400" aria-hidden={true} />
+          <FileText
+            className="text-muted-foreground/60 size-3.5"
+            aria-hidden={true}
+          />
           {studyGuidesCount}{" "}
           {studyGuidesCount === 1 ? "study guide" : "study guides"}
         </span>
         {lastUpdatedLabel ? (
           <span className="flex items-center gap-1.5">
-            <Calendar className="size-3.5 text-zinc-400" aria-hidden={true} />
+            <Calendar
+              className="text-muted-foreground/60 size-3.5"
+              aria-hidden={true}
+            />
             {lastUpdatedLabel}
           </span>
         ) : null}

--- a/web/lib/features/dashboard/courses/section-membership-button.tsx
+++ b/web/lib/features/dashboard/courses/section-membership-button.tsx
@@ -91,12 +91,16 @@ export function SectionMembershipButton({
   }
 
   const handleJoin = () => {
+    // Don't optimistically swap to "member" -- access to the course
+    // material depends on the server confirming enrollment, so the
+    // caller drives a router.refresh inside this transition and the
+    // button stays in `isPending` (spinner) until the new server
+    // payload renders. Errors bubble to the caller's toast.
     startTransition(async () => {
-      setOptimisticMembership("member");
       try {
         await onJoin();
       } catch {
-        // useOptimistic reverts on settle; caller surfaces toast.
+        // caller surfaces toast.
       }
     });
   };
@@ -106,9 +110,14 @@ export function SectionMembershipButton({
       type="button"
       disabled={isPending}
       onClick={handleJoin}
+      aria-label={isPending ? "Joining section" : undefined}
       className={cn("min-w-[5.5rem]", className)}
     >
-      Join
+      {isPending ? (
+        <Loader2 className="size-4 animate-spin" aria-hidden={true} />
+      ) : (
+        "Join"
+      )}
     </Button>
   );
 }

--- a/web/lib/features/dashboard/courses/section-row.tsx
+++ b/web/lib/features/dashboard/courses/section-row.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+
+import { joinSection, leaveSection } from "@/lib/api";
+import type { SectionSummary } from "@/lib/api/types";
+import { toast } from "@/lib/features/shared/toast/toast";
+import { cn } from "@/lib/utils";
+
+import { SectionMembershipButton } from "./section-membership-button";
+
+type Membership = "member" | "not-member" | "unknown";
+
+interface SectionRowProps {
+  courseId: string;
+  section: SectionSummary;
+  /**
+   * Initial membership state for this section. The page determines this
+   * by checking the user's enrollments — pass `"unknown"` only when the
+   * caller can't pre-resolve it (the button will still render correctly).
+   */
+  initialMembership: Membership;
+  className?: string;
+}
+
+export function SectionRow({
+  courseId,
+  section,
+  initialMembership,
+  className,
+}: SectionRowProps) {
+  const [membership, setMembership] = useState<Membership>(initialMembership);
+
+  const sectionLabel = section.section_code
+    ? `Section ${section.section_code}`
+    : "Section";
+
+  const handleJoin = async () => {
+    try {
+      await joinSection(courseId, section.id);
+      setMembership("member");
+    } catch (err) {
+      toast.error(err);
+      throw err;
+    }
+  };
+
+  const handleLeave = async () => {
+    try {
+      await leaveSection(courseId, section.id);
+      setMembership("not-member");
+    } catch (err) {
+      toast.error(err);
+      throw err;
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-4 px-5 py-3.5",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-3.5">
+        <span className="rounded-md bg-zinc-100 px-2 py-0.5 font-mono text-[11px] font-semibold tracking-[-0.2px] text-zinc-800">
+          {sectionLabel}
+        </span>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <p className="truncate text-[14px] font-medium text-zinc-950">
+            {section.instructor_name ?? "Instructor TBA"}
+          </p>
+          <p className="truncate text-[12px] text-zinc-500">
+            <span>{section.term}</span>
+            <span className="px-2 text-zinc-300" aria-hidden={true}>
+              ·
+            </span>
+            <span>
+              {section.member_count}{" "}
+              {section.member_count === 1 ? "member" : "members"}
+            </span>
+          </p>
+        </div>
+      </div>
+      <SectionMembershipButton
+        membership={membership}
+        onJoin={handleJoin}
+        onLeave={handleLeave}
+      />
+    </div>
+  );
+}

--- a/web/lib/features/dashboard/courses/section-row.tsx
+++ b/web/lib/features/dashboard/courses/section-row.tsx
@@ -63,16 +63,16 @@ export function SectionRow({
       )}
     >
       <div className="flex min-w-0 flex-1 items-center gap-3.5">
-        <span className="rounded-md bg-zinc-100 px-2 py-0.5 font-mono text-[11px] font-semibold tracking-[-0.2px] text-zinc-800">
+        <span className="bg-muted text-foreground rounded-md px-2 py-0.5 font-mono text-[11px] font-semibold tracking-[-0.2px]">
           {sectionLabel}
         </span>
         <div className="flex min-w-0 flex-col gap-0.5">
-          <p className="truncate text-[14px] font-medium text-zinc-950">
+          <p className="text-foreground truncate text-[14px] font-medium">
             {section.instructor_name ?? "Instructor TBA"}
           </p>
-          <p className="truncate text-[12px] text-zinc-500">
+          <p className="text-muted-foreground truncate text-[12px]">
             <span>{section.term}</span>
-            <span className="px-2 text-zinc-300" aria-hidden={true}>
+            <span className="text-muted-foreground/50 px-2" aria-hidden={true}>
               ·
             </span>
             <span>

--- a/web/lib/features/dashboard/courses/section-row.tsx
+++ b/web/lib/features/dashboard/courses/section-row.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { joinSection, leaveSection } from "@/lib/api";
@@ -29,6 +30,7 @@ export function SectionRow({
   initialMembership,
   className,
 }: SectionRowProps) {
+  const router = useRouter();
   const [membership, setMembership] = useState<Membership>(initialMembership);
 
   const sectionLabel = section.section_code
@@ -38,7 +40,12 @@ export function SectionRow({
   const handleJoin = async () => {
     try {
       await joinSection(courseId, section.id);
-      setMembership("member");
+      // Re-fetch the route so the page swaps from the picker view to
+      // the enrolled banner + study-guide grid. router.refresh() is
+      // called inside the button's transition, so the spinner stays
+      // up until the new server payload renders -- no flash of
+      // stale "Join" UI between success and the page swap.
+      router.refresh();
     } catch (err) {
       toast.error(err);
       throw err;
@@ -49,6 +56,7 @@ export function SectionRow({
     try {
       await leaveSection(courseId, section.id);
       setMembership("not-member");
+      router.refresh();
     } catch (err) {
       toast.error(err);
       throw err;

--- a/web/lib/features/dashboard/study-guides/study-guide-card.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-card.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import { ChevronUp, Globe2, Lock, NotebookPen } from "lucide-react";
+
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
@@ -6,12 +8,12 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Globe2, Lock, ThumbsUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface StudyGuideListItemResponse {
   id: string;
   title: string;
+  description?: string | null;
   creator: { display_name: string };
   vote_score: number;
   quiz_count: number;
@@ -23,6 +25,8 @@ export interface StudyGuideListItemResponse {
   // distinguish `private` vs `public` here; the "Shared" indicator
   // (private + >=1 grant) surfaces on the detail page instead.
   visibility: "private" | "public";
+  /** ISO 8601 timestamp; rendered as a relative "X days ago" label when present. */
+  updated_at?: string;
 }
 
 interface StudyGuideCardProps {
@@ -40,21 +44,29 @@ export function StudyGuideCard({
 }: StudyGuideCardProps) {
   const destination = href ?? `/study-guides/${guide.id}`;
 
+  if (variant === "compact") {
+    return (
+      <Link
+        href={destination}
+        className={cn(
+          "bg-card border-border block rounded-xl border p-4 transition-all",
+          "hover:border-foreground/20 hover:shadow-md",
+        )}
+      >
+        <CompactVariant guide={guide} />
+      </Link>
+    );
+  }
+
   return (
     <Link
       href={destination}
       className={cn(
-        "block rounded-xl border p-4 transition-all duration-200",
-        "bg-gray-50 dark:bg-black",
-        "border-black/10 dark:border-white/20",
-        "hover:shadow-md dark:hover:shadow-2xl dark:hover:shadow-emerald-500/10",
+        "bg-card border-border group flex h-full flex-col gap-2.5 rounded-[10px] border px-5 pb-4 pt-[18px] transition-all",
+        "hover:border-foreground/20 focus-visible:ring-ring hover:shadow-md focus-visible:outline-hidden focus-visible:ring-2",
       )}
     >
-      {variant === "compact" ? (
-        <CompactVariant guide={guide} />
-      ) : (
-        <ListVariant guide={guide} courseLabel={courseLabel} />
-      )}
+      <ListVariant guide={guide} courseLabel={courseLabel} />
     </Link>
   );
 }
@@ -83,61 +95,116 @@ function ListVariant({
   guide: StudyGuideListItemResponse;
   courseLabel?: string;
 }) {
+  const initial =
+    guide.creator.display_name.trim().charAt(0).toUpperCase() || "?";
+  const relative = formatRelativeTime(guide.updated_at);
+
   return (
-    <div className="space-y-3">
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex min-w-0 flex-1 items-start gap-1.5">
-          <p className="line-clamp-2 flex-1 text-sm font-bold leading-snug text-foreground">
-            {guide.title}
-          </p>
-          <VisibilityIndicator visibility={guide.visibility} />
+    <>
+      <div className="flex items-start gap-3.5">
+        <div className="flex shrink-0 flex-col items-center gap-0.5 pt-0.5">
+          <ChevronUp
+            className="text-muted-foreground size-3.5"
+            aria-hidden={true}
+          />
+          <span className="text-foreground font-mono text-[12px] font-semibold">
+            {guide.vote_score}
+          </span>
         </div>
-        {guide.is_recommended && (
-          <Badge
-            variant="secondary"
-            className="shrink-0 text-xs bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400"
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <div className="flex items-start gap-1.5">
+            <h3 className="text-foreground line-clamp-2 flex-1 text-[15px] font-semibold leading-[1.35] tracking-[-0.2px]">
+              {guide.title}
+            </h3>
+            <VisibilityIndicator visibility={guide.visibility} />
+            {guide.is_recommended ? (
+              <Badge
+                variant="secondary"
+                className="bg-primary/10 text-primary shrink-0 text-[11px] font-semibold"
+              >
+                Recommended
+              </Badge>
+            ) : null}
+          </div>
+          {guide.description ? (
+            <p className="text-muted-foreground line-clamp-2 text-[13px] leading-[1.5]">
+              {guide.description}
+            </p>
+          ) : null}
+          {courseLabel ? (
+            <p className="text-muted-foreground text-[12px]">{courseLabel}</p>
+          ) : null}
+          {guide.tags.length > 0 ? (
+            <div className="flex flex-wrap gap-1 pt-0.5">
+              {guide.tags.map((tag, index) => (
+                <Badge
+                  key={`${tag}-${index}`}
+                  variant="secondary"
+                  className="bg-muted text-muted-foreground text-[11px]"
+                >
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex-1" />
+
+      <div className="bg-border/60 h-px w-full" />
+
+      <div className="flex items-center justify-between pt-1.5 text-[12px]">
+        <div className="text-muted-foreground flex min-w-0 items-center gap-2">
+          <span
+            className="bg-muted text-foreground inline-flex size-[22px] shrink-0 items-center justify-center rounded-full font-semibold"
+            aria-hidden={true}
           >
-            Recommended
-          </Badge>
-        )}
-      </div>
-
-      <p className="text-xs text-muted-foreground">
-        by {guide.creator.display_name}
-        {courseLabel ? ` · ${courseLabel}` : ""}
-      </p>
-
-      <div className="flex items-center gap-2">
-        <Badge
-          variant="outline"
-          className="flex items-center gap-1 text-xs border-border text-muted-foreground"
-        >
-          <ThumbsUp className="h-3 w-3" />
-          {guide.vote_score}
-        </Badge>
-        <Badge
-          variant="outline"
-          className="text-xs border-border text-muted-foreground"
-        >
-          {guide.quiz_count === 1 ? "1 quiz" : `${guide.quiz_count} quizzes`}
-        </Badge>
-      </div>
-
-      {guide.tags.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {guide.tags.map((tag, index) => (
-            <Badge
-              key={`${tag}-${index}`}
-              variant="secondary"
-              className="text-xs bg-muted text-muted-foreground"
-            >
-              {tag}
-            </Badge>
-          ))}
+            {initial}
+          </span>
+          <span className="text-foreground/80 truncate font-medium">
+            {guide.creator.display_name}
+          </span>
+          {relative ? (
+            <>
+              <span className="text-muted-foreground/50" aria-hidden={true}>
+                ·
+              </span>
+              <span className="truncate">{relative}</span>
+            </>
+          ) : null}
         </div>
-      )}
-    </div>
+        <span className="text-muted-foreground flex shrink-0 items-center gap-1.5 font-medium">
+          <NotebookPen
+            className="text-muted-foreground/60 size-3"
+            aria-hidden={true}
+          />
+          {guide.quiz_count}
+        </span>
+      </div>
+    </>
   );
+}
+
+function formatRelativeTime(iso?: string): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  const diffMs = Date.now() - then;
+  if (diffMs < 0) return "just now";
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 4) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
 }
 
 function VisibilityIndicator({


### PR DESCRIPTION
## Summary
- Adds `/courses/[courseId]` as a Server Component (ASK-197). Parallel-fetches `getCourse`, `listCourseStudyGuides`, and `listMyEnrollments`. The enrollment list pre-resolves per-section membership without an N+1 of `checkMembership` calls. A 404 from `getCourse` routes through `notFound()`.
- Two states based on whether the caller is in a section of this course:
  - **Enrolled**: stone-tinted "You're in Section 0X" status banner + study-guide grid (with `+ New guide` CTA, `No study guides yet` empty state).
  - **Not enrolled**: `Pick a section` card lists the sections inline with `<SectionMembershipButton>` Join controls; study-guide grid is replaced by a dimmed teaser ("+ N more guides locked"). Empty section list renders `No sections offered`.
- `SectionRow` is a small client wrapper that binds `joinSection` / `leaveSection` to the existing button + surfaces failures via the shared toast.

## Test plan
- [x] `pnpm exec jest courses` — 31 tests pass (6 new ASK-197 tests cover AC1–5 + the not-enrolled case).
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec eslint` clean on the four new files.
- [x] `pnpm exec prettier --check` clean.
- [ ] Manual eyeball on staging at `/courses/<id>` — both joined and not-joined paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added course detail page displaying course metadata, sections, and study guides
  * Integrated section enrollment system with join/leave functionality
  * Course header showing enrollment stats and quick actions (favorite, share)
  * Study guide preview UI for enrolled and non-enrolled users

* **Tests**
  * Added comprehensive test suite for course detail page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->