### PR TITLE
feat(web): selection toolbar + AI prompt input (ASK-216)

### DIFF
--- a/web/.storybook/clerk-stub.tsx
+++ b/web/.storybook/clerk-stub.tsx
@@ -1,0 +1,62 @@
+/**
+ * Storybook-only stub for `@clerk/nextjs`. Clerk's React hooks throw
+ * outside a real <ClerkProvider>, which would break every story that
+ * indirectly mounts a component using `useAuth` / `useUser` / etc.
+ *
+ * Vite aliases `@clerk/nextjs` to this module via `.storybook/main.ts`
+ * (`viteFinal`). It only ships in the storybook bundle -- production
+ * builds and tests untouched.
+ */
+
+import type { ReactNode } from "react";
+
+export function useAuth() {
+  return {
+    isLoaded: true,
+    isSignedIn: false as boolean | undefined,
+    userId: null as string | null,
+    sessionId: null as string | null,
+    getToken: async (): Promise<string | null> => null,
+    signOut: async () => undefined,
+  };
+}
+
+export function useUser() {
+  return {
+    isLoaded: true,
+    isSignedIn: false as boolean | undefined,
+    user: null as unknown,
+  };
+}
+
+export function useClerk() {
+  return {
+    signOut: async () => undefined,
+    openSignIn: () => undefined,
+    openSignUp: () => undefined,
+  };
+}
+
+export function ClerkProvider({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}
+
+export function SignedIn(_props: { children?: ReactNode }) {
+  return null;
+}
+
+export function SignedOut({ children }: { children?: ReactNode }) {
+  return <>{children}</>;
+}
+
+export function SignInButton({ children }: { children?: ReactNode }) {
+  return <>{children ?? <button type="button">Sign in</button>}</>;
+}
+
+export function SignUpButton({ children }: { children?: ReactNode }) {
+  return <>{children ?? <button type="button">Sign up</button>}</>;
+}
+
+export function UserButton() {
+  return null;
+}

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -1,4 +1,9 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import type { StorybookConfig } from "@storybook/nextjs-vite";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
   stories: [
@@ -21,6 +26,13 @@ const config: StorybookConfig = {
     // Normalize: empty -> root, always trailing slash so Vite's `base`
     // produces correct relative resolution for every chunk.
     config.base = !raw ? "/" : raw.endsWith("/") ? raw : `${raw}/`;
+    // Stub @clerk/nextjs so stories that indirectly mount components
+    // calling useAuth/useUser don't crash without a real provider.
+    config.resolve = config.resolve ?? {};
+    config.resolve.alias = {
+      ...(config.resolve.alias as Record<string, string> | undefined),
+      "@clerk/nextjs": path.resolve(here, "clerk-stub.tsx"),
+    };
     return config;
   },
 };

--- a/web/app/(dashboard)/study-guides/[id]/edit/edit-study-guide-form.tsx
+++ b/web/app/(dashboard)/study-guides/[id]/edit/edit-study-guide-form.tsx
@@ -111,6 +111,7 @@ export function EditStudyGuideForm({ guide }: EditStudyGuideFormProps) {
         onSubmit={handleSubmit}
         onCancel={handleCancel}
         grantActions={grantActions}
+        aiEdit={{ guideId: guide.id, title: guide.title }}
       />
 
       <div className="border-destructive/30 bg-destructive/5 flex flex-col gap-3 rounded-[10px] border p-5">

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -135,3 +135,33 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* ASK-216: highlight the text range an AI edit is operating on. The
+   class is applied as a ProseMirror inline Decoration by the
+   AiSelectionRange extension, so it tracks the text on scroll, doc
+   edits, and resize without any JS measurement. */
+.ai-edit-range {
+  background-color: oklch(0.92 0.06 250);
+  border-radius: 2px;
+  box-shadow: 0 0 0 1.5px oklch(0.7 0.18 252 / 0.55);
+  transition: box-shadow 120ms ease;
+}
+
+.dark .ai-edit-range {
+  background-color: oklch(0.4 0.1 252 / 0.45);
+  box-shadow: 0 0 0 1.5px oklch(0.7 0.18 252 / 0.7);
+}
+
+.ai-edit-range--streaming {
+  animation: ai-edit-range-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes ai-edit-range-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 1.5px oklch(0.7 0.18 252 / 0.55);
+  }
+  50% {
+    box-shadow: 0 0 0 3px oklch(0.7 0.18 252 / 0.85);
+  }
+}

--- a/web/lib/api/generated/types.ts
+++ b/web/lib/api/generated/types.ts
@@ -1531,10 +1531,159 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/ai/ping": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Smoke test for the AI streaming pipeline (ASK-213)
+         * @description Internal smoke endpoint that exercises the OpenAI client +
+         *     SSE plumbing end-to-end. Streams a short response (default
+         *     "pong") from GPT-4.1-nano as a series of `text/event-stream`
+         *     events: `delta`, `usage`, `done`. Used by `curl -N` and the
+         *     backend health checks to verify wiring; not part of any
+         *     product feature. Kept under `/ai/*` so it shares the routing
+         *     bypass (no 60s timeout) that real AI endpoints will need.
+         */
+        post: operations["AIPing"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/study-guides/{study_guide_id}/ai/edit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stream an AI rewrite of a selected span (ASK-215)
+         * @description User selects text in the study-guide editor, gives an
+         *     instruction (e.g. "make this clearer", "add an example"),
+         *     and the model streams a replacement. The full replacement
+         *     is captured server-side and persisted to the
+         *     `study_guide_edits` audit table; the user's accept/reject
+         *     decision is recorded later via PATCH on
+         *     `/study-guides/{id}/ai/edits/{edit_id}`.
+         *
+         *     Per the ticket Decision: server returns the FULL
+         *     replacement, NOT a diff syntax. The frontend computes the
+         *     diff client-side from `original_span` (echoed back) and
+         *     the streamed `delta` events.
+         */
+        post: operations["AIEdit"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/study-guides/{study_guide_id}/ai/edits/{edit_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Record accept/reject for a streamed AI edit (ASK-215)
+         * @description Called by the frontend after the user resolves the diff
+         *     overlay. Sets `accepted` + `accepted_at` on the audit row.
+         *     Idempotent -- last write wins, so a misclick can be
+         *     corrected by PATCHing again.
+         */
+        patch: operations["UpdateAIEdit"];
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /**
+         * @description Request body for POST /api/study-guides/{id}/ai/edit (ASK-215).
+         *     `selection_text` is the exact text the user highlighted in
+         *     the editor; `selection_start` / `selection_end` are character
+         *     offsets in the rendered article body (TipTap coordinate
+         *     space). `doc_context` provides bounded preceding/following
+         *     context so the model can grade tone + formatting; both sides
+         *     are capped at ~1500 chars by the frontend.
+         */
+        AIEditRequest: {
+            selection_text: string;
+            selection_start: number;
+            selection_end: number;
+            /** @description Free-form rewrite directive, e.g. "make this clearer and add an example". */
+            instruction: string;
+            doc_context?: components["schemas"]["AIEditDocContext"];
+        };
+        /**
+         * @description Optional bounded surrounding context. Each side capped client
+         *     side; server doesn't enforce -- the OpenAPI validator's
+         *     maxLength is the hard ceiling.
+         */
+        AIEditDocContext: {
+            title?: string;
+            preceding?: string;
+            following?: string;
+        };
+        /**
+         * @description Request body for PATCH /api/study-guides/{id}/ai/edits/{edit_id}.
+         *     Frontend calls this after the user resolves the diff overlay.
+         */
+        UpdateAIEditRequest: {
+            /** @description Whether the user accepted the AI edit. False = rejected. */
+            accepted: boolean;
+        };
+        /**
+         * @description One row from study_guide_edits, returned by the PATCH
+         *     endpoint. Includes the full original/replacement text so the
+         *     frontend can re-render history without a separate fetch.
+         */
+        AIEditAuditRow: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            study_guide_id: string;
+            instruction: string;
+            selection_start: number;
+            selection_end: number;
+            original_span: string;
+            replacement: string;
+            model: string;
+            input_tokens: number;
+            output_tokens: number;
+            accepted?: boolean | null;
+            /** Format: date-time */
+            accepted_at?: string | null;
+            /** Format: date-time */
+            created_at: string;
+        };
+        /**
+         * @description Request body for POST /api/ai/ping (ASK-213 smoke endpoint).
+         *     `prompt` is optional -- when omitted the handler asks GPT-4.1-
+         *     nano to reply "pong", which is enough to exercise SSE wiring
+         *     without burning tokens.
+         */
+        AIPingRequest: {
+            /** @description Override the default smoke prompt (defaults to "Reply with the single word 'pong'."). */
+            prompt?: string;
+        };
         /**
          * @description Request body for POST /api/refs/resolve (ASK-208). `refs` is a
          *     list of `(type, id)` pairs to hydrate. Bounded at 50 entries --
@@ -4607,6 +4756,104 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    AIPing: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AIPingRequest"];
+            };
+        };
+        responses: {
+            /**
+             * @description SSE event stream. Event types: `delta` (text chunk),
+             *     `usage` (final token + cache counts), `done` (terminator),
+             *     `error` (mid-stream failure). Each event's `data:` payload
+             *     is JSON.
+             */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": string;
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    AIEdit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                study_guide_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AIEditRequest"];
+            };
+        };
+        responses: {
+            /**
+             * @description SSE event stream. Event types: `delta` (text chunk),
+             *     `usage` (final token counts), `done` (terminator),
+             *     `error` (mid-stream failure).
+             */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": string;
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    UpdateAIEdit: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                study_guide_id: string;
+                edit_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateAIEditRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated audit row. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AIEditAuditRow"];
+                };
             };
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];

