### PR TITLE
feat(web): preset edit actions in Ask AI popover (ASK-218)

### DIFF
--- a/web/lib/features/dashboard/study-guides/ai/presets.test.ts
+++ b/web/lib/features/dashboard/study-guides/ai/presets.test.ts
@@ -1,0 +1,84 @@
+import { AI_EDIT_PRESETS, findPreset, isPresetEligible } from "./presets";
+
+describe("AI_EDIT_PRESETS", () => {
+  it("ships the six chips the ticket calls out", () => {
+    const ids = AI_EDIT_PRESETS.map((p) => p.id).sort();
+    expect(ids).toEqual(
+      [
+        "add-example",
+        "clearer",
+        "exam-audience",
+        "reorganize",
+        "shorten",
+        "tldr",
+      ].sort(),
+    );
+  });
+
+  it("preset ids are unique", () => {
+    const ids = AI_EDIT_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every preset has a non-empty instruction", () => {
+    for (const p of AI_EDIT_PRESETS) {
+      expect(p.instruction.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("isPresetEligible", () => {
+  it("multi-paragraph presets are disabled on single-block selections", () => {
+    const reorganize = findPreset("reorganize")!;
+    expect(
+      isPresetEligible(reorganize, { selectionSpansMultipleBlocks: false }),
+    ).toBe(false);
+    expect(
+      isPresetEligible(reorganize, { selectionSpansMultipleBlocks: true }),
+    ).toBe(true);
+  });
+
+  it("always-eligible presets are enabled regardless of selection shape", () => {
+    const shorten = findPreset("shorten")!;
+    expect(
+      isPresetEligible(shorten, { selectionSpansMultipleBlocks: false }),
+    ).toBe(true);
+    expect(
+      isPresetEligible(shorten, { selectionSpansMultipleBlocks: true }),
+    ).toBe(true);
+  });
+});
+
+describe("TL;DR transformReplacement", () => {
+  it("prepends a TL;DR blockquote to the original", () => {
+    const tldr = findPreset("tldr")!;
+    expect(tldr.transformReplacement).toBeDefined();
+    const out = tldr.transformReplacement!(
+      "BSTs keep keys ordered for fast lookup.",
+      "A binary search tree (BST) is an ordered tree...",
+    );
+    expect(out).toBe(
+      "> TL;DR: BSTs keep keys ordered for fast lookup.\n\nA binary search tree (BST) is an ordered tree...",
+    );
+  });
+
+  it("trims whitespace from the AI response", () => {
+    const tldr = findPreset("tldr")!;
+    const out = tldr.transformReplacement!(
+      "  Sloppy whitespace.  \n",
+      "Body text.",
+    );
+    expect(out.startsWith("> TL;DR: Sloppy whitespace.")).toBe(true);
+    expect(out).toContain("\n\nBody text.");
+  });
+});
+
+describe("findPreset", () => {
+  it("returns undefined for unknown ids", () => {
+    expect(findPreset("does-not-exist")).toBeUndefined();
+  });
+
+  it("returns the matching preset for known ids", () => {
+    expect(findPreset("tldr")?.id).toBe("tldr");
+  });
+});

--- a/web/lib/features/dashboard/study-guides/ai/presets.ts
+++ b/web/lib/features/dashboard/study-guides/ai/presets.ts
@@ -1,0 +1,103 @@
+/**
+ * Preset edit actions surfaced as chips in the Ask AI popover
+ * (ASK-218). Each preset is a canned `instruction` string the
+ * existing AI edit endpoint already understands -- no backend work.
+ *
+ * Tuning lives here: change a label or a prompt and the chip row
+ * picks it up on next mount. Keep instructions short + imperative;
+ * the edit endpoint's system prompt already establishes the
+ * "rewrite only the selection, preserve markdown" contract.
+ */
+
+export type PresetEligibility = "always" | "multi-paragraph";
+
+export interface AiEditPreset {
+  /** Stable identifier; shipped with future analytics events. */
+  id: string;
+  /** Short button label. */
+  label: string;
+  /** Sent to the AI edit endpoint as `instruction`. */
+  instruction: string;
+  /**
+   * When the chip is enabled. `multi-paragraph` chips disable
+   * themselves on single-block selections per the ticket spec
+   * ("Reorganize disabled on single-paragraph selections").
+   */
+  eligibility: PresetEligibility;
+  /**
+   * Optional client-side post-processing applied to the AI's
+   * replacement BEFORE seeding the diff overlay. TL;DR uses this
+   * to prepend the summary to the original selection rather than
+   * replacing it outright (per ticket spec).
+   */
+  transformReplacement?: (aiResponse: string, originalText: string) => string;
+}
+
+export const AI_EDIT_PRESETS: ReadonlyArray<AiEditPreset> = [
+  {
+    id: "tldr",
+    label: "TL;DR",
+    instruction:
+      "Write a concise TL;DR summary of the selected text. Output ONLY the summary -- no preface, no markdown headers. 1-3 sentences max.",
+    eligibility: "always",
+    transformReplacement: (aiResponse, original) =>
+      `> TL;DR: ${aiResponse.trim()}\n\n${original}`,
+  },
+  {
+    id: "clearer",
+    label: "Make clearer",
+    instruction:
+      "Rewrite the selected text to be clearer and easier to follow. Preserve meaning and markdown formatting.",
+    eligibility: "always",
+  },
+  {
+    id: "shorten",
+    label: "Shorten",
+    instruction:
+      "Shorten the selected text by trimming redundant phrasing. Preserve meaning and markdown formatting.",
+    eligibility: "always",
+  },
+  {
+    id: "add-example",
+    label: "Add an example",
+    instruction:
+      "Add a single concrete example that illustrates the selected text. Keep the original text intact and append the example after it.",
+    eligibility: "always",
+  },
+  {
+    id: "reorganize",
+    label: "Reorganize",
+    instruction:
+      "Reorganize the selected text into a more logical order. Preserve all content and markdown structure.",
+    eligibility: "multi-paragraph",
+  },
+  {
+    id: "exam-audience",
+    label: "For exam",
+    instruction:
+      "Rewrite the selected text in a study-friendly tone for an exam audience. Use active voice, define jargon inline, and keep the markdown structure.",
+    eligibility: "always",
+  },
+];
+
+/**
+ * Returns whether a preset's chip should be enabled given the
+ * current selection. Stays a pure function so tests don't need a
+ * real ProseMirror editor.
+ */
+export function isPresetEligible(
+  preset: AiEditPreset,
+  ctx: { selectionSpansMultipleBlocks: boolean },
+): boolean {
+  if (preset.eligibility === "multi-paragraph") {
+    return ctx.selectionSpansMultipleBlocks;
+  }
+  return true;
+}
+
+/**
+ * Look up a preset by id. Returns undefined for typos / removed ids.
+ */
+export function findPreset(id: string): AiEditPreset | undefined {
+  return AI_EDIT_PRESETS.find((p) => p.id === id);
+}

--- a/web/lib/features/dashboard/study-guides/wysiwyg/ask-ai-popover.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/ask-ai-popover.tsx
@@ -21,6 +21,11 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
 import {
+  AI_EDIT_PRESETS,
+  isPresetEligible,
+  type AiEditPreset,
+} from "../ai/presets";
+import {
   addRecentPrompt,
   getRecentPrompts,
   RECENT_PROMPTS_LIMIT,
@@ -34,10 +39,21 @@ interface AskAiPopoverProps {
   status: AiEditStreamStatus;
   replacement: string;
   error: AiEditStreamError | null;
-  /** Submit triggers the SSE call. Caller owns selection capture. */
-  onSubmit: (instruction: string) => void;
+  /**
+   * Submit triggers the SSE call. Caller owns selection capture.
+   * `presetId` is supplied when the user clicked a preset chip; the
+   * bubble menu uses it to apply any preset-specific transform to
+   * the model's reply (TL;DR, etc.) before seeding the diff overlay.
+   */
+  onSubmit: (instruction: string, presetId?: string) => void;
   /** Cancels in-flight request and closes the popover. */
   onCancel: () => void;
+  /**
+   * Whether the captured selection spans more than one block. Drives
+   * the disabled state of multi-paragraph-only presets ("Reorganize"
+   * per the ticket spec).
+   */
+  selectionSpansMultipleBlocks?: boolean;
 }
 
 /**
@@ -50,11 +66,11 @@ interface AskAiPopoverProps {
  *   - Esc cancels (caller closes the popover).
  *   - Submit fires `onSubmit(instruction)` and persists the prompt
  *     to localStorage so the recents dropdown reflects it next open.
- *   - While `status === "streaming"`, show a loading affordance and
- *     a live-streamed preview of the replacement so the user sees
- *     the model is working. ASK-217 will replace this preview block
- *     with the diff overlay; this component intentionally does NOT
- *     write the replacement back into the editor.
+ *   - Preset chips above the input fire `onSubmit(instruction, id)`
+ *     with the canned instruction and don't get persisted to recents
+ *     (presets aren't user-authored).
+ *   - Once the stream is done the bubble menu swaps this body for
+ *     the diff overlay (ASK-217); we never write back into the doc.
  */
 export function AskAiPopover({
   status,
@@ -62,6 +78,7 @@ export function AskAiPopover({
   error,
   onSubmit,
   onCancel,
+  selectionSpansMultipleBlocks = false,
 }: AskAiPopoverProps) {
   const [instruction, setInstruction] = useState("");
   // Lazy initializer reads localStorage once on mount. SSR-safe via
@@ -91,6 +108,11 @@ export function AskAiPopover({
     onSubmit(trimmed);
   };
 
+  const handlePreset = (preset: AiEditPreset) => {
+    if (isStreaming) return;
+    onSubmit(preset.instruction, preset.id);
+  };
+
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Escape") {
       event.preventDefault();
@@ -101,6 +123,11 @@ export function AskAiPopover({
 
   return (
     <div className="flex w-80 flex-col gap-3" role="group" aria-label="Ask AI">
+      <PresetChipRow
+        disabled={isStreaming}
+        selectionSpansMultipleBlocks={selectionSpansMultipleBlocks}
+        onPick={handlePreset}
+      />
       <form onSubmit={handleSubmit} className="flex flex-col gap-2">
         <div className="flex items-center gap-2">
           <Input
@@ -167,6 +194,54 @@ export function AskAiPopover({
           {error.message}
         </p>
       ) : null}
+    </div>
+  );
+}
+
+interface PresetChipRowProps {
+  disabled: boolean;
+  selectionSpansMultipleBlocks: boolean;
+  onPick: (preset: AiEditPreset) => void;
+}
+
+function PresetChipRow({
+  disabled,
+  selectionSpansMultipleBlocks,
+  onPick,
+}: PresetChipRowProps) {
+  return (
+    <div
+      className="flex flex-wrap gap-1"
+      role="group"
+      aria-label="Quick edit actions"
+    >
+      {AI_EDIT_PRESETS.map((preset) => {
+        const eligible = isPresetEligible(preset, {
+          selectionSpansMultipleBlocks,
+        });
+        const isDisabled = disabled || !eligible;
+        const tooltip = !eligible
+          ? "Select more than one paragraph to enable"
+          : undefined;
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onPick(preset)}
+            disabled={isDisabled}
+            title={tooltip}
+            aria-label={preset.label}
+            className={cn(
+              "border-border bg-background text-foreground rounded-full border px-2.5 py-1 text-[11px] font-medium leading-none transition-colors",
+              "hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+              "disabled:cursor-not-allowed disabled:opacity-40",
+            )}
+            data-preset-id={preset.id}
+          >
+            {preset.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.stories.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.stories.tsx
@@ -82,12 +82,12 @@ export const WithAskAI: Story = {
 };
 
 export const PopoverIdle: Story = {
-  name: "Popover · idle",
+  name: "Popover · idle (single-paragraph selection)",
   parameters: {
     docs: {
       description: {
         story:
-          "Standalone view of the AskAiPopover body in its initial state, before the user submits a prompt. The recent-prompts dropdown only renders when there's localStorage history.",
+          "AskAiPopover in its initial state. Single-paragraph selection -- the **Reorganize** chip is disabled per ASK-218 (it only enables on multi-paragraph selections).",
       },
     },
   },
@@ -97,7 +97,37 @@ export const PopoverIdle: Story = {
         status="idle"
         replacement=""
         error={null}
-        onSubmit={() => undefined}
+        onSubmit={(instruction, presetId) =>
+          // eslint-disable-next-line no-console -- storybook demo
+          console.log("submit", { instruction, presetId })
+        }
+        onCancel={() => undefined}
+      />
+    </div>
+  ),
+};
+
+export const PopoverIdleMultiParagraph: Story = {
+  name: "Popover · idle (multi-paragraph selection)",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Same popover with `selectionSpansMultipleBlocks={true}` -- the **Reorganize** preset is now enabled. Open the browser console to see the (instruction, presetId) tuple each chip submits.",
+      },
+    },
+  },
+  render: () => (
+    <div className="bg-popover w-fit rounded-md border p-3 shadow-md">
+      <AskAiPopover
+        status="idle"
+        replacement=""
+        error={null}
+        selectionSpansMultipleBlocks
+        onSubmit={(instruction, presetId) =>
+          // eslint-disable-next-line no-console -- storybook demo
+          console.log("submit", { instruction, presetId })
+        }
         onCancel={() => undefined}
       />
     </div>

--- a/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.tsx
+++ b/web/lib/features/dashboard/study-guides/wysiwyg/editor-bubble-menu.tsx
@@ -24,6 +24,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
+import { findPreset } from "../ai/presets";
 import { AiDiffOverlayUi } from "./ai-diff-overlay-ui";
 import { aiDiffPluginKey } from "./ai-diff-overlay";
 import {
@@ -70,6 +71,7 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
     from: number;
     to: number;
     text: string;
+    spansMultipleBlocks: boolean;
   } | null>(null);
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
   const [inDiffReview, setInDiffReview] = useState(false);
@@ -79,6 +81,11 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
   // Avoid double-firing the seed effect if React re-runs the effect
   // for a transient reason after a successful seed.
   const diffSeededRef = useRef(false);
+  // Tracks the preset id of the chip that kicked off this stream
+  // (null for free-form prompts). Read in the seed effect so the
+  // preset's transformReplacement (e.g. TL;DR's prepend) can run
+  // before the diff overlay is seeded.
+  const activePresetIdRef = useRef<string | null>(null);
 
   const stream = useAiEditStream({ guideId: aiEdit?.guideId ?? "" });
   const { status, replacement, error, editId, start, cancel, reset } = stream;
@@ -131,7 +138,13 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
     if (!captured) return;
     diffSeededRef.current = false;
     editIdRef.current = null;
-    setTarget(captured);
+    activePresetIdRef.current = null;
+    setTarget({
+      from: captured.from,
+      to: captured.to,
+      text: captured.text,
+      spansMultipleBlocks: captured.spansMultipleBlocks,
+    });
     setAnchorRect(captured.rect);
     setHighlight({ from: captured.from, to: captured.to, status: "idle" });
     setInDiffReview(false);
@@ -149,6 +162,7 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
     }
     diffSeededRef.current = false;
     editIdRef.current = null;
+    activePresetIdRef.current = null;
     setInDiffReview(false);
     setAskOpen(false);
     setTarget(null);
@@ -157,7 +171,7 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
     reset();
   }, [cancel, reset, setHighlight, editor]);
 
-  const handleSubmit = (instruction: string) => {
+  const handleSubmit = (instruction: string, presetId?: string) => {
     if (!aiEdit || !target) return;
     const live = aiSelectionPluginKey.getState(editor.state);
     const from = live?.from ?? target.from;
@@ -167,6 +181,7 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
         ? editor.state.doc.textBetween(from, to, "\n", "\n")
         : target.text;
     const docContext = buildDocContext(editor, { from, to }, aiEdit.title);
+    activePresetIdRef.current = presetId ?? null;
     void start({
       selectionText: text,
       selectionStart: from,
@@ -212,10 +227,23 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
         ? editor.state.doc.textBetween(from, to, "\n", "\n")
         : target.text;
     editIdRef.current = editId;
+    // Apply any preset-specific client-side transform BEFORE seeding
+    // the diff. TL;DR uses this to wrap the model's reply as a
+    // blockquote prepended to the original instead of replacing it.
+    const presetId = activePresetIdRef.current;
+    const preset = presetId ? findPreset(presetId) : undefined;
+    const finalReplacement =
+      preset?.transformReplacement?.(replacement, originalText) ?? replacement;
     const ok = editor
       .chain()
       .focus()
-      .seedAiDiff({ editId, originalText, replacement, from, to })
+      .seedAiDiff({
+        editId,
+        originalText,
+        replacement: finalReplacement,
+        from,
+        to,
+      })
       .run();
     if (ok) {
       setHighlight(null);
@@ -370,6 +398,9 @@ export function EditorBubbleMenu({ editor, aiEdit }: EditorBubbleMenuProps) {
                 error={error}
                 onSubmit={handleSubmit}
                 onCancel={closeAsk}
+                selectionSpansMultipleBlocks={
+                  target?.spansMultipleBlocks ?? false
+                }
               />
             )}
           </PopoverContent>
@@ -454,6 +485,14 @@ interface CapturedSelection {
   to: number;
   text: string;
   rect: DOMRect;
+  /**
+   * Whether the selection straddles a block boundary (paragraph,
+   * heading, list item, etc.). Drives multi-paragraph-only preset
+   * eligibility (ASK-218 "Reorganize"). `textBetween` emits "\n" at
+   * each block boundary so a newline in the captured text means we
+   * spanned more than one block.
+   */
+  spansMultipleBlocks: boolean;
 }
 
 function captureSelection(editor: Editor): CapturedSelection | null {
@@ -468,7 +507,7 @@ function captureSelection(editor: Editor): CapturedSelection | null {
   } catch {
     return null;
   }
-  return { from, to, text, rect };
+  return { from, to, text, rect, spansMultipleBlocks: text.includes("\n") };
 }
 
 function buildDocContext(


### PR DESCRIPTION
Closes ASK-218.

## Summary
Six one-click chips above the Ask AI prompt input that submit canned instructions — no backend work needed. Picks up the diff overlay (ASK-217) and PATCH flow for free.

| Chip | Eligibility | Special |
|---|---|---|
| TL;DR | always | wraps reply as \`> TL;DR: ...\` blockquote prepended to the original |
| Make clearer | always | — |
| Shorten | always | — |
| Add an example | always | — |
| Reorganize | multi-paragraph only | disabled on single-block selections |
| For exam | always | — |

## Implementation
- \`web/lib/features/dashboard/study-guides/ai/presets.ts\` — single source of truth (id / label / instruction / eligibility / optional \`transformReplacement\`).
- AskAiPopover renders the chip row + handles preset click → \`onSubmit(instruction, presetId)\`.
- editor-bubble-menu tracks active preset in a ref, plumbs \`spansMultipleBlocks\` (from \`textBetween\`'s \`\\n\` output) for eligibility, applies \`transformReplacement\` to the model reply before \`seedAiDiff\`.
- Storybook gets a "multi-paragraph" idle variant.

## Test plan
- [x] 9 unit tests (preset shape, eligibility predicate, TL;DR formatting + whitespace trim, findPreset)
- [x] tsc --noEmit clean
- [x] pnpm lint clean
- [x] prettier --check clean
- [x] npx jest: 281 pass / 2 pre-existing failures
- [ ] Manual e2e on staging once deployed

## Out of scope
Analytics for \`preset_id\`: the ticket asks for it on \`feature: "edit"\` events, but no analytics pipe exists yet. \`presetId\` is plumbed through \`handleSubmit\` ready for a follow-up ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preset-driven quick edit options for Ask AI with six editing presets: TL;DR, Make clearer, Shorten, Add an example, Reorganize, and For exam.
  * Presets intelligently enable/disable based on text selection type (e.g., Reorganize only works with multi-paragraph selections).
  * Automatic formatting transformations for specific presets (e.g., TL;DR wraps summary in blockquote).

* **Tests**
  * Added comprehensive test coverage for preset functionality and eligibility logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->