### PR TITLE
feat(web): wire create-study-guide page to the editor (ASK-191)

### DIFF
--- a/web/app/(dashboard)/study-guides/new/new-study-guide-form.test.tsx
+++ b/web/app/(dashboard)/study-guides/new/new-study-guide-form.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * ASK-191 acceptance tests for the create-a-study-guide page.
+ * Mocks the API actions, the toast, and `next/navigation` so the
+ * test owns the redirect + error surface.
+ */
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { ApiError } from "@/lib/api/errors";
+import type { EnrollmentResponse } from "@/lib/api/types";
+
+// ContentEditor transitively imports react-markdown (ESM); the same
+// stub the StudyGuideForm test uses keeps Jest from choking on it.
+jest.mock(
+  "../../../../lib/features/dashboard/study-guides/content-editor",
+  () => ({
+    ContentEditor: React.forwardRef<
+      unknown,
+      { value: string; onChange: (next: string) => void }
+    >(function StubContentEditor({ value, onChange }) {
+      return (
+        <textarea
+          aria-label="Content"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      );
+    }),
+  }),
+);
+
+import { NewStudyGuideForm } from "./new-study-guide-form";
+
+const pushMock = jest.fn();
+const backMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+    back: backMock,
+    refresh: jest.fn(),
+    replace: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
+jest.mock("../../../../lib/api", () => ({
+  createStudyGuideForCourse: jest.fn(),
+}));
+
+const toastErrorMock = jest.fn();
+jest.mock("../../../../lib/features/shared/toast/toast", () => ({
+  toast: {
+    error: (err: unknown) => toastErrorMock(err),
+    success: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+import { createStudyGuideForCourse } from "../../../../lib/api";
+const createMock = createStudyGuideForCourse as jest.MockedFunction<
+  typeof createStudyGuideForCourse
+>;
+
+const COURSE_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+function makeEnrollments(courseId = COURSE_A): EnrollmentResponse[] {
+  return [
+    {
+      section: {
+        id: "11111111-1111-1111-1111-111111111111",
+        term: "Spring 2026",
+        section_code: "01",
+        instructor_name: "Dr. Aragoneses",
+      },
+      course: {
+        id: courseId,
+        department: "CPTS",
+        number: "322",
+        title: "Systems Programming",
+      },
+      school: { id: "s_1", acronym: "WSU" },
+      role: "student",
+      joined_at: "2026-04-20T10:00:00Z",
+    },
+  ];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("NewStudyGuideForm (ASK-191)", () => {
+  it("submits a valid draft to the selected course and redirects (AC1)", async () => {
+    createMock.mockResolvedValue({
+      id: "g_new",
+    } as Awaited<ReturnType<typeof createStudyGuideForCourse>>);
+    render(
+      <NewStudyGuideForm
+        enrollments={makeEnrollments()}
+        defaultCourseId={null}
+      />,
+    );
+    await userEvent.type(screen.getByLabelText(/title/i), "Buffer Overflows");
+    await userEvent.type(
+      screen.getByLabelText(/content/i),
+      "Stack smashing walkthrough...",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
+    expect(createMock).toHaveBeenCalledWith(
+      COURSE_A,
+      expect.objectContaining({
+        title: "Buffer Overflows",
+        content: "Stack smashing walkthrough...",
+      }),
+    );
+    await waitFor(() =>
+      expect(pushMock).toHaveBeenCalledWith("/study-guides/g_new"),
+    );
+  });
+
+  it("toasts a forbidden ApiError without redirecting (AC2)", async () => {
+    const apiErr = new ApiError(
+      "POST /courses/.../study-guides failed: 403",
+      { status: 403 } as unknown as Response,
+      { code: 403, status: "forbidden", message: "Not enrolled" },
+    );
+    createMock.mockRejectedValue(apiErr);
+    render(
+      <NewStudyGuideForm
+        enrollments={makeEnrollments()}
+        defaultCourseId={null}
+      />,
+    );
+    await userEvent.type(screen.getByLabelText(/title/i), "Buffer Overflows");
+    await userEvent.type(
+      screen.getByLabelText(/content/i),
+      "Stack smashing walkthrough...",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith(apiErr));
+    expect(pushMock).not.toHaveBeenCalled();
+    expect((screen.getByLabelText(/title/i) as HTMLInputElement).value).toBe(
+      "Buffer Overflows",
+    );
+  });
+
+  it("renders the empty state with a /courses link when no enrollments (AC3)", () => {
+    render(<NewStudyGuideForm enrollments={[]} defaultCourseId={null} />);
+    expect(screen.getByText("Join a course first")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Browse courses" }),
+    ).toHaveAttribute("href", "/courses");
+    expect(screen.queryByLabelText(/title/i)).not.toBeInTheDocument();
+  });
+
+  it("calls router.back() when Cancel is clicked (AC4)", async () => {
+    render(
+      <NewStudyGuideForm
+        enrollments={makeEnrollments()}
+        defaultCourseId={null}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(backMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/app/(dashboard)/study-guides/new/new-study-guide-form.test.tsx
+++ b/web/app/(dashboard)/study-guides/new/new-study-guide-form.test.tsx
@@ -109,7 +109,9 @@ describe("NewStudyGuideForm (ASK-191)", () => {
       screen.getByLabelText(/content/i),
       "Stack smashing walkthrough...",
     );
-    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /save as draft/i }),
+    );
     await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
     expect(createMock).toHaveBeenCalledWith(
       COURSE_A,
@@ -141,7 +143,9 @@ describe("NewStudyGuideForm (ASK-191)", () => {
       screen.getByLabelText(/content/i),
       "Stack smashing walkthrough...",
     );
-    await userEvent.click(screen.getByRole("button", { name: /create/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /save as draft/i }),
+    );
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith(apiErr));
     expect(pushMock).not.toHaveBeenCalled();
     expect((screen.getByLabelText(/title/i) as HTMLInputElement).value).toBe(

--- a/web/app/(dashboard)/study-guides/new/new-study-guide-form.test.tsx
+++ b/web/app/(dashboard)/study-guides/new/new-study-guide-form.test.tsx
@@ -109,9 +109,7 @@ describe("NewStudyGuideForm (ASK-191)", () => {
       screen.getByLabelText(/content/i),
       "Stack smashing walkthrough...",
     );
-    await userEvent.click(
-      screen.getByRole("button", { name: /save as draft/i }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: /create/i }));
     await waitFor(() => expect(createMock).toHaveBeenCalledTimes(1));
     expect(createMock).toHaveBeenCalledWith(
       COURSE_A,
@@ -143,9 +141,7 @@ describe("NewStudyGuideForm (ASK-191)", () => {
       screen.getByLabelText(/content/i),
       "Stack smashing walkthrough...",
     );
-    await userEvent.click(
-      screen.getByRole("button", { name: /save as draft/i }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: /create/i }));
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith(apiErr));
     expect(pushMock).not.toHaveBeenCalled();
     expect((screen.getByLabelText(/title/i) as HTMLInputElement).value).toBe(

--- a/web/app/(dashboard)/study-guides/new/new-study-guide-form.tsx
+++ b/web/app/(dashboard)/study-guides/new/new-study-guide-form.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+/**
+ * Client child for `/study-guides/new` (ASK-191). Picks the
+ * destination course (must be one the caller is enrolled in),
+ * then delegates the rest to the shared `<StudyGuideForm>`.
+ */
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMemo, useRef, useState } from "react";
+import { BookOpen } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { createStudyGuideForCourse } from "@/lib/api";
+import { ApiError } from "@/lib/api/errors";
+import type {
+  CreateStudyGuideRequest,
+  EnrollmentResponse,
+  UpdateStudyGuideRequest,
+} from "@/lib/api/types";
+import {
+  StudyGuideForm,
+  type StudyGuideFormField,
+  type StudyGuideFormHandle,
+} from "@/lib/features/dashboard/study-guides/study-guide-form";
+import { toast } from "@/lib/features/shared/toast/toast";
+
+interface NewStudyGuideFormProps {
+  enrollments: EnrollmentResponse[];
+  /**
+   * Course id from `?course=<id>`. Pre-selects the matching
+   * enrollment when present and valid; ignored otherwise.
+   */
+  defaultCourseId: string | null;
+}
+
+export function NewStudyGuideForm({
+  enrollments,
+  defaultCourseId,
+}: NewStudyGuideFormProps) {
+  const router = useRouter();
+  const formRef = useRef<StudyGuideFormHandle>(null);
+
+  // De-dupe by course id -- a user can be enrolled in multiple
+  // sections of the same course over different terms; the picker
+  // only cares about the destination course, not the section.
+  const courses = useMemo(() => {
+    const seen = new Set<string>();
+    const list: EnrollmentResponse["course"][] = [];
+    for (const e of enrollments) {
+      if (seen.has(e.course.id)) continue;
+      seen.add(e.course.id);
+      list.push(e.course);
+    }
+    return list;
+  }, [enrollments]);
+
+  const initialCourseId =
+    defaultCourseId && courses.some((c) => c.id === defaultCourseId)
+      ? defaultCourseId
+      : (courses[0]?.id ?? null);
+
+  const [selectedCourseId, setSelectedCourseId] = useState<string | null>(
+    initialCourseId,
+  );
+
+  if (courses.length === 0) {
+    return (
+      <section className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-6 py-10">
+        <Header />
+        <EmptyState
+          icon={<BookOpen className="size-8" aria-hidden={true} />}
+          title="Join a course first"
+          body="Study guides are created under a course. Join one to start writing."
+          action={
+            <Button asChild>
+              <Link href="/courses">Browse courses</Link>
+            </Button>
+          }
+          className="border-border bg-muted/30 rounded-[10px] border py-12"
+        />
+      </section>
+    );
+  }
+
+  const handleSubmit = async (
+    body: CreateStudyGuideRequest | UpdateStudyGuideRequest,
+  ) => {
+    if (!selectedCourseId) {
+      toast.error("Pick a course before saving");
+      return;
+    }
+    try {
+      const created = await createStudyGuideForCourse(
+        selectedCourseId,
+        body as CreateStudyGuideRequest,
+      );
+      router.push(`/study-guides/${created.id}`);
+    } catch (err) {
+      // Surface field-level validation_error details on the form when
+      // the API hands them back; otherwise fall back to a toast so
+      // unstructured failures still show visibly. Do NOT rethrow --
+      // react-hook-form clears `isSubmitting` either way, and a
+      // bubbling rejection becomes an unhandled-promise warning.
+      if (err instanceof ApiError && err.body?.status === "validation_error") {
+        const details = err.body.details;
+        const fields: StudyGuideFormField[] = ["title", "content", "tags"];
+        let projected = false;
+        if (details && typeof details === "object") {
+          for (const field of fields) {
+            const message = (details as Record<string, unknown>)[field];
+            if (typeof message === "string") {
+              formRef.current?.setError(field, message);
+              projected = true;
+            }
+          }
+        }
+        if (!projected) toast.error(err);
+      } else {
+        toast.error(err);
+      }
+    }
+  };
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  return (
+    <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-10">
+      <Header />
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="course-select" className="text-sm font-medium">
+          Course
+        </Label>
+        <Select
+          value={selectedCourseId ?? undefined}
+          onValueChange={setSelectedCourseId}
+        >
+          <SelectTrigger id="course-select" className="w-full">
+            <SelectValue placeholder="Pick a course" />
+          </SelectTrigger>
+          <SelectContent>
+            {courses.map((course) => (
+              <SelectItem key={course.id} value={course.id}>
+                {course.department} {course.number} — {course.title}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-muted-foreground text-xs">
+          New guides are scoped to a course. Pick the one this guide belongs to
+          — you can&rsquo;t move it later without recreating.
+        </p>
+      </div>
+
+      <StudyGuideForm
+        ref={formRef}
+        mode="create"
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+      />
+    </section>
+  );
+}
+
+function Header() {
+  return (
+    <header className="space-y-1.5">
+      <h1 className="text-foreground text-[28px] font-semibold leading-tight tracking-[-0.4px]">
+        New study guide
+      </h1>
+      <p className="text-muted-foreground text-sm">
+        Draft notes, an outline, or a cheat sheet for one of your courses.
+      </p>
+    </header>
+  );
+}

--- a/web/app/(dashboard)/study-guides/new/new-study-guide-form.tsx
+++ b/web/app/(dashboard)/study-guides/new/new-study-guide-form.tsx
@@ -7,7 +7,7 @@
  */
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMemo, useRef, useState } from "react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 import { BookOpen } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -75,19 +75,21 @@ export function NewStudyGuideForm({
 
   if (courses.length === 0) {
     return (
-      <section className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-6 py-10">
-        <Header />
-        <EmptyState
-          icon={<BookOpen className="size-8" aria-hidden={true} />}
-          title="Join a course first"
-          body="Study guides are created under a course. Join one to start writing."
-          action={
-            <Button asChild>
-              <Link href="/courses">Browse courses</Link>
-            </Button>
-          }
-          className="border-border bg-muted/30 rounded-[10px] border py-12"
-        />
+      <section className="flex flex-col gap-8 py-2">
+        <PageHeader />
+        <div className="mx-auto w-full max-w-2xl">
+          <EmptyState
+            icon={<BookOpen className="size-8" aria-hidden={true} />}
+            title="Join a course first"
+            body="Study guides live under a course so the right people can find them. Join a section and you&rsquo;ll land back here ready to draft."
+            action={
+              <Button asChild>
+                <Link href="/courses">Browse courses</Link>
+              </Button>
+            }
+            className="border-border bg-muted/30 rounded-[10px] border py-12"
+          />
+        </div>
       </section>
     );
   }
@@ -136,53 +138,75 @@ export function NewStudyGuideForm({
   };
 
   return (
-    <section className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-10">
-      <Header />
+    <section className="flex flex-col gap-8 py-2">
+      <PageHeader>
+        <CoursePicker
+          courses={courses}
+          value={selectedCourseId}
+          onChange={setSelectedCourseId}
+        />
+      </PageHeader>
 
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="course-select" className="text-sm font-medium">
-          Course
-        </Label>
-        <Select
-          value={selectedCourseId ?? undefined}
-          onValueChange={setSelectedCourseId}
-        >
-          <SelectTrigger id="course-select" className="w-full">
-            <SelectValue placeholder="Pick a course" />
-          </SelectTrigger>
-          <SelectContent>
-            {courses.map((course) => (
-              <SelectItem key={course.id} value={course.id}>
-                {course.department} {course.number} — {course.title}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <p className="text-muted-foreground text-xs">
-          New guides are scoped to a course. Pick the one this guide belongs to
-          — you can&rsquo;t move it later without recreating.
-        </p>
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <StudyGuideForm
+          ref={formRef}
+          mode="create"
+          onSubmit={handleSubmit}
+          onCancel={handleCancel}
+        />
       </div>
-
-      <StudyGuideForm
-        ref={formRef}
-        mode="create"
-        onSubmit={handleSubmit}
-        onCancel={handleCancel}
-      />
     </section>
   );
 }
 
-function Header() {
+function PageHeader({ children }: { children?: ReactNode }) {
   return (
-    <header className="space-y-1.5">
-      <h1 className="text-foreground text-[28px] font-semibold leading-tight tracking-[-0.4px]">
-        New study guide
-      </h1>
-      <p className="text-muted-foreground text-sm">
-        Draft notes, an outline, or a cheat sheet for one of your courses.
-      </p>
+    <header className="flex flex-wrap items-end justify-between gap-x-6 gap-y-3">
+      <div className="space-y-1.5">
+        <h1 className="text-foreground text-[28px] font-semibold leading-tight tracking-[-0.4px]">
+          New study guide
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          Draft notes, an outline, or a cheat sheet for one of your courses.
+        </p>
+      </div>
+      {children}
     </header>
+  );
+}
+
+function CoursePicker({
+  courses,
+  value,
+  onChange,
+}: {
+  courses: { id: string; department: string; number: string; title: string }[];
+  value: string | null;
+  onChange: (id: string) => void;
+}) {
+  return (
+    <div className="flex flex-col items-start gap-1.5 sm:items-end">
+      <Label
+        htmlFor="course-select"
+        className="text-muted-foreground text-xs font-medium uppercase tracking-wide"
+      >
+        Save to
+      </Label>
+      <Select value={value ?? undefined} onValueChange={onChange}>
+        <SelectTrigger
+          id="course-select"
+          className="h-9 w-full min-w-[260px] text-sm"
+        >
+          <SelectValue placeholder="Pick a course" />
+        </SelectTrigger>
+        <SelectContent align="end">
+          {courses.map((course) => (
+            <SelectItem key={course.id} value={course.id}>
+              {course.department} {course.number} — {course.title}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
   );
 }

--- a/web/app/(dashboard)/study-guides/new/page.tsx
+++ b/web/app/(dashboard)/study-guides/new/page.tsx
@@ -1,15 +1,35 @@
-export default function NewStudyGuidePage() {
+/**
+ * Create-a-study-guide route (ASK-191).
+ *
+ * Server Component. Pre-fetches the caller's enrollments so the
+ * client form can render a course selector populated from real
+ * data. The `?course=<id>` query param is the hint we send from
+ * the course detail page's "+ New guide" CTA -- when present and
+ * the user is enrolled, the selector starts on that course.
+ */
+import { listMyEnrollments } from "@/lib/api";
+
+import { NewStudyGuideForm } from "./new-study-guide-form";
+
+interface PageProps {
+  searchParams: Promise<{ course?: string | string[] }>;
+}
+
+function pickCourseId(value: string | string[] | undefined): string | null {
+  if (!value) return null;
+  return Array.isArray(value) ? (value[0] ?? null) : value;
+}
+
+export default async function NewStudyGuidePage({ searchParams }: PageProps) {
+  const [{ enrollments }, params] = await Promise.all([
+    listMyEnrollments(),
+    searchParams,
+  ]);
+
   return (
-    <section className="space-y-4">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          Create Study Guide
-        </h1>
-        <p className="text-muted-foreground text-sm">
-          Start a new study guide draft.
-        </p>
-      </header>
-      <div className="bg-muted/50 min-h-[60vh] rounded-xl" />
-    </section>
+    <NewStudyGuideForm
+      enrollments={enrollments}
+      defaultCourseId={pickCourseId(params.course)}
+    />
   );
 }

--- a/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
@@ -118,7 +118,7 @@ describe("StudyGuideForm / create mode", () => {
     await typeTag(user, "concurrency");
     await typeTag(user, "threads");
     await typeTag(user, "systems");
-    await user.click(screen.getByRole("button", { name: /create/i }));
+    await user.click(screen.getByRole("button", { name: /save as draft/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith({
       title: "Concurrency notes",
@@ -142,7 +142,9 @@ describe("StudyGuideForm / create mode", () => {
       screen.getByLabelText(/content/i),
       "Body long enough to satisfy the min-length requirement.",
     );
-    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /save as draft/i }),
+    ).toBeDisabled();
     await waitFor(() =>
       expect(
         screen.getByText("Title must be at least 3 characters"),
@@ -161,7 +163,9 @@ describe("StudyGuideForm / create mode", () => {
     );
     await user.type(screen.getByLabelText(/title/i), "Valid title");
     await user.type(screen.getByLabelText(/content/i), "short");
-    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /save as draft/i }),
+    ).toBeDisabled();
     await waitFor(() =>
       expect(
         screen.getByText("Content must be at least 10 characters"),
@@ -381,7 +385,7 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
       screen.getByRole("button", { name: /visibility: private/i }),
     ).toBeInTheDocument();
     await fillRequiredFields(user);
-    await user.click(screen.getByRole("button", { name: /create/i }));
+    await user.click(screen.getByRole("button", { name: /save as draft/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ visibility: "private" }),
@@ -403,7 +407,8 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
     expect(
       await screen.findByRole("button", { name: /visibility: public/i }),
     ).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /create/i }));
+    // After flipping to public, the submit label switches to "Publish".
+    await user.click(screen.getByRole("button", { name: /^publish$/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ visibility: "public" }),

--- a/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
@@ -375,15 +375,17 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
     );
   }
 
-  it("defaults to Private in create mode and submits visibility=private", async () => {
+  it("Save as draft submits visibility=private and exposes no visibility chip", async () => {
     const user = userEvent.setup();
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     render(
       <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
     );
+    // Create-mode no longer renders the visibility chip -- the action
+    // buttons are the visibility selector.
     expect(
-      screen.getByRole("button", { name: /visibility: private/i }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /visibility:/i }),
+    ).not.toBeInTheDocument();
     await fillRequiredFields(user);
     await user.click(screen.getByRole("button", { name: /save as draft/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
@@ -392,22 +394,13 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
     );
   });
 
-  it("flips to Public via the popover radio and submits visibility=public", async () => {
+  it("Publish submits visibility=public", async () => {
     const user = userEvent.setup();
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     render(
       <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
     );
     await fillRequiredFields(user);
-    await user.click(
-      screen.getByRole("button", { name: /visibility: private/i }),
-    );
-    await user.click(await screen.findByRole("radio", { name: /public/i }));
-    // Chip label should reflect the new selection immediately.
-    expect(
-      await screen.findByRole("button", { name: /visibility: public/i }),
-    ).toBeInTheDocument();
-    // After flipping to public, the submit label switches to "Publish".
     await user.click(screen.getByRole("button", { name: /^publish$/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith(
@@ -429,8 +422,7 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
     ).toBeInTheDocument();
   });
 
-  it("hides the grants manager in create mode and shows the save-first hint", async () => {
-    const user = userEvent.setup();
+  it("does not mount the grants manager in create mode", () => {
     render(
       <StudyGuideForm
         mode="create"
@@ -438,12 +430,9 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
         onCancel={jest.fn()}
       />,
     );
-    await user.click(
-      screen.getByRole("button", { name: /visibility: private/i }),
-    );
-    expect(
-      await screen.findByText(/save the guide first to share/i),
-    ).toBeInTheDocument();
+    // Create mode replaces the visibility popover with explicit
+    // Save-as-draft / Publish buttons; sharing lives on the edit page
+    // where the guide already has an id.
     expect(screen.queryByTestId("grants-manager-stub")).not.toBeInTheDocument();
   });
 

--- a/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
@@ -118,7 +118,7 @@ describe("StudyGuideForm / create mode", () => {
     await typeTag(user, "concurrency");
     await typeTag(user, "threads");
     await typeTag(user, "systems");
-    await user.click(screen.getByRole("button", { name: /save as draft/i }));
+    await user.click(screen.getByRole("button", { name: /create/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith({
       title: "Concurrency notes",
@@ -142,9 +142,7 @@ describe("StudyGuideForm / create mode", () => {
       screen.getByLabelText(/content/i),
       "Body long enough to satisfy the min-length requirement.",
     );
-    expect(
-      screen.getByRole("button", { name: /save as draft/i }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
     await waitFor(() =>
       expect(
         screen.getByText("Title must be at least 3 characters"),
@@ -163,9 +161,7 @@ describe("StudyGuideForm / create mode", () => {
     );
     await user.type(screen.getByLabelText(/title/i), "Valid title");
     await user.type(screen.getByLabelText(/content/i), "short");
-    expect(
-      screen.getByRole("button", { name: /save as draft/i }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
     await waitFor(() =>
       expect(
         screen.getByText("Content must be at least 10 characters"),
@@ -375,33 +371,38 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
     );
   }
 
-  it("Save as draft submits visibility=private and exposes no visibility chip", async () => {
+  it("defaults to Private in create mode and submits visibility=private", async () => {
     const user = userEvent.setup();
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     render(
       <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
     );
-    // Create-mode no longer renders the visibility chip -- the action
-    // buttons are the visibility selector.
     expect(
-      screen.queryByRole("button", { name: /visibility:/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: /visibility: private/i }),
+    ).toBeInTheDocument();
     await fillRequiredFields(user);
-    await user.click(screen.getByRole("button", { name: /save as draft/i }));
+    await user.click(screen.getByRole("button", { name: /create/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ visibility: "private" }),
     );
   });
 
-  it("Publish submits visibility=public", async () => {
+  it("flips to Public via the popover radio and submits visibility=public", async () => {
     const user = userEvent.setup();
     const onSubmit = jest.fn().mockResolvedValue(undefined);
     render(
       <StudyGuideForm mode="create" onSubmit={onSubmit} onCancel={jest.fn()} />,
     );
     await fillRequiredFields(user);
-    await user.click(screen.getByRole("button", { name: /^publish$/i }));
+    await user.click(
+      screen.getByRole("button", { name: /visibility: private/i }),
+    );
+    await user.click(await screen.findByRole("radio", { name: /public/i }));
+    expect(
+      await screen.findByRole("button", { name: /visibility: public/i }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /create/i }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ visibility: "public" }),
@@ -422,7 +423,8 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not mount the grants manager in create mode", () => {
+  it("hides the grants manager in create mode and shows the save-first hint", async () => {
+    const user = userEvent.setup();
     render(
       <StudyGuideForm
         mode="create"
@@ -430,9 +432,12 @@ describe("StudyGuideForm / visibility (ASK-212)", () => {
         onCancel={jest.fn()}
       />,
     );
-    // Create mode replaces the visibility popover with explicit
-    // Save-as-draft / Publish buttons; sharing lives on the edit page
-    // where the guide already has an id.
+    await user.click(
+      screen.getByRole("button", { name: /visibility: private/i }),
+    );
+    expect(
+      await screen.findByText(/save the guide first to share/i),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("grants-manager-stub")).not.toBeInTheDocument();
   });
 

--- a/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.test.tsx
@@ -128,7 +128,7 @@ describe("StudyGuideForm / create mode", () => {
     });
   });
 
-  it("disables Save and shows inline error while title is below 3 chars (AC3)", async () => {
+  it("shows the title min-length error after the field blurs (AC3)", async () => {
     const user = userEvent.setup();
     render(
       <StudyGuideForm
@@ -137,20 +137,23 @@ describe("StudyGuideForm / create mode", () => {
         onCancel={jest.fn()}
       />,
     );
-    await user.type(screen.getByLabelText(/title/i), "Hi");
-    await user.type(
-      screen.getByLabelText(/content/i),
-      "Body long enough to satisfy the min-length requirement.",
-    );
-    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
+    const title = screen.getByLabelText(/title/i) as HTMLInputElement;
+    await user.type(title, "Hi");
+    // While focused / before blur, no inline error -- we don't yell
+    // at the user mid-typing.
+    expect(
+      screen.queryByText("Title must be at least 3 characters"),
+    ).not.toBeInTheDocument();
+    act(() => title.blur());
     await waitFor(() =>
       expect(
         screen.getByText("Title must be at least 3 characters"),
       ).toBeInTheDocument(),
     );
+    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
   });
 
-  it("disables Save and shows inline error while content is below 10 chars (AC4)", async () => {
+  it("shows the content min-length error after the field blurs (AC4)", async () => {
     const user = userEvent.setup();
     render(
       <StudyGuideForm
@@ -160,13 +163,18 @@ describe("StudyGuideForm / create mode", () => {
       />,
     );
     await user.type(screen.getByLabelText(/title/i), "Valid title");
-    await user.type(screen.getByLabelText(/content/i), "short");
-    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
+    const content = screen.getByLabelText(/content/i) as HTMLTextAreaElement;
+    await user.type(content, "short");
+    expect(
+      screen.queryByText("Content must be at least 10 characters"),
+    ).not.toBeInTheDocument();
+    act(() => content.blur());
     await waitFor(() =>
       expect(
         screen.getByText("Content must be at least 10 characters"),
       ).toBeInTheDocument(),
     );
+    expect(screen.getByRole("button", { name: /create/i })).toBeDisabled();
   });
 
   it("fires onCancel when Cancel is clicked", async () => {

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -90,10 +90,11 @@ export const StudyGuideForm = forwardRef<
 ) {
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    // onChange so the Save button can disable/enable reactively as the
-    // user types -- matches "Submit button disabled until required
-    // fields meet min length" (AC3/AC4).
-    mode: "onChange",
+    // onTouched so we don't yell at the user while they're still
+    // typing the first three characters of their title. Validation
+    // kicks in once the field has been blurred, then keeps validating
+    // onChange so the inline error clears live as they fix it.
+    mode: "onTouched",
     defaultValues: {
       title: initial?.title ?? "",
       content: initial?.content ?? "",

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 
 import { Badge } from "@/components/ui/badge";
@@ -118,6 +118,10 @@ export const StudyGuideForm = forwardRef<
   );
 
   const { isSubmitting, isValid } = form.formState;
+  const currentVisibility = useWatch({
+    control: form.control,
+    name: "visibility",
+  });
 
   const handleSubmit = async (values: FormValues) => {
     // Only forward `visibility` when it actually changed (or in create
@@ -133,13 +137,22 @@ export const StudyGuideForm = forwardRef<
     });
   };
 
-  const submitLabel = isSubmitting
-    ? mode === "create"
-      ? "Creating…"
-      : "Saving…"
-    : mode === "create"
-      ? "Create"
-      : "Save";
+  // In create mode, surface the visibility intent on the submit
+  // itself: drafting (private) reads "Save as draft", publishing
+  // (public) reads "Publish". Edit mode keeps the simpler "Save"
+  // because the visibility popover sits next to it for tweaks.
+  const submitLabel =
+    mode === "create"
+      ? currentVisibility === "public"
+        ? isSubmitting
+          ? "Publishing…"
+          : "Publish"
+        : isSubmitting
+          ? "Saving draft…"
+          : "Save as draft"
+      : isSubmitting
+        ? "Saving…"
+        : "Save";
 
   return (
     <Form {...form}>

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -119,27 +119,34 @@ export const StudyGuideForm = forwardRef<
 
   const { isSubmitting, isValid } = form.formState;
 
-  const submitWith = (visibility: "private" | "public" | null) =>
-    form.handleSubmit(async (values) => {
-      // In create mode the action button drives visibility, so we
-      // ignore the form field. In edit mode visibility comes from
-      // the popover chip and we only forward it when it changed.
-      const finalVisibility = visibility ?? values.visibility;
-      const visibilityChanged =
-        mode === "create" || initial?.visibility !== finalVisibility;
-      await onSubmit({
-        title: values.title,
-        content: values.content,
-        tags: values.tags,
-        ...(visibilityChanged ? { visibility: finalVisibility } : {}),
-      });
+  const handleSubmit = async (values: FormValues) => {
+    // Only forward `visibility` when it actually changed (or in create
+    // mode). PATCH-ing it on every save would silently force pre-
+    // backfill rows with a missing/null visibility into "private".
+    const visibilityChanged =
+      mode === "create" || initial?.visibility !== values.visibility;
+    await onSubmit({
+      title: values.title,
+      content: values.content,
+      tags: values.tags,
+      ...(visibilityChanged ? { visibility: values.visibility } : {}),
     });
+  };
 
-  const editSubmitLabel = isSubmitting ? "Saving…" : "Save";
+  const submitLabel = isSubmitting
+    ? mode === "create"
+      ? "Creating…"
+      : "Saving…"
+    : mode === "create"
+      ? "Create"
+      : "Save";
 
   return (
     <Form {...form}>
-      <form onSubmit={submitWith(null)} className="flex flex-col">
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        className="flex flex-col"
+      >
         <FormField
           control={form.control}
           name="title"
@@ -203,34 +210,32 @@ export const StudyGuideForm = forwardRef<
                 </FormItem>
               )}
             />
-            {mode === "edit" ? (
-              <FormField
-                control={form.control}
-                name="visibility"
-                render={({ field }) => (
-                  <FormItem className="space-y-1">
-                    <FormControl>
-                      <VisibilityChip
-                        visibility={field.value}
-                        grantCount={grantCount}
+            <FormField
+              control={form.control}
+              name="visibility"
+              render={({ field }) => (
+                <FormItem className="space-y-1">
+                  <FormControl>
+                    <VisibilityChip
+                      visibility={field.value}
+                      grantCount={mode === "edit" ? grantCount : 0}
+                      disabled={isSubmitting}
+                    >
+                      <VisibilityPopoverBody
+                        mode={mode}
+                        studyGuideId={initial?.id}
+                        value={field.value}
+                        onChange={field.onChange}
                         disabled={isSubmitting}
-                      >
-                        <VisibilityPopoverBody
-                          mode={mode}
-                          studyGuideId={initial?.id}
-                          value={field.value}
-                          onChange={field.onChange}
-                          disabled={isSubmitting}
-                          onGrantCountChange={handleGrantCountChange}
-                          grantActions={grantActions}
-                        />
-                      </VisibilityChip>
-                    </FormControl>
-                    <FormMessage className="px-0" />
-                  </FormItem>
-                )}
-              />
-            ) : null}
+                        onGrantCountChange={handleGrantCountChange}
+                        grantActions={grantActions}
+                      />
+                    </VisibilityChip>
+                  </FormControl>
+                  <FormMessage className="px-0" />
+                </FormItem>
+              )}
+            />
           </div>
           <div className="flex shrink-0 justify-end gap-2">
             <Button
@@ -241,29 +246,9 @@ export const StudyGuideForm = forwardRef<
             >
               Cancel
             </Button>
-            {mode === "create" ? (
-              <>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={submitWith("private")}
-                  disabled={!isValid || isSubmitting}
-                >
-                  {isSubmitting ? "Saving draft…" : "Save as draft"}
-                </Button>
-                <Button
-                  type="button"
-                  onClick={submitWith("public")}
-                  disabled={!isValid || isSubmitting}
-                >
-                  {isSubmitting ? "Publishing…" : "Publish"}
-                </Button>
-              </>
-            ) : (
-              <Button type="submit" disabled={!isValid || isSubmitting}>
-                {editSubmitLabel}
-              </Button>
-            )}
+            <Button type="submit" disabled={!isValid || isSubmitting}>
+              {submitLabel}
+            </Button>
           </div>
         </div>
       </form>

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useForm, useWatch } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { Badge } from "@/components/ui/badge";
@@ -118,48 +118,28 @@ export const StudyGuideForm = forwardRef<
   );
 
   const { isSubmitting, isValid } = form.formState;
-  const currentVisibility = useWatch({
-    control: form.control,
-    name: "visibility",
-  });
 
-  const handleSubmit = async (values: FormValues) => {
-    // Only forward `visibility` when it actually changed (or in create
-    // mode). PATCH-ing it on every save would silently force pre-
-    // backfill rows with a missing/null visibility into "private".
-    const visibilityChanged =
-      mode === "create" || initial?.visibility !== values.visibility;
-    await onSubmit({
-      title: values.title,
-      content: values.content,
-      tags: values.tags,
-      ...(visibilityChanged ? { visibility: values.visibility } : {}),
+  const submitWith = (visibility: "private" | "public" | null) =>
+    form.handleSubmit(async (values) => {
+      // In create mode the action button drives visibility, so we
+      // ignore the form field. In edit mode visibility comes from
+      // the popover chip and we only forward it when it changed.
+      const finalVisibility = visibility ?? values.visibility;
+      const visibilityChanged =
+        mode === "create" || initial?.visibility !== finalVisibility;
+      await onSubmit({
+        title: values.title,
+        content: values.content,
+        tags: values.tags,
+        ...(visibilityChanged ? { visibility: finalVisibility } : {}),
+      });
     });
-  };
 
-  // In create mode, surface the visibility intent on the submit
-  // itself: drafting (private) reads "Save as draft", publishing
-  // (public) reads "Publish". Edit mode keeps the simpler "Save"
-  // because the visibility popover sits next to it for tweaks.
-  const submitLabel =
-    mode === "create"
-      ? currentVisibility === "public"
-        ? isSubmitting
-          ? "Publishing…"
-          : "Publish"
-        : isSubmitting
-          ? "Saving draft…"
-          : "Save as draft"
-      : isSubmitting
-        ? "Saving…"
-        : "Save";
+  const editSubmitLabel = isSubmitting ? "Saving…" : "Save";
 
   return (
     <Form {...form}>
-      <form
-        onSubmit={form.handleSubmit(handleSubmit)}
-        className="flex flex-col"
-      >
+      <form onSubmit={submitWith(null)} className="flex flex-col">
         <FormField
           control={form.control}
           name="title"
@@ -223,32 +203,34 @@ export const StudyGuideForm = forwardRef<
                 </FormItem>
               )}
             />
-            <FormField
-              control={form.control}
-              name="visibility"
-              render={({ field }) => (
-                <FormItem className="space-y-1">
-                  <FormControl>
-                    <VisibilityChip
-                      visibility={field.value}
-                      grantCount={mode === "edit" ? grantCount : 0}
-                      disabled={isSubmitting}
-                    >
-                      <VisibilityPopoverBody
-                        mode={mode}
-                        studyGuideId={initial?.id}
-                        value={field.value}
-                        onChange={field.onChange}
+            {mode === "edit" ? (
+              <FormField
+                control={form.control}
+                name="visibility"
+                render={({ field }) => (
+                  <FormItem className="space-y-1">
+                    <FormControl>
+                      <VisibilityChip
+                        visibility={field.value}
+                        grantCount={grantCount}
                         disabled={isSubmitting}
-                        onGrantCountChange={handleGrantCountChange}
-                        grantActions={grantActions}
-                      />
-                    </VisibilityChip>
-                  </FormControl>
-                  <FormMessage className="px-0" />
-                </FormItem>
-              )}
-            />
+                      >
+                        <VisibilityPopoverBody
+                          mode={mode}
+                          studyGuideId={initial?.id}
+                          value={field.value}
+                          onChange={field.onChange}
+                          disabled={isSubmitting}
+                          onGrantCountChange={handleGrantCountChange}
+                          grantActions={grantActions}
+                        />
+                      </VisibilityChip>
+                    </FormControl>
+                    <FormMessage className="px-0" />
+                  </FormItem>
+                )}
+              />
+            ) : null}
           </div>
           <div className="flex shrink-0 justify-end gap-2">
             <Button
@@ -259,9 +241,29 @@ export const StudyGuideForm = forwardRef<
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={!isValid || isSubmitting}>
-              {submitLabel}
-            </Button>
+            {mode === "create" ? (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={submitWith("private")}
+                  disabled={!isValid || isSubmitting}
+                >
+                  {isSubmitting ? "Saving draft…" : "Save as draft"}
+                </Button>
+                <Button
+                  type="button"
+                  onClick={submitWith("public")}
+                  disabled={!isValid || isSubmitting}
+                >
+                  {isSubmitting ? "Publishing…" : "Publish"}
+                </Button>
+              </>
+            ) : (
+              <Button type="submit" disabled={!isValid || isSubmitting}>
+                {editSubmitLabel}
+              </Button>
+            )}
           </div>
         </div>
       </form>


### PR DESCRIPTION
## Summary
- Replaces the placeholder at \`/study-guides/new\` with a real Server-Component page that pre-fetches \`listMyEnrollments\` and renders a client \`NewStudyGuideForm\`.
- The client form puts a de-duped course \`<Select>\` above the shared \`<StudyGuideForm mode=\"create\">\`. Submit calls \`createStudyGuideForCourse(selectedCourseId, body)\` and redirects to \`/study-guides/{new-id}\`.
- The selector pre-selects from \`?course=<id>\`, so the \"+ New guide\" button on the course detail page (ASK-197) lands on the right course.
- Errors: validation_error projects field-level messages onto the form; everything else toasts. No rethrow so \`isSubmitting\` clears cleanly.
- Empty state when the user has no enrollments → \`<EmptyState>\` with a \`/courses\` link, no form.

## Test plan
- [x] \`pnpm exec jest study-guides/new\` — 4 tests pass (AC1–AC4).
- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] \`pnpm exec eslint\` clean on the new files.
- [x] \`pnpm exec prettier --check\` clean.
- [ ] Manual on staging: \`/courses/<id>\` → \`+ New guide\` → form pre-selects that course → fill → save → land on \`/study-guides/<id>\`.