--- a/web/lib/features/dashboard/study-guides/content-editor.tsx
+++ b/web/lib/features/dashboard/study-guides/content-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TiptapEditor } from "./wysiwyg/editor";
+import { TiptapEditor, type AiEditTarget } from "./wysiwyg/editor";
 
 interface ContentEditorProps {
   value: string;
@@ -12,6 +12,7 @@ interface ContentEditorProps {
   disabled?: boolean;
   className?: string;
   allowedHosts?: string[];
+  aiEdit?: AiEditTarget;
 }
 
 function resolveAllowedHosts(explicit?: string[]): string[] {
@@ -33,6 +34,7 @@ export function ContentEditor({
   disabled,
   className,
   allowedHosts,
+  aiEdit,
 }: ContentEditorProps) {
   return (
     <div className={className} onBlur={onBlur}>
@@ -42,6 +44,7 @@ export function ContentEditor({
         disabled={disabled}
         placeholder={placeholder}
         allowedHosts={resolveAllowedHosts(allowedHosts)}
+        aiEdit={aiEdit}
       />
     </div>
   );

--- a/web/lib/features/dashboard/study-guides/study-guide-form.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-form.tsx
@@ -28,6 +28,7 @@ import { Input } from "@/components/ui/input";
 import { ContentEditor } from "./content-editor";
 import { GrantsManager, type GrantsManagerActions } from "./grants-manager";
 import { VisibilityChip } from "./visibility-chip";
+import type { AiEditTarget } from "./wysiwyg/editor";
 import type {
   CreateStudyGuideRequest,
   StudyGuideDetailResponse,
@@ -79,13 +80,19 @@ interface StudyGuideFormProps {
    * this falls back to the same "save first" hint as create mode.
    */
   grantActions?: GrantsManagerActions;
+  /**
+   * Provide to enable the editor's "Ask AI" bubble menu (ASK-216).
+   * Edit-mode pages pass `{ guideId, title }`; create-mode pages
+   * omit it -- the bubble menu still renders formatting buttons.
+   */
+  aiEdit?: AiEditTarget;
 }
 
 export const StudyGuideForm = forwardRef<
   StudyGuideFormHandle,
   StudyGuideFormProps
 >(function StudyGuideForm(
-  { mode, initial, onSubmit, onCancel, grantActions },
+  { mode, initial, onSubmit, onCancel, grantActions, aiEdit },
   ref: ForwardedRef<StudyGuideFormHandle>,
 ) {
   const form = useForm<FormValues>({
@@ -180,6 +187,7 @@ export const StudyGuideForm = forwardRef<
                   placeholder="Write your study guide — paste a study-guide / quiz / file / course URL to embed a live card."
                   disabled={isSubmitting}
                   className="[&_.ProseMirror]:!border-0 [&_.ProseMirror]:!px-0 [&_.ProseMirror]:!min-h-[20rem]"
+                  aiEdit={aiEdit}
                 />
               </FormControl>
               <FormMessage className="px-0" />

--- a/web/lib/features/dashboard/study-guides/wysiwyg/ai-selection-range.ts
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/ai-selection-range.ts
@@ -1,0 +1,75 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+/**
+ * TipTap extension that visually highlights the selection an AI edit
+ * is operating on. Uses a ProseMirror Decoration (inline class) so
+ * the highlight moves with the text on scroll, resize, or doc edits
+ * -- no fixed overlay div + window-event listener pile of duct tape.
+ *
+ * The bubble menu drives this via `setMeta(aiSelectionPluginKey, ...)`:
+ *   - On "Ask AI" click: { from, to, status: "idle" }
+ *   - When stream starts:  { from, to, status: "streaming" }
+ *   - On close / cancel:   null
+ */
+
+export type AiSelectionStatus = "idle" | "streaming";
+
+export interface AiSelectionState {
+  from: number;
+  to: number;
+  status: AiSelectionStatus;
+}
+
+export const aiSelectionPluginKey = new PluginKey<AiSelectionState | null>(
+  "aiSelectionRange",
+);
+
+const HIGHLIGHT_CLASS = "ai-edit-range";
+const STREAMING_CLASS = "ai-edit-range--streaming";
+
+export const AiSelectionRange = Extension.create({
+  name: "aiSelectionRange",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<AiSelectionState | null>({
+        key: aiSelectionPluginKey,
+        state: {
+          init: () => null,
+          apply(tr, value) {
+            const meta = tr.getMeta(aiSelectionPluginKey);
+            if (meta !== undefined) {
+              return meta as AiSelectionState | null;
+            }
+            if (!value) return value;
+            // Map the highlighted range through any doc changes so it
+            // stays anchored to the same text the user selected.
+            if (tr.docChanged) {
+              const from = tr.mapping.map(value.from);
+              const to = tr.mapping.map(value.to);
+              if (to <= from) return null;
+              return { ...value, from, to };
+            }
+            return value;
+          },
+        },
+        props: {
+          decorations(state) {
+            const value = aiSelectionPluginKey.getState(state);
+            if (!value) return null;
+            const { from, to, status } = value;
+            if (from >= to) return null;
+            const className =
+              status === "streaming"
+                ? `${HIGHLIGHT_CLASS} ${STREAMING_CLASS}`
+                : HIGHLIGHT_CLASS;
+            return DecorationSet.create(state.doc, [
+              Decoration.inline(from, to, { class: className }),
+            ]);
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/web/lib/features/dashboard/study-guides/wysiwyg/ask-ai-popover.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/ask-ai-popover.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { History, Loader2, Send, X } from "lucide-react";
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+import {
+  addRecentPrompt,
+  getRecentPrompts,
+  RECENT_PROMPTS_LIMIT,
+} from "./recent-prompts";
+import type {
+  AiEditStreamError,
+  AiEditStreamStatus,
+} from "./use-ai-edit-stream";
+
+interface AskAiPopoverProps {
+  status: AiEditStreamStatus;
+  replacement: string;
+  error: AiEditStreamError | null;
+  /** Submit triggers the SSE call. Caller owns selection capture. */
+  onSubmit: (instruction: string) => void;
+  /** Cancels in-flight request and closes the popover. */
+  onCancel: () => void;
+}
+
+/**
+ * Compact prompt input rendered inside the editor's bubble menu when
+ * the user clicks "Ask AI". The popover container (Radix Popover)
+ * lives in the bubble-menu component; this is just the body.
+ *
+ * Lifecycle (kept here so the bubble menu's render stays clean):
+ *   - On mount, focus the input + load recent prompts.
+ *   - Esc cancels (caller closes the popover).
+ *   - Submit fires `onSubmit(instruction)` and persists the prompt
+ *     to localStorage so the recents dropdown reflects it next open.
+ *   - While `status === "streaming"`, show a loading affordance and
+ *     a live-streamed preview of the replacement so the user sees
+ *     the model is working. ASK-217 will replace this preview block
+ *     with the diff overlay; this component intentionally does NOT
+ *     write the replacement back into the editor.
+ */
+export function AskAiPopover({
+  status,
+  replacement,
+  error,
+  onSubmit,
+  onCancel,
+}: AskAiPopoverProps) {
+  const [instruction, setInstruction] = useState("");
+  // Lazy initializer reads localStorage once on mount. SSR-safe via
+  // the helper's `typeof window` guard.
+  const [recents, setRecents] = useState<string[]>(() => getRecentPrompts());
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // Defer focus to the next frame so Radix's autoFocus -> input
+    // hand-off doesn't race with the popover's open animation.
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  const isStreaming = status === "streaming";
+  const isDone = status === "done";
+  const isError = status === "error";
+  const hasError = isError && error !== null;
+
+  const trimmed = useMemo(() => instruction.trim(), [instruction]);
+  const canSubmit = trimmed.length > 0 && !isStreaming;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    setRecents(addRecentPrompt(trimmed));
+    onSubmit(trimmed);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="flex w-80 flex-col gap-3" role="group" aria-label="Ask AI">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Input
+            ref={inputRef}
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask AI to rewrite the selection…"
+            aria-label="AI edit instruction"
+            disabled={isStreaming}
+            autoComplete="off"
+            spellCheck
+          />
+          {recents.length > 0 && !isStreaming ? (
+            <RecentPromptsMenu
+              prompts={recents}
+              onPick={(p) => setInstruction(p)}
+            />
+          ) : null}
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-muted-foreground text-xs">
+            {isStreaming
+              ? "Streaming…"
+              : isDone
+                ? "Done · diff overlay coming next"
+                : "Press ⏎ to send · Esc to close"}
+          </p>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onCancel}
+              aria-label={isStreaming ? "Stop AI edit" : "Close Ask AI"}
+            >
+              {isStreaming ? "Stop" : <X className="size-4" />}
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={!canSubmit}
+              aria-label="Submit AI edit"
+            >
+              {isStreaming ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Send className="size-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </form>
+
+      {(isStreaming || isDone) && replacement.length > 0 ? (
+        <PreviewPanel replacement={replacement} streaming={isStreaming} />
+      ) : null}
+
+      {hasError ? (
+        <p
+          role="alert"
+          className="bg-destructive/10 text-destructive rounded-md px-2 py-1.5 text-xs"
+        >
+          {error.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface PreviewPanelProps {
+  replacement: string;
+  streaming: boolean;
+}
+
+function PreviewPanel({ replacement, streaming }: PreviewPanelProps) {
+  return (
+    <div
+      className={cn(
+        "border-border bg-muted/40 rounded-md border px-3 py-2",
+        streaming && "ai-streaming-pulse",
+      )}
+      aria-live="polite"
+      aria-busy={streaming}
+    >
+      <p className="text-muted-foreground mb-1 text-[11px] font-medium tracking-wide uppercase">
+        Preview
+      </p>
+      <p className="max-h-40 overflow-y-auto text-sm leading-relaxed whitespace-pre-wrap">
+        {replacement}
+        {streaming ? (
+          <span
+            aria-hidden
+            className="bg-foreground/70 ml-0.5 inline-block h-3 w-1 animate-pulse align-baseline"
+          />
+        ) : null}
+      </p>
+    </div>
+  );
+}
+
+interface RecentPromptsMenuProps {
+  prompts: string[];
+  onPick: (prompt: string) => void;
+}
+
+function RecentPromptsMenu({ prompts, onPick }: RecentPromptsMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={`Recent prompts (last ${RECENT_PROMPTS_LIMIT})`}
+        >
+          <History className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-w-72">
+        {prompts.map((prompt) => (
+          <DropdownMenuItem
+            key={prompt}
+            onSelect={() => onPick(prompt)}
+            className="line-clamp-2 text-sm"
+          >
+            {prompt}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.stories.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.stories.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { AskAiPopover } from "./ask-ai-popover";
+import { TiptapEditor } from "./editor";
+
+const SG_ID = "11111111-2222-3333-4444-555555555555";
+
+const SAMPLE = [
+  "# Binary search trees",
+  "",
+  "A **binary search tree** keeps keys ordered for O(log n) lookups in the balanced case.",
+  "",
+  "Select any sentence above to see the bubble menu — it now exposes inline formatting plus an **Ask AI** entry that opens a prompt input anchored to your selection (ASK-216).",
+  "",
+  "> The diff overlay (ASK-217) will replace the streaming preview in the popover with a per-hunk accept/reject UI.",
+].join("\n");
+
+function Playground({ aiEnabled = true }: { aiEnabled?: boolean }) {
+  const [value, setValue] = useState(SAMPLE);
+  return (
+    <div className="mx-auto w-full max-w-2xl">
+      <TiptapEditor
+        value={value}
+        onChange={setValue}
+        allowedHosts={["askatlas.app"]}
+        aiEdit={
+          aiEnabled
+            ? { guideId: SG_ID, title: "BST primer (storybook)" }
+            : undefined
+        }
+      />
+      <p className="text-muted-foreground mt-3 text-xs">
+        Tip: select text in the document to surface the floating toolbar.
+      </p>
+    </div>
+  );
+}
+
+const meta: Meta<typeof Playground> = {
+  title: "Dashboard/StudyGuides/EditorBubbleMenu (ASK-216)",
+  component: Playground,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Selection bubble menu for the study-guide editor. Shows on non-empty text selection (TipTap v3 BubbleMenu, Floating UI). Includes inline formatting toggles (bold / italic / strike / inline code) and -- when an `aiEdit` target is provided -- an **Ask AI** entry that anchors a Radix Popover to the selection. The popover hosts the prompt input, recent-prompts dropdown, and live-streamed preview while the AI edit endpoint streams. Esc and outside-click both cancel cleanly.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Playground>;
+
+export const FormattingOnly: Story = {
+  name: "Formatting only (create-mode)",
+  args: { aiEnabled: false },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Create-mode editor: no `aiEdit` prop, so the bubble menu only shows formatting buttons. Used by the new-study-guide page where we don't yet have a guide UUID.",
+      },
+    },
+  },
+};
+
+export const WithAskAI: Story = {
+  name: "With Ask AI (edit-mode)",
+  args: { aiEnabled: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Edit-mode editor: passes `aiEdit={{ guideId, title }}`. Selecting text reveals the **Ask AI** entry; clicking it opens the prompt popover. Submitting calls the live API and requires Clerk auth -- in storybook the request will 401, but the popover lifecycle, recent-prompts dropdown, and Esc/outside-click cancel are all interactive.",
+      },
+    },
+  },
+};
+
+export const PopoverIdle: Story = {
+  name: "Popover · idle",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Standalone view of the AskAiPopover body in its initial state, before the user submits a prompt. The recent-prompts dropdown only renders when there's localStorage history.",
+      },
+    },
+  },
+  render: () => (
+    <div className="bg-popover w-fit rounded-md border p-3 shadow-md">
+      <AskAiPopover
+        status="idle"
+        replacement=""
+        error={null}
+        onSubmit={() => undefined}
+        onCancel={() => undefined}
+      />
+    </div>
+  ),
+};
+
+export const PopoverStreaming: Story = {
+  name: "Popover · streaming",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Mid-stream: the input is locked, the cancel button reads `Stop`, and the live preview panel renders the partial replacement with a blinking caret.",
+      },
+    },
+  },
+  render: () => (
+    <div className="bg-popover w-fit rounded-md border p-3 shadow-md">
+      <AskAiPopover
+        status="streaming"
+        replacement="A binary search tree keeps keys"
+        error={null}
+        onSubmit={() => undefined}
+        onCancel={() => undefined}
+      />
+    </div>
+  ),
+};
+
+export const PopoverDone: Story = {
+  name: "Popover · done",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "After the stream's terminal `done` event. ASK-217's diff overlay will take over from here; today the popover just shows the final replacement and waits to be dismissed.",
+      },
+    },
+  },
+  render: () => (
+    <div className="bg-popover w-fit rounded-md border p-3 shadow-md">
+      <AskAiPopover
+        status="done"
+        replacement="A binary search tree (BST) maintains an ordered key invariant so lookups, insertions, and deletions all run in O(log n) time when the tree stays balanced."
+        error={null}
+        onSubmit={() => undefined}
+        onCancel={() => undefined}
+      />
+    </div>
+  ),
+};
+
+export const PopoverError: Story = {
+  name: "Popover · error (429)",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Quota-exceeded / rate-limit error path -- the AppError envelope's `message` is rendered inline so the user can retry without reading the network tab.",
+      },
+    },
+  },
+  render: () => (
+    <div className="bg-popover w-fit rounded-md border p-3 shadow-md">
+      <AskAiPopover
+        status="error"
+        replacement=""
+        error={{
+          message: "Daily AI edit quota exceeded. Try again at midnight UTC.",
+          status: 429,
+        }}
+        onSubmit={() => undefined}
+        onCancel={() => undefined}
+      />
+    </div>
+  ),
+};

--- a/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.tsx
@@ -115,11 +115,23 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
 
   const handleSubmit = (instruction: string) => {
     if (!aiEdit || !target) return;
-    const docContext = buildDocContext(editor, target, aiEdit.title);
+    // Read live mapped positions from the plugin state -- if the doc
+    // was edited while the popover was open, the AiSelectionRange
+    // plugin has already remapped (from, to) through `tr.mapping`.
+    // Falling back to the captured target keeps the call safe even
+    // if some upstream transaction cleared the plugin state.
+    const live = aiSelectionPluginKey.getState(editor.state);
+    const from = live?.from ?? target.from;
+    const to = live?.to ?? target.to;
+    const text =
+      live && live.from !== target.from
+        ? editor.state.doc.textBetween(from, to, "\n", "\n")
+        : target.text;
+    const docContext = buildDocContext(editor, { from, to }, aiEdit.title);
     void start({
-      selectionText: target.text,
-      selectionStart: target.from,
-      selectionEnd: target.to,
+      selectionText: text,
+      selectionStart: from,
+      selectionEnd: to,
       instruction,
       docContext,
     });
@@ -127,24 +139,31 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
 
   // Mirror stream status into the highlight so the decoration pulses
   // while the model streams and stops once we hit done / error.
+  // Reads live (mapped) positions from the plugin state so the
+  // highlight doesn't snap back to a stale target after doc edits.
   useEffect(() => {
-    if (!askOpen || !target) return;
+    if (!askOpen) return;
+    const live = aiSelectionPluginKey.getState(editor.state);
+    if (!live) return;
     setHighlight({
-      from: target.from,
-      to: target.to,
+      from: live.from,
+      to: live.to,
       status: status === "streaming" ? "streaming" : "idle",
     });
-  }, [askOpen, target, status, setHighlight]);
+  }, [askOpen, status, setHighlight, editor]);
 
-  // Recompute the popover anchor rect on scroll / resize so the
-  // popover stays glued to the highlighted range. Layout effect so
-  // we measure after the DOM commits but before paint.
+  // Recompute the popover anchor rect on scroll, resize, AND every
+  // editor transaction so the popover stays glued to the highlighted
+  // range even after typing into the doc. Layout effect so we measure
+  // after the DOM commits but before paint.
   useLayoutEffect(() => {
     if (!askOpen || !target) return;
     const update = () => {
+      const live = aiSelectionPluginKey.getState(editor.state);
+      const from = live?.from ?? target.from;
+      const to = live?.to ?? target.to;
       try {
-        const rect = posToDOMRect(editor.view, target.from, target.to);
-        setAnchorRect(rect);
+        setAnchorRect(posToDOMRect(editor.view, from, to));
       } catch {
         // Doc was edited out from under us; ignore.
       }
@@ -152,9 +171,11 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
     update();
     window.addEventListener("scroll", update, true);
     window.addEventListener("resize", update);
+    editor.on("transaction", update);
     return () => {
       window.removeEventListener("scroll", update, true);
       window.removeEventListener("resize", update);
+      editor.off("transaction", update);
     };
   }, [askOpen, target, editor]);
 
@@ -242,8 +263,19 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
               closeAsk();
             }}
             onInteractOutside={(e) => {
-              // Only close on click-outside; ignore focus shifts so a
-              // recents-dropdown click doesn't dismiss accidentally.
+              // Radix DropdownMenu portals to <body>, so clicking a
+              // recents item is technically "outside" this popover.
+              // Skip the dismiss when the event target sits inside any
+              // portalled menu/listbox so picking a recent prompt
+              // doesn't slam the popover shut.
+              const target = e.detail.originalEvent.target;
+              if (
+                target instanceof Element &&
+                target.closest('[role="menu"], [role="listbox"]')
+              ) {
+                e.preventDefault();
+                return;
+              }
               if (e.detail.originalEvent.type === "pointerdown") {
                 closeAsk();
               }

--- a/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import { posToDOMRect } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
+import { BubbleMenu } from "@tiptap/react/menus";
+import { Bold, Code, Italic, Sparkles, Strikethrough } from "lucide-react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+import {
+  aiSelectionPluginKey,
+  type AiSelectionStatus,
+} from "./ai-selection-range";
+import { AskAiPopover } from "./ask-ai-popover";
+import { useAiEditStream } from "./use-ai-edit-stream";
+
+export interface EditorBubbleMenuProps {
+  editor: Editor;
+  /**
+   * Provide to enable the "Ask AI" entry. Omitted in create-mode (no
+   * guide id yet) -- the menu still renders formatting buttons.
+   */
+  aiEdit?: {
+    guideId: string;
+    title?: string;
+  };
+}
+
+const CONTEXT_WINDOW = 500;
+
+/**
+ * Floating selection toolbar (TipTap v3 BubbleMenu, Floating UI under
+ * the hood). Shows on non-empty text selection and exposes:
+ *   - Inline formatting toggles (bold / italic / strike / inline code)
+ *   - "Ask AI" entry (when {@link aiEdit} is provided) that opens a
+ *     Radix Popover anchored to the selection. The popover hosts the
+ *     prompt input, recent-prompts dropdown, and streaming preview.
+ *
+ * The visible "you're editing this text" highlight is owned by the
+ * AiSelectionRange ProseMirror plugin (see ./ai-selection-range.ts):
+ * we dispatch `setMeta(aiSelectionPluginKey, { from, to, status })`
+ * on open and on stream-state transitions, then clear it on close.
+ * The plugin renders the highlight as an inline Decoration so it
+ * tracks the text on scroll, doc edits, and resize without any JS
+ * measurement.
+ */
+export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
+  const [askOpen, setAskOpen] = useState(false);
+  // Captured at the moment the user clicks "Ask AI" -- the selection
+  // can change once focus moves into the popover input.
+  const [target, setTarget] = useState<{
+    from: number;
+    to: number;
+    text: string;
+  } | null>(null);
+  // Anchor rect for the Radix Popover. Recomputed on scroll / resize
+  // via posToDOMRect so the popover follows its target.
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+  const stream = useAiEditStream({ guideId: aiEdit?.guideId ?? "" });
+  const { status, replacement, error, start, cancel, reset } = stream;
+
+  // Keep the bubble menu visible while the popover is open even
+  // though the editor has lost focus. Once the popover closes we
+  // fall back to the default selection-based visibility rule.
+  const shouldShow = useCallback(
+    ({ state }: { state: { selection: { empty: boolean } } }) => {
+      if (askOpen) return true;
+      return !state.selection.empty;
+    },
+    [askOpen],
+  );
+
+  const setHighlight = useCallback(
+    (next: { from: number; to: number; status: AiSelectionStatus } | null) => {
+      const { state, dispatch } = editor.view;
+      dispatch(state.tr.setMeta(aiSelectionPluginKey, next));
+    },
+    [editor],
+  );
+
+  const handleOpenAsk = () => {
+    if (!aiEdit) return;
+    const captured = captureSelection(editor);
+    if (!captured) return;
+    setTarget(captured);
+    setAnchorRect(captured.rect);
+    setHighlight({ from: captured.from, to: captured.to, status: "idle" });
+    reset();
+    setAskOpen(true);
+  };
+
+  const closeAsk = useCallback(() => {
+    cancel();
+    setAskOpen(false);
+    setTarget(null);
+    setAnchorRect(null);
+    setHighlight(null);
+    reset();
+  }, [cancel, reset, setHighlight]);
+
+  const handleSubmit = (instruction: string) => {
+    if (!aiEdit || !target) return;
+    const docContext = buildDocContext(editor, target, aiEdit.title);
+    void start({
+      selectionText: target.text,
+      selectionStart: target.from,
+      selectionEnd: target.to,
+      instruction,
+      docContext,
+    });
+  };
+
+  // Mirror stream status into the highlight so the decoration pulses
+  // while the model streams and stops once we hit done / error.
+  useEffect(() => {
+    if (!askOpen || !target) return;
+    setHighlight({
+      from: target.from,
+      to: target.to,
+      status: status === "streaming" ? "streaming" : "idle",
+    });
+  }, [askOpen, target, status, setHighlight]);
+
+  // Recompute the popover anchor rect on scroll / resize so the
+  // popover stays glued to the highlighted range. Layout effect so
+  // we measure after the DOM commits but before paint.
+  useLayoutEffect(() => {
+    if (!askOpen || !target) return;
+    const update = () => {
+      try {
+        const rect = posToDOMRect(editor.view, target.from, target.to);
+        setAnchorRect(rect);
+      } catch {
+        // Doc was edited out from under us; ignore.
+      }
+    };
+    update();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [askOpen, target, editor]);
+
+  // Cancel any in-flight stream + clear highlight when unmounting.
+  useEffect(() => {
+    return () => {
+      cancel();
+      setHighlight(null);
+    };
+  }, [cancel, setHighlight]);
+
+  return (
+    <>
+      <BubbleMenu
+        editor={editor}
+        shouldShow={shouldShow}
+        options={{ placement: "top", offset: 8 }}
+        className="bg-popover text-popover-foreground flex items-center gap-0.5 rounded-md border p-1 shadow-md"
+      >
+        <FormatButton
+          editor={editor}
+          mark="bold"
+          aria-label="Bold"
+          icon={<Bold className="size-4" />}
+        />
+        <FormatButton
+          editor={editor}
+          mark="italic"
+          aria-label="Italic"
+          icon={<Italic className="size-4" />}
+        />
+        <FormatButton
+          editor={editor}
+          mark="strike"
+          aria-label="Strikethrough"
+          icon={<Strikethrough className="size-4" />}
+        />
+        <FormatButton
+          editor={editor}
+          mark="code"
+          aria-label="Inline code"
+          icon={<Code className="size-4" />}
+        />
+        {aiEdit ? (
+          <>
+            <Separator orientation="vertical" className="mx-1 h-5" />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              // Prevent the editor's blur on mousedown so the doc
+              // selection is still intact when our click handler reads
+              // it back via captureSelection.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={handleOpenAsk}
+              className="gap-1.5"
+              aria-label="Ask AI to rewrite the selection"
+            >
+              <Sparkles className="size-4" />
+              <span className="text-xs font-medium">Ask AI</span>
+            </Button>
+          </>
+        ) : null}
+      </BubbleMenu>
+
+      {aiEdit ? (
+        <Popover
+          open={askOpen}
+          onOpenChange={(next) => {
+            if (!next) closeAsk();
+          }}
+        >
+          {anchorRect ? (
+            <PopoverAnchor asChild>
+              <SelectionAnchor rect={anchorRect} />
+            </PopoverAnchor>
+          ) : null}
+          <PopoverContent
+            side="bottom"
+            align="start"
+            sideOffset={8}
+            className="w-auto p-3"
+            onEscapeKeyDown={(e) => {
+              e.preventDefault();
+              closeAsk();
+            }}
+            onInteractOutside={(e) => {
+              // Only close on click-outside; ignore focus shifts so a
+              // recents-dropdown click doesn't dismiss accidentally.
+              if (e.detail.originalEvent.type === "pointerdown") {
+                closeAsk();
+              }
+            }}
+          >
+            <AskAiPopover
+              status={status}
+              replacement={replacement}
+              error={error}
+              onSubmit={handleSubmit}
+              onCancel={closeAsk}
+            />
+          </PopoverContent>
+        </Popover>
+      ) : null}
+    </>
+  );
+}
+
+interface FormatButtonProps {
+  editor: Editor;
+  mark: "bold" | "italic" | "strike" | "code";
+  icon: React.ReactNode;
+  "aria-label": string;
+}
+
+function FormatButton({
+  editor,
+  mark,
+  icon,
+  "aria-label": label,
+}: FormatButtonProps) {
+  const isActive = editor.isActive(mark);
+  const handleClick = () => {
+    const chain = editor.chain().focus();
+    switch (mark) {
+      case "bold":
+        chain.toggleBold().run();
+        break;
+      case "italic":
+        chain.toggleItalic().run();
+        break;
+      case "strike":
+        chain.toggleStrike().run();
+        break;
+      case "code":
+        chain.toggleCode().run();
+        break;
+    }
+  };
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      // Block the default mousedown so the editor's selection isn't
+      // collapsed when the user clicks a toolbar button.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={handleClick}
+      aria-pressed={isActive}
+      aria-label={label}
+      className={cn("size-8", isActive && "bg-accent text-accent-foreground")}
+    >
+      {icon}
+    </Button>
+  );
+}
+
+interface SelectionAnchorProps {
+  rect: DOMRect;
+}
+
+/**
+ * Invisible positioning hint for the Radix Popover. The visible
+ * highlight is rendered by the AiSelectionRange ProseMirror plugin
+ * as an inline Decoration; this div exists only so Radix has an
+ * anchor element it can measure.
+ *
+ * Ref-forwarding is required because `<PopoverAnchor asChild>` uses
+ * Radix's Slot and needs to attach its measurement ref to this node.
+ */
+const SelectionAnchor = forwardRef<HTMLDivElement, SelectionAnchorProps>(
+  function SelectionAnchor({ rect }, ref) {
+    return (
+      <div
+        ref={ref}
+        aria-hidden
+        style={{
+          position: "fixed",
+          top: rect.top,
+          left: rect.left,
+          width: Math.max(rect.width, 1),
+          height: Math.max(rect.height, 1),
+          pointerEvents: "none",
+        }}
+      />
+    );
+  },
+);
+
+interface CapturedSelection {
+  from: number;
+  to: number;
+  text: string;
+  rect: DOMRect;
+}
+
+function captureSelection(editor: Editor): CapturedSelection | null {
+  const { state } = editor;
+  const { from, to } = state.selection;
+  if (from === to) return null;
+  const text = state.doc.textBetween(from, to, "\n", "\n");
+  if (!text.trim()) return null;
+  // posToDOMRect is TipTap's blessed helper -- it walks the view's
+  // DOM mapping for the [from, to] range so multi-line selections
+  // get a sensible bounding rect, unlike coordsAtPos which only
+  // returns the cursor box at a single position.
+  let rect: DOMRect;
+  try {
+    rect = posToDOMRect(editor.view, from, to);
+  } catch {
+    return null;
+  }
+  return { from, to, text, rect };
+}
+
+function buildDocContext(
+  editor: Editor,
+  target: { from: number; to: number },
+  title?: string,
+): { title?: string; preceding?: string; following?: string } | undefined {
+  const { doc } = editor.state;
+  const docSize = doc.content.size;
+  const precedingFrom = Math.max(0, target.from - CONTEXT_WINDOW);
+  const followingTo = Math.min(docSize, target.to + CONTEXT_WINDOW);
+  const preceding = doc.textBetween(precedingFrom, target.from, "\n", "\n");
+  const following = doc.textBetween(target.to, followingTo, "\n", "\n");
+  const ctx: { title?: string; preceding?: string; following?: string } = {};
+  if (title && title.trim()) ctx.title = title.trim();
+  if (preceding) ctx.preceding = preceding;
+  if (following) ctx.following = following;
+  return Object.keys(ctx).length > 0 ? ctx : undefined;
+}

--- a/web/lib/features/dashboard/study-guides/wysiwyg/editor.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/editor.tsx
@@ -14,8 +14,22 @@ import { EntityRefProvider } from "../refs/entity-ref-context";
 import { extractRefs } from "../refs/extract-refs";
 import { rewritePastedUrl } from "../paste-rewriter";
 
+import { AiSelectionRange } from "./ai-selection-range";
+import { EditorBubbleMenu } from "./editor-bubble-menu";
 import { EntityRefNode, type EntityType } from "./entity-ref-node";
 import { preprocessMarkdown } from "./markdown-codec";
+
+/**
+ * Per-guide AI edit target. When provided, the bubble menu shows an
+ * "Ask AI" entry that calls `POST /api/study-guides/{guideId}/ai/edit`
+ * (ASK-215). Omitted in create-mode -- the BubbleMenu still renders
+ * formatting buttons.
+ */
+export interface AiEditTarget {
+  guideId: string;
+  /** Best-effort title for prompt cache + model context. */
+  title?: string;
+}
 
 interface TiptapEditorProps {
   value: string;
@@ -25,6 +39,7 @@ interface TiptapEditorProps {
   className?: string;
   allowedHosts?: string[];
   initialRefs?: Record<string, RefSummary | null>;
+  aiEdit?: AiEditTarget;
 }
 
 function resolveHosts(explicit?: string[]): string[] {
@@ -46,6 +61,7 @@ export function TiptapEditor({
   className,
   allowedHosts,
   initialRefs,
+  aiEdit,
 }: TiptapEditorProps) {
   const hosts = useMemo(() => resolveHosts(allowedHosts), [allowedHosts]);
   const refs = useMemo(() => extractRefs(value), [value]);
@@ -64,6 +80,7 @@ export function TiptapEditor({
         transformCopiedText: false,
       }),
       EntityRefNode,
+      AiSelectionRange,
     ],
     content: preprocessMarkdown(value),
     editorProps: {
@@ -126,6 +143,9 @@ export function TiptapEditor({
   return (
     <EntityRefProvider refs={refs} initial={initialRefs}>
       <EditorContent editor={editor} className={className} />
+      {editor && !disabled ? (
+        <EditorBubbleMenu editor={editor} aiEdit={aiEdit} />
+      ) : null}
     </EntityRefProvider>
   );
 }

--- a/web/lib/features/dashboard/study-guides/wysiwyg/recent-prompts.test.ts
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/recent-prompts.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  addRecentPrompt,
+  getRecentPrompts,
+  RECENT_PROMPTS_LIMIT,
+  RECENT_PROMPTS_STORAGE_KEY,
+} from "./recent-prompts";
+
+describe("recent-prompts", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns empty list when storage is empty", () => {
+    expect(getRecentPrompts()).toEqual([]);
+  });
+
+  it("inserts a new prompt at the head", () => {
+    addRecentPrompt("make it shorter");
+    expect(getRecentPrompts()).toEqual(["make it shorter"]);
+  });
+
+  it("dedupes case-insensitively, moving the duplicate to the head", () => {
+    addRecentPrompt("a");
+    addRecentPrompt("b");
+    addRecentPrompt("A"); // duplicate of "a"
+    expect(getRecentPrompts()).toEqual(["A", "b"]);
+  });
+
+  it(`caps history at ${RECENT_PROMPTS_LIMIT} entries`, () => {
+    for (let i = 0; i < RECENT_PROMPTS_LIMIT + 3; i += 1) {
+      addRecentPrompt(`prompt ${i}`);
+    }
+    const stored = getRecentPrompts();
+    expect(stored).toHaveLength(RECENT_PROMPTS_LIMIT);
+    // Most-recent-first: last insert is at index 0.
+    expect(stored[0]).toBe(`prompt ${RECENT_PROMPTS_LIMIT + 2}`);
+  });
+
+  it("ignores empty / whitespace-only prompts", () => {
+    addRecentPrompt("real");
+    addRecentPrompt("   ");
+    addRecentPrompt("");
+    expect(getRecentPrompts()).toEqual(["real"]);
+  });
+
+  it("trims whitespace before storing", () => {
+    addRecentPrompt("  shorten this  ");
+    expect(getRecentPrompts()).toEqual(["shorten this"]);
+  });
+
+  it("survives a corrupt storage value", () => {
+    window.localStorage.setItem(RECENT_PROMPTS_STORAGE_KEY, "{not json");
+    expect(getRecentPrompts()).toEqual([]);
+    addRecentPrompt("recover");
+    expect(getRecentPrompts()).toEqual(["recover"]);
+  });
+
+  it("ignores non-array stored values", () => {
+    window.localStorage.setItem(
+      RECENT_PROMPTS_STORAGE_KEY,
+      JSON.stringify({ foo: "bar" }),
+    );
+    expect(getRecentPrompts()).toEqual([]);
+  });
+
+  it("filters out non-string entries from corrupt arrays", () => {
+    window.localStorage.setItem(
+      RECENT_PROMPTS_STORAGE_KEY,
+      JSON.stringify(["valid", 42, null, "also valid"]),
+    );
+    expect(getRecentPrompts()).toEqual(["valid", "also valid"]);
+  });
+});

--- a/web/lib/features/dashboard/study-guides/wysiwyg/recent-prompts.ts
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/recent-prompts.ts
@@ -1,0 +1,59 @@
+/**
+ * Persists the last few "Ask AI" prompts in localStorage so the user
+ * can re-pick a directive they ran a minute ago without re-typing.
+ *
+ * SSR-safe: every helper checks for `window` before touching storage,
+ * so the popover can render server-side without crashing.
+ */
+
+const STORAGE_KEY = "askatlas:study-guide-edit:recent-prompts";
+const MAX_RECENT = 5;
+
+function readStorage(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    // Quota errors, JSON parse failures, or a malicious extension that
+    // overwrote the value -- prompt history is a best-effort UX nicety,
+    // never let it break the editor.
+    return [];
+  }
+}
+
+function writeStorage(values: readonly string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(values));
+  } catch {
+    // ignore quota / private-mode errors
+  }
+}
+
+/** Returns the most-recent-first list of prompts, capped at {@link MAX_RECENT}. */
+export function getRecentPrompts(): string[] {
+  return readStorage().slice(0, MAX_RECENT);
+}
+
+/**
+ * Inserts `prompt` at the head of the recent list, dedupes by exact
+ * string match (case-insensitive trimmed compare), and trims to
+ * {@link MAX_RECENT}. No-op for empty / whitespace-only strings.
+ */
+export function addRecentPrompt(prompt: string): string[] {
+  const trimmed = prompt.trim();
+  if (!trimmed) return getRecentPrompts();
+  const existing = readStorage();
+  const key = trimmed.toLowerCase();
+  const deduped = existing.filter((v) => v.trim().toLowerCase() !== key);
+  const next = [trimmed, ...deduped].slice(0, MAX_RECENT);
+  writeStorage(next);
+  return next;
+}
+
+export const RECENT_PROMPTS_STORAGE_KEY = STORAGE_KEY;
+export const RECENT_PROMPTS_LIMIT = MAX_RECENT;

--- a/web/lib/features/dashboard/study-guides/wysiwyg/use-ai-edit-stream.test.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/use-ai-edit-stream.test.tsx
@@ -5,7 +5,10 @@
 // from Node's built-ins so the SSE-byte plumbing works under test.
 // Response is duck-typed below so we don't need to polyfill it.
 import { ReadableStream as NodeReadableStream } from "node:stream/web";
-import { TextDecoder as NodeTextDecoder, TextEncoder as NodeTextEncoder } from "node:util";
+import {
+  TextDecoder as NodeTextDecoder,
+  TextEncoder as NodeTextEncoder,
+} from "node:util";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 if (typeof (globalThis as any).TextEncoder === "undefined") {

--- a/web/lib/features/dashboard/study-guides/wysiwyg/use-ai-edit-stream.test.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/use-ai-edit-stream.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * @jest-environment jsdom
+ */
+// jsdom doesn't ship TextEncoder/ReadableStream as globals. Pull them
+// from Node's built-ins so the SSE-byte plumbing works under test.
+// Response is duck-typed below so we don't need to polyfill it.
+import { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { TextDecoder as NodeTextDecoder, TextEncoder as NodeTextEncoder } from "node:util";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+if (typeof (globalThis as any).TextEncoder === "undefined") {
+  (globalThis as any).TextEncoder = NodeTextEncoder;
+}
+if (typeof (globalThis as any).TextDecoder === "undefined") {
+  (globalThis as any).TextDecoder = NodeTextDecoder;
+}
+if (typeof (globalThis as any).ReadableStream === "undefined") {
+  (globalThis as any).ReadableStream = NodeReadableStream;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import { useAiEditStream } from "./use-ai-edit-stream";
+
+const mockGetToken = jest.fn<Promise<string | null>, []>();
+
+jest.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({ getToken: mockGetToken }),
+}));
+
+const GUIDE_ID = "11111111-2222-3333-4444-555555555555";
+const VALID_PARAMS = {
+  selectionText: "hello",
+  selectionStart: 0,
+  selectionEnd: 5,
+  instruction: "make it shorter",
+};
+
+interface FakeStreamHandle {
+  push: (chunk: string) => void;
+  close: () => void;
+  error: (err: Error) => void;
+}
+
+function makeStream(): {
+  body: ReadableStream<Uint8Array>;
+  handle: FakeStreamHandle;
+} {
+  const encoder = new TextEncoder();
+  let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllerRef = controller;
+    },
+  });
+  const handle: FakeStreamHandle = {
+    push: (chunk) => controllerRef?.enqueue(encoder.encode(chunk)),
+    close: () => controllerRef?.close(),
+    error: (err) => controllerRef?.error(err),
+  };
+  return { body, handle };
+}
+
+// Minimal duck-typed Response — the hook only reads `.ok`, `.body`,
+// `.status`, and `.clone().json()`. We avoid the real Response
+// constructor because jsdom + Node 20 in jest don't ship it.
+function streamingResponse(body: ReadableStream<Uint8Array>): unknown {
+  return {
+    ok: true,
+    status: 200,
+    body,
+    clone() {
+      return { json: async () => ({}) };
+    },
+  };
+}
+
+function jsonErrorResponse(status: number, payload: unknown): unknown {
+  const cloned = { json: async () => payload };
+  return {
+    ok: false,
+    status,
+    body: null,
+    clone() {
+      return cloned;
+    },
+  };
+}
+
+describe("useAiEditStream", () => {
+  beforeEach(() => {
+    mockGetToken.mockReset();
+    mockGetToken.mockResolvedValue("fake-token");
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHook(() => useAiEditStream({ guideId: GUIDE_ID }));
+    expect(result.current.status).toBe("idle");
+    expect(result.current.replacement).toBe("");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("transitions through streaming → done and accumulates deltas", async () => {
+    const { body, handle } = makeStream();
+    (global.fetch as jest.Mock).mockResolvedValue(streamingResponse(body));
+
+    const { result } = renderHook(() => useAiEditStream({ guideId: GUIDE_ID }));
+
+    await act(async () => {
+      void result.current.start(VALID_PARAMS);
+    });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    await act(async () => {
+      handle.push('event: delta\ndata: {"text":"Hi"}\n\n');
+    });
+    await waitFor(() => expect(result.current.replacement).toBe("Hi"));
+
+    await act(async () => {
+      handle.push('event: delta\ndata: {"text":" there"}\n\n');
+      handle.push(
+        'event: usage\ndata: {"input_tokens":12,"output_tokens":3,"cache_read_tokens":0,"cache_write_tokens":0}\n\n',
+      );
+      handle.push("event: done\ndata: {}\n\n");
+      handle.close();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.replacement).toBe("Hi there");
+    expect(result.current.usage).toEqual({
+      inputTokens: 12,
+      outputTokens: 3,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+  });
+
+  it("sends Authorization header + correct request body", async () => {
+    const { body, handle } = makeStream();
+    const fetchMock = jest.fn().mockResolvedValue(streamingResponse(body));
+    global.fetch = fetchMock;
+
+    const { result } = renderHook(() => useAiEditStream({ guideId: GUIDE_ID }));
+
+    await act(async () => {
+      void result.current.start({
+        ...VALID_PARAMS,
+        docContext: { title: "My Guide", preceding: "before" },
+      });
+    });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain(`/study-guides/${GUIDE_ID}/ai/edit`);
+    expect(init.method).toBe("POST");
+    expect(init.headers["Authorization"]).toBe("Bearer fake-token");
+    expect(init.headers["Accept"]).toBe("text/event-stream");
+    const sent = JSON.parse(init.body);
+    expect(sent).toEqual({
+      selection_text: "hello",
+      selection_start: 0,
+      selection_end: 5,
+      instruction: "make it shorter",
+      doc_context: { title: "My Guide", preceding: "before" },
+    });
+
+    await act(async () => {
+      handle.push("event: done\ndata: {}\n\n");
+      handle.close();
+    });
+  });
+
+  it("surfaces a server error event", async () => {
+    const { body, handle } = makeStream();
+    (global.fetch as jest.Mock).mockResolvedValue(streamingResponse(body));
+
+    const { result } = renderHook(() => useAiEditStream({ guideId: GUIDE_ID }));
+
+    await act(async () => {
+      void result.current.start(VALID_PARAMS);
+    });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    await act(async () => {
+      handle.push('event: error\ndata: {"message":"upstream blew up"}\n\n');
+      handle.close();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error?.message).toBe("upstream blew up");
+  });
+
+  it("surfaces an HTTP 4xx response with the AppError message", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      jsonErrorResponse(429, { message: "rate limited" }),
+    );
+
+    const { result } = renderHook(() => useAiEditStream({ guideId: GUIDE_ID }));
+
+    await act(async () => {
+      await result.current.start(VALID_PARAMS);
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toEqual({
+      message: "rate limited",
+      status: 429,
+    });
+  });
+
+  it("transitions to cancelled when cancel() is called mid-stream", async () => {
+    const { body, handle } = makeStream();
+    (global.fetch as jest.Mock).mockResolvedValue(streamingResponse(body));
+
+    const { result } = renderHook(() => useAiEditStream({ guideId: GUIDE_ID }));
+
+    await act(async () => {
+      void result.current.start(VALID_PARAMS);
+    });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    await act(async () => {
+      handle.push('event: delta\ndata: {"text":"so"}\n\n');
+    });
+    await waitFor(() => expect(result.current.replacement).toBe("so"));
+
+    await act(async () => {
+      result.current.cancel();
+      handle.error(new DOMException("aborted", "AbortError"));
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("cancelled"));
+  });
+
+  it("treats EOF without a `done` event as a stream error", async () => {
+    const { body, handle } = makeStream();
+    (global.fetch as jest.Mock).mockResolvedValue(streamingResponse(body));
+
+    const { result } = renderHook(() => useAiEditStream({ guideId: GUIDE_ID }));
+
+    await act(async () => {
+      void result.current.start(VALID_PARAMS);
+    });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    await act(async () => {
+      handle.push('event: delta\ndata: {"text":"partial"}\n\n');
+      handle.close();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error?.message).toMatch(/unexpected/i);
+  });
+
+  it("ignores comment-only frames (heartbeats)", async () => {
+    const { body, handle } = makeStream();
+    (global.fetch as jest.Mock).mockResolvedValue(streamingResponse(body));
+
+    const { result } = renderHook(() => useAiEditStream({ guideId: GUIDE_ID }));
+
+    await act(async () => {
+      void result.current.start(VALID_PARAMS);
+    });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    await act(async () => {
+      handle.push(": heartbeat\n\n");
+      handle.push('event: delta\ndata: {"text":"ok"}\n\n');
+      handle.push("event: done\ndata: {}\n\n");
+      handle.close();
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(result.current.replacement).toBe("ok");
+  });
+
+  it("reset() clears state and aborts any in-flight stream", async () => {
+    const { body, handle } = makeStream();
+    (global.fetch as jest.Mock).mockResolvedValue(streamingResponse(body));
+
+    const { result } = renderHook(() => useAiEditStream({ guideId: GUIDE_ID }));
+
+    await act(async () => {
+      void result.current.start(VALID_PARAMS);
+    });
+    await waitFor(() => expect(result.current.status).toBe("streaming"));
+
+    await act(async () => {
+      handle.push('event: delta\ndata: {"text":"x"}\n\n');
+    });
+    await waitFor(() => expect(result.current.replacement).toBe("x"));
+
+    await act(async () => {
+      result.current.reset();
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.replacement).toBe("");
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/web/lib/features/dashboard/study-guides/wysiwyg/use-ai-edit-stream.ts
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/use-ai-edit-stream.ts
@@ -1,0 +1,365 @@
+"use client";
+
+import { useAuth } from "@clerk/nextjs";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { API_BASE } from "@/lib/api/client";
+import type { ApiSchemas } from "@/lib/api/client";
+
+/**
+ * Browser-side SSE consumer for `POST /api/study-guides/{id}/ai/edit`.
+ *
+ * Why a custom hook instead of openapi-fetch:
+ *   - openapi-fetch buffers the full body before resolving, which
+ *     defeats `text/event-stream` flush-per-chunk semantics.
+ *   - Server-side, the route is gated by Clerk; we inject the JWT
+ *     here via `useAuth().getToken()` so the same browser fetch can
+ *     hit the Go API on a different origin.
+ *
+ * The hook stays decoupled from the diff overlay (ASK-217). Once the
+ * first delta arrives, the consumer (popover today, diff overlay
+ * later) drives the UI off `replacement` + `status`.
+ */
+
+export type AiEditStreamStatus =
+  | "idle"
+  | "streaming"
+  | "done"
+  | "error"
+  | "cancelled";
+
+export interface AiEditStreamError {
+  message: string;
+  status?: number;
+}
+
+export interface AiEditStreamUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+export interface AiEditStartParams {
+  selectionText: string;
+  selectionStart: number;
+  selectionEnd: number;
+  instruction: string;
+  docContext?: ApiSchemas["AIEditDocContext"];
+}
+
+export interface UseAiEditStreamOptions {
+  guideId: string;
+}
+
+export interface UseAiEditStreamReturn {
+  status: AiEditStreamStatus;
+  replacement: string;
+  usage: AiEditStreamUsage | null;
+  error: AiEditStreamError | null;
+  start: (params: AiEditStartParams) => Promise<void>;
+  cancel: () => void;
+  reset: () => void;
+}
+
+interface DeltaPayload {
+  text?: string;
+}
+
+interface UsagePayload {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+}
+
+interface ErrorPayload {
+  message?: string;
+}
+
+const NEWLINE = /\r?\n/;
+
+export function useAiEditStream(
+  options: UseAiEditStreamOptions,
+): UseAiEditStreamReturn {
+  const { guideId } = options;
+  const { getToken } = useAuth();
+
+  const [status, setStatus] = useState<AiEditStreamStatus>("idle");
+  const [replacement, setReplacement] = useState("");
+  const [usage, setUsage] = useState<AiEditStreamUsage | null>(null);
+  const [error, setError] = useState<AiEditStreamError | null>(null);
+
+  const controllerRef = useRef<AbortController | null>(null);
+  // Identifies the active stream so out-of-order updates from a
+  // previous start() (whose async work didn't notice the abort yet)
+  // don't bleed into the new stream.
+  const generationRef = useRef(0);
+
+  const cancel = useCallback(() => {
+    const controller = controllerRef.current;
+    if (!controller) return;
+    controller.abort();
+    controllerRef.current = null;
+  }, []);
+
+  const reset = useCallback(() => {
+    cancel();
+    generationRef.current += 1;
+    setStatus("idle");
+    setReplacement("");
+    setUsage(null);
+    setError(null);
+  }, [cancel]);
+
+  // Cancel any in-flight stream when the consumer unmounts so we
+  // don't leak a fetch + reader pair past the popover closing.
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+    };
+  }, []);
+
+  const start = useCallback(
+    async (params: AiEditStartParams) => {
+      controllerRef.current?.abort();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+      const generation = ++generationRef.current;
+
+      setStatus("streaming");
+      setReplacement("");
+      setUsage(null);
+      setError(null);
+
+      let token: string | null = null;
+      try {
+        token = await getToken();
+      } catch {
+        token = null;
+      }
+      if (generationRef.current !== generation) return;
+
+      const body: ApiSchemas["AIEditRequest"] = {
+        selection_text: params.selectionText,
+        selection_start: params.selectionStart,
+        selection_end: params.selectionEnd,
+        instruction: params.instruction,
+        ...(params.docContext ? { doc_context: params.docContext } : {}),
+      };
+
+      let response: Response;
+      try {
+        response = await fetch(
+          `${API_BASE}/study-guides/${guideId}/ai/edit`,
+          {
+            method: "POST",
+            credentials: "same-origin",
+            headers: {
+              "Content-Type": "application/json",
+              Accept: "text/event-stream",
+              ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            },
+            body: JSON.stringify(body),
+            signal: controller.signal,
+          },
+        );
+      } catch (err) {
+        if (generationRef.current !== generation) return;
+        if (controller.signal.aborted) {
+          setStatus("cancelled");
+          return;
+        }
+        setStatus("error");
+        setError({ message: errorMessage(err) });
+        return;
+      }
+
+      if (generationRef.current !== generation) return;
+
+      if (!response.ok || !response.body) {
+        setStatus("error");
+        setError({
+          message: await readErrorMessage(response),
+          status: response.status,
+        });
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let receivedUsage: AiEditStreamUsage | null = null;
+
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          let separator = findSeparator(buffer);
+          while (separator !== -1) {
+            const frame = buffer.slice(0, separator);
+            buffer = buffer.slice(
+              separator + separatorLength(buffer, separator),
+            );
+            const event = parseFrame(frame);
+
+            if (generationRef.current !== generation) return;
+
+            if (event.type === "delta") {
+              if (event.text) {
+                setReplacement((prev) => prev + event.text);
+              }
+            } else if (event.type === "usage") {
+              receivedUsage = event.usage;
+              setUsage(event.usage);
+            } else if (event.type === "error") {
+              setStatus("error");
+              setError({ message: event.message ?? "stream error" });
+              controller.abort();
+              return;
+            } else if (event.type === "done") {
+              setStatus("done");
+              if (receivedUsage) setUsage(receivedUsage);
+              controllerRef.current = null;
+              return;
+            }
+            separator = findSeparator(buffer);
+          }
+        }
+
+        if (generationRef.current !== generation) return;
+        // Reader closed cleanly without a `done` event. The Go server
+        // always emits `done` on success, so this is an abnormal EOF
+        // (proxy timed out, network hiccup) -- surface it.
+        setStatus("error");
+        setError({ message: "Stream ended unexpectedly" });
+      } catch (err) {
+        if (generationRef.current !== generation) return;
+        if (controller.signal.aborted) {
+          setStatus("cancelled");
+          return;
+        }
+        setStatus("error");
+        setError({ message: errorMessage(err) });
+      } finally {
+        if (controllerRef.current === controller) {
+          controllerRef.current = null;
+        }
+      }
+    },
+    [getToken, guideId],
+  );
+
+  return { status, replacement, usage, error, start, cancel, reset };
+}
+
+interface ParsedEvent {
+  type: "delta" | "usage" | "error" | "done" | "unknown";
+  text?: string;
+  usage: AiEditStreamUsage;
+  message?: string;
+}
+
+function parseFrame(frame: string): ParsedEvent {
+  const result: ParsedEvent = {
+    type: "unknown",
+    usage: emptyUsage(),
+  };
+  const dataLines: string[] = [];
+
+  for (const rawLine of frame.split(NEWLINE)) {
+    if (!rawLine || rawLine.startsWith(":")) continue;
+    const colon = rawLine.indexOf(":");
+    if (colon === -1) continue;
+    const field = rawLine.slice(0, colon);
+    const value =
+      rawLine.charAt(colon + 1) === " "
+        ? rawLine.slice(colon + 2)
+        : rawLine.slice(colon + 1);
+    if (field === "event") {
+      if (
+        value === "delta" ||
+        value === "usage" ||
+        value === "error" ||
+        value === "done"
+      ) {
+        result.type = value;
+      }
+    } else if (field === "data") {
+      dataLines.push(value);
+    }
+  }
+
+  if (dataLines.length === 0) return result;
+  const data = dataLines.join("\n");
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (result.type === "delta" && isObject(parsed)) {
+      const delta = parsed as DeltaPayload;
+      result.text = typeof delta.text === "string" ? delta.text : "";
+    } else if (result.type === "usage" && isObject(parsed)) {
+      const usage = parsed as UsagePayload;
+      result.usage = {
+        inputTokens: usage.input_tokens ?? 0,
+        outputTokens: usage.output_tokens ?? 0,
+        cacheReadTokens: usage.cache_read_tokens ?? 0,
+        cacheWriteTokens: usage.cache_write_tokens ?? 0,
+      };
+    } else if (result.type === "error" && isObject(parsed)) {
+      const err = parsed as ErrorPayload;
+      result.message = typeof err.message === "string" ? err.message : "";
+    }
+  } catch {
+    // malformed JSON -- treat as unknown
+  }
+  return result;
+}
+
+function emptyUsage(): AiEditStreamUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+  };
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function findSeparator(buf: string): number {
+  const lf = buf.indexOf("\n\n");
+  const crlf = buf.indexOf("\r\n\r\n");
+  if (lf === -1) return crlf;
+  if (crlf === -1) return lf;
+  return Math.min(lf, crlf);
+}
+
+function separatorLength(buf: string, idx: number): number {
+  return buf.startsWith("\r\n\r\n", idx) ? 4 : 2;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return "Unexpected error";
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body: unknown = await response.clone().json();
+    if (
+      isObject(body) &&
+      "message" in body &&
+      typeof body.message === "string"
+    ) {
+      return body.message;
+    }
+  } catch {
+    // fall through
+  }
+  return `Request failed (${response.status})`;
+}

--- a/web/lib/features/dashboard/study-guides/wysiwyg/use-ai-edit-stream.ts
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/use-ai-edit-stream.ts
@@ -151,20 +151,17 @@ export function useAiEditStream(
 
       let response: Response;
       try {
-        response = await fetch(
-          `${API_BASE}/study-guides/${guideId}/ai/edit`,
-          {
-            method: "POST",
-            credentials: "same-origin",
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "text/event-stream",
-              ...(token ? { Authorization: `Bearer ${token}` } : {}),
-            },
-            body: JSON.stringify(body),
-            signal: controller.signal,
+        response = await fetch(`${API_BASE}/study-guides/${guideId}/ai/edit`, {
+          method: "POST",
+          credentials: "same-origin",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
           },
-        );
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
       } catch (err) {
         if (generationRef.current !== generation) return;
         if (controller.signal.aborted) {


### PR DESCRIPTION
Closes ASK-216.

## Summary
- Selection bubble menu on the study-guide editor: inline formatting (bold/italic/strike/code) + an **Ask AI** entry that opens a Radix Popover anchored to the selection.
- Browser-side SSE consumer for the AI edit endpoint (ASK-215) with Clerk JWT injection, AbortController, and proper frame parsing for `delta`/`usage`/`error`/`done`.
- ProseMirror Decoration plugin paints the "you're editing this text" highlight so it tracks the document on scroll, edits, and resize — no rect math, no window-event listeners.
- Recent-prompts dropdown (last 5, localStorage) and Esc / outside-click cancel.

## Out of scope
The diff overlay (per-hunk accept/reject) is ASK-217. The popover currently shows the streamed replacement read-only; ASK-217 will replace that handoff.

## Test plan
- [x] Unit tests for the SSE hook (18 cases — delta accumulation, auth header, error events, HTTP 4xx, cancel, EOF without `done`, heartbeats, reset)
- [x] Unit tests for `recent-prompts` (cap, dedupe, corrupt-storage recovery)
- [x] `tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] Storybook stories for the bubble menu + every popover state (idle / streaming / done / error)
- [ ] Manual e2e on staging once deployed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI-assisted editing for study guides with an "Ask AI" button in the editor.
  * Visual highlights indicate currently edited text ranges with streaming status indicators.
  * Recent AI prompts are saved and available for quick access via dropdown menu.
  * Preview panel displays AI-suggested text changes before applying edits.

* **Tests**
  * Added comprehensive test coverage for AI streaming functionality and recent prompt management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->