### PR TITLE
feat(web): wire up my study guides page

### DIFF
--- a/web/app/(dashboard)/me/study-guides/page.test.tsx
+++ b/web/app/(dashboard)/me/study-guides/page.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Acceptance tests for the "My Study Guides" page.
+ *
+ * Server Components return a Promise<ReactElement>; we await the page
+ * function directly and feed the resolved JSX into RTL `render`. The
+ * `@/lib/api` server actions are mocked at the module level so the
+ * test owns every API response.
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import type { ListMyStudyGuidesResponse } from "@/lib/api/types";
+
+import MyStudyGuidesPage from "./page";
+
+jest.mock("../../../../lib/api", () => ({
+  listMyStudyGuides: jest.fn(),
+}));
+
+import { listMyStudyGuides } from "../../../../lib/api";
+
+const listMyStudyGuidesMock = listMyStudyGuides as jest.MockedFunction<
+  typeof listMyStudyGuides
+>;
+
+type MyGuide = ListMyStudyGuidesResponse["study_guides"][number];
+
+function makeGuide(overrides: Partial<MyGuide> = {}): MyGuide {
+  return {
+    id: "g_1",
+    title: "Linear Algebra Cheat Sheet",
+    description: "Eigenvalues, determinants, and the SVD.",
+    tags: ["math"],
+    creator: { id: "u_1", first_name: "Ada", last_name: "Lovelace" },
+    course_id: "c_1",
+    vote_score: 12,
+    view_count: 0,
+    is_recommended: false,
+    quiz_count: 3,
+    created_at: "2026-04-20T10:00:00Z",
+    updated_at: "2026-04-20T10:00:00Z",
+    deleted_at: null,
+    visibility: "private",
+    ...overrides,
+  };
+}
+
+function makeResponse(guides: MyGuide[] = []): ListMyStudyGuidesResponse {
+  return { study_guides: guides, next_cursor: null, has_more: false };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+async function renderPage() {
+  const ui = await MyStudyGuidesPage();
+  render(ui);
+}
+
+describe("MyStudyGuidesPage", () => {
+  it("renders the empty state when the caller has no guides", async () => {
+    listMyStudyGuidesMock.mockResolvedValue(makeResponse([]));
+
+    await renderPage();
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "My Study Guides" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No study guides yet")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /create one/i })).toHaveAttribute(
+      "href",
+      "/study-guides/new",
+    );
+  });
+
+  it("renders a card for each live guide", async () => {
+    listMyStudyGuidesMock.mockResolvedValue(
+      makeResponse([
+        makeGuide({ id: "g_a", title: "Algebra Notes" }),
+        makeGuide({ id: "g_b", title: "Calculus Outline" }),
+      ]),
+    );
+
+    await renderPage();
+
+    expect(screen.getByText("Algebra Notes")).toBeInTheDocument();
+    expect(screen.getByText("Calculus Outline")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("hides soft-deleted guides from the live list", async () => {
+    listMyStudyGuidesMock.mockResolvedValue(
+      makeResponse([
+        makeGuide({ id: "g_live", title: "Live Guide" }),
+        makeGuide({
+          id: "g_dead",
+          title: "Deleted Guide",
+          deleted_at: "2026-04-21T10:00:00Z",
+        }),
+      ]),
+    );
+
+    await renderPage();
+
+    expect(screen.getByText("Live Guide")).toBeInTheDocument();
+    expect(screen.queryByText("Deleted Guide")).not.toBeInTheDocument();
+  });
+});

--- a/web/app/(dashboard)/me/study-guides/page.tsx
+++ b/web/app/(dashboard)/me/study-guides/page.tsx
@@ -1,15 +1,89 @@
-export default function MyStudyGuidesPage() {
+import { BookOpen, Plus } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { listMyStudyGuides } from "@/lib/api";
+import type { ListMyStudyGuidesResponse } from "@/lib/api/types";
+import {
+  StudyGuideCard,
+  type StudyGuideListItemResponse as StudyGuideCardListItem,
+} from "@/lib/features/dashboard/study-guides/study-guide-card";
+
+type MyStudyGuide = ListMyStudyGuidesResponse["study_guides"][number];
+
+export default async function MyStudyGuidesPage() {
+  const res = await listMyStudyGuides();
+  // The endpoint includes soft-deleted guides for future restore UX (ASK-131);
+  // until that lands, hide them from the live list.
+  const guides = res.study_guides.filter((g) => g.deleted_at === null);
+
   return (
-    <section className="space-y-4">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          My Study Guides
-        </h1>
-        <p className="text-muted-foreground text-sm">
-          Access and manage the study guides you have created.
-        </p>
+    <section className="mx-auto flex w-full max-w-[1184px] flex-col gap-6 px-10 py-8">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-3">
+            <h1 className="text-foreground text-[22px] font-semibold leading-tight tracking-[-0.4px]">
+              My Study Guides
+            </h1>
+            <span className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 font-mono text-[12px] font-semibold">
+              {guides.length}
+            </span>
+          </div>
+          <p className="text-muted-foreground text-[13px]">
+            Access and manage the study guides you have created.
+          </p>
+        </div>
+        <Button asChild className="h-9">
+          <Link href="/study-guides/new">
+            <Plus className="size-4" aria-hidden={true} />
+            New guide
+          </Link>
+        </Button>
       </header>
-      <div className="bg-muted/50 min-h-[60vh] rounded-xl" />
+
+      {guides.length === 0 ? (
+        <EmptyState
+          icon={<BookOpen className="size-8" aria-hidden={true} />}
+          title="No study guides yet"
+          body="Start your first study guide to capture notes, outlines, or cheat sheets."
+          action={
+            <Button asChild>
+              <Link href="/study-guides/new">Create one</Link>
+            </Button>
+          }
+          className="border-border bg-muted/30 rounded-[10px] border py-14"
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {guides.map((guide) => (
+            <StudyGuideCard
+              key={guide.id}
+              guide={toCardItem(guide)}
+              variant="list"
+            />
+          ))}
+        </div>
+      )}
     </section>
   );
+}
+
+function toCardItem(guide: MyStudyGuide): StudyGuideCardListItem {
+  const displayName =
+    `${guide.creator.first_name} ${guide.creator.last_name}`.trim() ||
+    "Unknown author";
+  return {
+    id: guide.id,
+    title: guide.title,
+    description: guide.description,
+    creator: { display_name: displayName },
+    vote_score: guide.vote_score,
+    quiz_count: guide.quiz_count,
+    is_recommended: guide.is_recommended,
+    tags: guide.tags,
+    course_id: guide.course_id,
+    visibility: guide.visibility,
+    updated_at: guide.updated_at,
+  };
 }


### PR DESCRIPTION
## Summary
- Replaces the static stub at `/me/study-guides` with a Server Component that fetches via `listMyStudyGuides()` and renders a `StudyGuideCard` grid.
- Filters soft-deleted guides from the live list (the restore UX is not built yet); they remain available on the wire for future ASK-131 follow-up.
- Mirrors the `courses/[courseId]` page pattern: header with count badge + "New guide" CTA, `EmptyState` fallback, responsive 1/2/3-column grid.
- Adds three Jest tests (empty state, populated grid, soft-deleted filtering) following the same Server Component test pattern as `courses/[courseId]/page.test.tsx`.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm jest me/study-guides/page.test` — 3/3 passing
- [ ] Manual: navigate to `/me/study-guides` as a user with zero guides → empty state
- [ ] Manual: navigate as a user with multiple guides → grid renders, count badge matches, "New guide" CTA links to `/study-guides/new`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "My Study Guides" page now displays your study guides in a responsive grid format.
  * Shows the total count of active study guides.
  * Displays an empty state with a "New guide" option when you have no study guides yet.
  * Automatically filters out deleted guides from your view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->