### PR TITLE
feat(web): wire practice page to live session API (ASK-192)

### DIFF
--- a/web/app/practice/page.test.tsx
+++ b/web/app/practice/page.test.tsx
@@ -1,0 +1,295 @@
+/**
+ * Tests for the practice page wire-up (ASK-192).
+ *
+ * The page is a client component; we exercise it with RTL through the
+ * full session lifecycle (start -> submit -> complete) and the empty /
+ * missing-quiz states. `next/navigation` and `@/lib/api` are mocked at
+ * the module level so the test owns every API + routing call.
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import type {
+  CompletedSessionResponse,
+  PracticeAnswerResponse,
+  PracticeSessionResponse,
+  QuizDetailResponse,
+} from "@/lib/api/types";
+
+const pushMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(),
+  useRouter: () => ({ push: pushMock, replace: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock("../../lib/api", () => ({
+  getQuiz: jest.fn(),
+  startPracticeSession: jest.fn(),
+  submitPracticeAnswer: jest.fn(),
+  completePracticeSession: jest.fn(),
+  abandonPracticeSession: jest.fn(),
+}));
+
+jest.mock("../../lib/features/shared/toast/toast", () => ({
+  toast: { error: jest.fn(), success: jest.fn(), info: jest.fn() },
+}));
+
+import { useSearchParams } from "next/navigation";
+
+import {
+  abandonPracticeSession,
+  completePracticeSession,
+  getQuiz,
+  startPracticeSession,
+  submitPracticeAnswer,
+} from "../../lib/api";
+
+import PracticePage from "./page";
+
+const useSearchParamsMock = useSearchParams as jest.MockedFunction<
+  typeof useSearchParams
+>;
+const getQuizMock = getQuiz as jest.MockedFunction<typeof getQuiz>;
+const startMock = startPracticeSession as jest.MockedFunction<
+  typeof startPracticeSession
+>;
+const submitMock = submitPracticeAnswer as jest.MockedFunction<
+  typeof submitPracticeAnswer
+>;
+const completeMock = completePracticeSession as jest.MockedFunction<
+  typeof completePracticeSession
+>;
+const abandonMock = abandonPracticeSession as jest.MockedFunction<
+  typeof abandonPracticeSession
+>;
+
+function setQuizQuery(quizId: string | null) {
+  useSearchParamsMock.mockReturnValue({
+    get: (key: string) => (key === "quiz" ? quizId : null),
+  } as unknown as ReturnType<typeof useSearchParams>);
+}
+
+function makeQuiz(
+  overrides: Partial<QuizDetailResponse> = {},
+): QuizDetailResponse {
+  return {
+    id: "q_1",
+    study_guide_id: "sg_1",
+    title: "Spring Quiz",
+    description: "A short quiz.",
+    creator: { id: "u_1", first_name: "Ada", last_name: "Lovelace" },
+    questions: [
+      {
+        id: "qid_1",
+        type: "multiple-choice",
+        question: "Capital of France?",
+        options: ["London", "Paris", "Berlin"],
+        correct_answer: "Paris",
+        hint: "Eiffel Tower lives there.",
+        feedback: { correct: "Nice!", incorrect: "It's Paris." },
+        sort_order: 1,
+      },
+      {
+        id: "qid_2",
+        type: "true-false",
+        question: "The sky is green.",
+        correct_answer: false,
+        hint: null,
+        feedback: { correct: "Right.", incorrect: "It's blue." },
+        sort_order: 2,
+      },
+    ],
+    created_at: "2026-04-20T10:00:00Z",
+    updated_at: "2026-04-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeSession(
+  overrides: Partial<PracticeSessionResponse> = {},
+): PracticeSessionResponse {
+  return {
+    id: "s_1",
+    quiz_id: "q_1",
+    started_at: "2026-04-27T10:00:00Z",
+    completed_at: null,
+    total_questions: 2,
+    correct_answers: 0,
+    answers: [],
+    ...overrides,
+  };
+}
+
+function makeAnswer(
+  overrides: Partial<PracticeAnswerResponse> = {},
+): PracticeAnswerResponse {
+  return {
+    question_id: "qid_1",
+    user_answer: "Paris",
+    is_correct: true,
+    verified: true,
+    answered_at: "2026-04-27T10:00:30Z",
+    ...overrides,
+  };
+}
+
+function makeCompleted(
+  overrides: Partial<CompletedSessionResponse> = {},
+): CompletedSessionResponse {
+  return {
+    id: "s_1",
+    quiz_id: "q_1",
+    started_at: "2026-04-27T10:00:00Z",
+    completed_at: "2026-04-27T10:05:00Z",
+    total_questions: 2,
+    correct_answers: 2,
+    score_percentage: 100,
+    ...overrides,
+  };
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("PracticePage (ASK-192)", () => {
+  it("shows the no-quiz nudge when ?quiz= is missing", () => {
+    setQuizQuery(null);
+
+    render(<PracticePage />);
+
+    expect(screen.getByText("Pick a quiz to practice")).toBeInTheDocument();
+    expect(getQuizMock).not.toHaveBeenCalled();
+    expect(startMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the empty-quiz state when the quiz has zero questions", async () => {
+    setQuizQuery("q_1");
+    getQuizMock.mockResolvedValue(makeQuiz({ questions: [] }));
+    startMock.mockResolvedValue(makeSession({ total_questions: 0 }));
+
+    render(<PracticePage />);
+    await flush();
+
+    expect(
+      screen.getByText("This quiz has no questions yet"),
+    ).toBeInTheDocument();
+  });
+
+  it("walks the full happy path: start -> submit -> complete", async () => {
+    setQuizQuery("q_1");
+    getQuizMock.mockResolvedValue(makeQuiz());
+    startMock.mockResolvedValue(makeSession());
+    submitMock.mockResolvedValueOnce(makeAnswer()).mockResolvedValueOnce(
+      makeAnswer({
+        question_id: "qid_2",
+        user_answer: "false",
+        is_correct: true,
+      }),
+    );
+    completeMock.mockResolvedValue(makeCompleted());
+
+    render(<PracticePage />);
+    await flush();
+
+    expect(screen.getByText("Capital of France?")).toBeInTheDocument();
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Paris" }));
+    fireEvent.click(screen.getByRole("button", { name: /submit answer/i }));
+    await flush();
+
+    expect(submitMock).toHaveBeenCalledWith("s_1", {
+      question_id: "qid_1",
+      user_answer: "Paris",
+    });
+    expect(screen.getByText("Correct!")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /next question/i }));
+    await flush();
+
+    expect(screen.getByText("The sky is green.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "False" }));
+    fireEvent.click(screen.getByRole("button", { name: /submit answer/i }));
+    await flush();
+
+    expect(submitMock).toHaveBeenLastCalledWith("s_1", {
+      question_id: "qid_2",
+      user_answer: "false",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /finish practice/i }));
+    await flush();
+
+    expect(completeMock).toHaveBeenCalledWith("s_1");
+    expect(screen.getByText("Practice Complete")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("resumes mid-session by jumping to the first unanswered question", async () => {
+    setQuizQuery("q_1");
+    getQuizMock.mockResolvedValue(makeQuiz());
+    startMock.mockResolvedValue(
+      makeSession({ correct_answers: 1, answers: [makeAnswer()] }),
+    );
+
+    render(<PracticePage />);
+    await flush();
+
+    // qid_1 is already answered; we should land on qid_2.
+    expect(screen.getByText("The sky is green.")).toBeInTheDocument();
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+  });
+
+  it("auto-completes when resuming a session with every answer already in", async () => {
+    setQuizQuery("q_1");
+    getQuizMock.mockResolvedValue(makeQuiz());
+    startMock.mockResolvedValue(
+      makeSession({
+        correct_answers: 2,
+        answers: [
+          makeAnswer(),
+          makeAnswer({
+            question_id: "qid_2",
+            user_answer: "false",
+            is_correct: true,
+          }),
+        ],
+      }),
+    );
+    completeMock.mockResolvedValue(makeCompleted());
+
+    render(<PracticePage />);
+    await flush();
+
+    expect(completeMock).toHaveBeenCalledWith("s_1");
+    expect(screen.getByText("Practice Complete")).toBeInTheDocument();
+  });
+
+  it("abandons the session when Leave is confirmed", async () => {
+    setQuizQuery("q_1");
+    getQuizMock.mockResolvedValue(makeQuiz());
+    startMock.mockResolvedValue(makeSession());
+    abandonMock.mockResolvedValue(undefined);
+
+    render(<PracticePage />);
+    await flush();
+
+    fireEvent.click(screen.getByRole("button", { name: /leave/i }));
+    const confirmButtons = screen.getAllByRole("button", { name: /^leave$/i });
+    // The dialog's confirm button is the last one rendered.
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+    await flush();
+
+    expect(abandonMock).toHaveBeenCalledWith("s_1");
+    expect(pushMock).toHaveBeenCalledWith("/home");
+  });
+});

--- a/web/app/practice/page.tsx
+++ b/web/app/practice/page.tsx
@@ -1,442 +1,583 @@
+/**
+ * Practice page wire-up (ASK-192).
+ *
+ * Reads `?quiz={id}`, fetches the quiz detail (for questions) and a
+ * practice session (created or resumed) in parallel, and walks the
+ * user through one question at a time. The server is the source of
+ * truth for `is_correct`; we display feedback from the submit
+ * response, never from a local string compare.
+ *
+ * Phases:
+ *   - `no-quiz`     no `?quiz=` query param; nudge to /study-guides
+ *   - `loading`     initial parallel fetch in flight
+ *   - `error`       fetch failed; allow retry
+ *   - `empty-quiz`  quiz has zero questions
+ *   - `playing`     answering questions
+ *   - `completed`   show ScoreScreen after completePracticeSession
+ *
+ * Resume: if the session already has answers, jump to the first
+ * unanswered question (by id). Already-submitted answers are kept in
+ * a `Map<questionId, PracticeAnswerResponse>` so revisiting a finished
+ * question would still render its outcome -- though the UX advances
+ * straight to the next unanswered slot on load.
+ */
 "use client";
 
-import { useState } from "react";
+import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  abandonPracticeSession,
+  completePracticeSession,
+  getQuiz,
+  startPracticeSession,
+  submitPracticeAnswer,
+} from "@/lib/api";
+import { ApiError } from "@/lib/api/errors";
+import type {
+  CompletedSessionResponse,
+  PracticeAnswerResponse,
+  PracticeSessionResponse,
+  QuizDetailResponse,
+  QuizQuestionResponse,
+} from "@/lib/api/types";
+import { ConfirmationDialog } from "@/lib/features/shared/confirmation-dialog";
+import { toast } from "@/lib/features/shared/toast/toast";
 import { cn } from "@/lib/utils";
 
-type QuestionType = "multiple-choice" | "true-false" | "freeform";
-
-interface Question {
-  id: string;
-  type: QuestionType;
-  question: string;
-  options?: string[];
-  correctAnswer: string | boolean;
-  hint: string;
-  feedback: {
-    correct: string;
-    incorrect: string;
-  };
-}
-
-interface StudyGuide {
-  id: string;
-  name: string;
-  topic: string;
-  questionCount: number;
-  questions: Question[];
-}
-
-const studyGuides: StudyGuide[] = [
-  {
-    id: "1",
-    name: "World Geography",
-    topic: "Geography",
-    questionCount: 3,
-    questions: [
-      {
-        id: "1",
-        type: "multiple-choice",
-        question: "What is the capital of France?",
-        options: ["London", "Paris", "Berlin", "Madrid"],
-        correctAnswer: "Paris",
-        hint: "Think of the Eiffel Tower!",
-        feedback: {
-          correct:
-            "Excellent! Paris is indeed the capital and largest city of France.",
-          incorrect:
-            "Not quite. Paris is the capital of France, famous for the Eiffel Tower and the Louvre.",
-        },
-      },
-      {
-        id: "2",
-        type: "freeform",
-        question: "What is the longest river in the world?",
-        correctAnswer: "Nile",
-        hint: "It flows through northeastern Africa.",
-        feedback: {
-          correct: "Perfect! The Nile River is approximately 6,650 km long.",
-          incorrect:
-            "The correct answer is the Nile River, which flows through northeastern Africa.",
-        },
-      },
-      {
-        id: "3",
-        type: "true-false",
-        question: "Mount Everest is located in Japan.",
-        correctAnswer: false,
-        hint: "It's in the Himalayas, on the border between Nepal and Tibet.",
-        feedback: {
-          correct:
-            "Correct! Mount Everest is on the Nepal-Tibet border, not in Japan.",
-          incorrect:
-            "Actually, Mount Everest is located on the border between Nepal and Tibet, not in Japan.",
-        },
-      },
-    ],
-  },
-  {
-    id: "2",
-    name: "Basic Science",
-    topic: "Science",
-    questionCount: 2,
-    questions: [
-      {
-        id: "4",
-        type: "true-false",
-        question: "The Earth is flat.",
-        correctAnswer: false,
-        hint: "Consider modern scientific evidence.",
-        feedback: {
-          correct: "Correct! The Earth is an oblate spheroid.",
-          incorrect: "The Earth is round, confirmed by scientific evidence.",
-        },
-      },
-      {
-        id: "5",
-        type: "multiple-choice",
-        question: "What is the chemical symbol for water?",
-        options: ["H2O", "CO2", "O2", "NaCl"],
-        correctAnswer: "H2O",
-        hint: "It's made of hydrogen and oxygen.",
-        feedback: {
-          correct: "Excellent! H2O represents two hydrogen and one oxygen.",
-          incorrect: "The correct answer is H2O.",
-        },
-      },
-    ],
-  },
-  {
-    id: "3",
-    name: "World History",
-    topic: "History",
-    questionCount: 2,
-    questions: [
-      {
-        id: "6",
-        type: "freeform",
-        question: "What year did World War II end?",
-        correctAnswer: "1945",
-        hint: "It ended in the mid-1940s.",
-        feedback: {
-          correct: "Perfect! World War II ended in 1945.",
-          incorrect: "World War II ended in 1945.",
-        },
-      },
-      {
-        id: "7",
-        type: "multiple-choice",
-        question: "Who was the first President of the United States?",
-        options: [
-          "Thomas Jefferson",
-          "George Washington",
-          "John Adams",
-          "Benjamin Franklin",
-        ],
-        correctAnswer: "George Washington",
-        hint: "He's on the one dollar bill.",
-        feedback: {
-          correct: "Correct! George Washington served from 1789-1797.",
-          incorrect: "George Washington was the first U.S. President.",
-        },
-      },
-    ],
-  },
-];
+type Phase =
+  | { kind: "no-quiz" }
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "empty-quiz"; quiz: QuizDetailResponse }
+  | {
+      kind: "playing";
+      quiz: QuizDetailResponse;
+      session: PracticeSessionResponse;
+      currentIndex: number;
+      answersByQuestionId: Map<string, PracticeAnswerResponse>;
+    }
+  | { kind: "completed"; result: CompletedSessionResponse };
 
 export default function PracticePage() {
-  const [selectedGuide, setSelectedGuide] = useState<StudyGuide | null>(null);
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-  const [userAnswer, setUserAnswer] = useState<string | null>(null);
-  const [showFeedback, setShowFeedback] = useState(false);
-  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
-  const [showHint, setShowHint] = useState(false);
+  // Next.js requires `useSearchParams` to live under a Suspense boundary
+  // so static-export can bail out cleanly when the URL is unknown at
+  // build time.
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <PracticePageInner />
+    </Suspense>
+  );
+}
 
-  // If a guide is selected, show the quiz
-  if (selectedGuide) {
-    const currentQuestion = selectedGuide.questions[currentQuestionIndex];
+function PracticePageInner() {
+  const params = useSearchParams();
+  const quizId = params.get("quiz");
 
-    const checkAnswer = () => {
-      if (!currentQuestion || !userAnswer) return;
+  const [phase, setPhase] = useState<Phase>(
+    quizId ? { kind: "loading" } : { kind: "no-quiz" },
+  );
 
-      const correct =
-        userAnswer.toLowerCase().trim() ===
-        currentQuestion.correctAnswer.toString().toLowerCase().trim();
-      setIsCorrect(correct);
-      setShowFeedback(true);
+  useEffect(() => {
+    if (!quizId) return;
+    let cancelled = false;
+
+    Promise.all([getQuiz(quizId), startPracticeSession(quizId)])
+      .then(async ([quiz, session]) => {
+        if (cancelled) return;
+        if (quiz.questions.length === 0) {
+          setPhase({ kind: "empty-quiz", quiz });
+          return;
+        }
+        const answersByQuestionId = answersByQuestionMap(session.answers);
+        const allAnswered = quiz.questions.every((q) =>
+          answersByQuestionId.has(q.id),
+        );
+        // A resumed session with every question already answered (or
+        // one the API returns with `completed_at` set) skips the
+        // player and finalizes immediately. Calling complete is
+        // idempotent on a finished session.
+        if (allAnswered || session.completed_at !== null) {
+          const result = await completePracticeSession(session.id);
+          if (cancelled) return;
+          setPhase({ kind: "completed", result });
+          return;
+        }
+        const startIndex = quiz.questions.findIndex(
+          (q) => !answersByQuestionId.has(q.id),
+        );
+        setPhase({
+          kind: "playing",
+          quiz,
+          session,
+          currentIndex: startIndex,
+          answersByQuestionId,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        toast.error(err);
+        setPhase({
+          kind: "error",
+          message:
+            err instanceof ApiError
+              ? `Couldn't start practice (${err.status}).`
+              : "Couldn't start practice.",
+        });
+      });
+
+    return () => {
+      cancelled = true;
     };
+  }, [quizId]);
 
-    const nextQuestion = () => {
-      if (currentQuestionIndex < selectedGuide.questions.length - 1) {
-        setCurrentQuestionIndex((prev) => prev + 1);
-        setUserAnswer(null);
-        setShowHint(false);
-        setShowFeedback(false);
-        setIsCorrect(null);
-      }
-    };
+  if (phase.kind === "no-quiz") return <NoQuizState />;
+  if (phase.kind === "loading") return <LoadingState />;
+  if (phase.kind === "error") return <ErrorState message={phase.message} />;
+  if (phase.kind === "empty-quiz") return <EmptyQuizState quiz={phase.quiz} />;
+  if (phase.kind === "completed") return <ScoreScreen result={phase.result} />;
 
-    return (
-      <div className="min-h-screen bg-black text-white">
-        {/* Header with Back Button */}
-        <div className="border-b border-white/10 bg-white/5">
-          <div className="max-w-7xl mx-auto px-6 py-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <Button
-                  onClick={() => {
-                    setSelectedGuide(null);
-                    setCurrentQuestionIndex(0);
-                    setUserAnswer(null);
-                    setShowHint(false);
-                    setShowFeedback(false);
-                  }}
-                  variant="ghost"
-                  size="sm"
-                  className="text-gray-400 hover:text-white"
-                >
-                  ← Back
-                </Button>
-                <div>
-                  <h2 className="font-semibold">{selectedGuide.name}</h2>
-                  <p className="text-sm text-gray-400">{selectedGuide.topic}</p>
-                </div>
-              </div>
-              <div>
-                <p className="text-sm text-gray-400">Progress</p>
-                <p className="text-lg font-semibold">
-                  {currentQuestionIndex + 1} / {selectedGuide.questions.length}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
+  return <Player phase={phase} setPhase={setPhase} />;
+}
 
-        <div className="max-w-4xl mx-auto px-6 py-12">
-          {currentQuestion ? (
-            <div className="bg-white/5 border border-white/10 rounded-xl p-8">
-              <Badge
-                className={cn(
-                  "mb-6",
-                  currentQuestion.type === "multiple-choice" &&
-                    "border-blue-500/50 text-blue-400",
-                  currentQuestion.type === "true-false" &&
-                    "border-green-500/50 text-green-400",
-                  currentQuestion.type === "freeform" &&
-                    "border-purple-500/50 text-purple-400",
-                )}
-                variant="outline"
-              >
-                {currentQuestion.type === "multiple-choice" &&
-                  "Multiple Choice"}
-                {currentQuestion.type === "true-false" && "True / False"}
-                {currentQuestion.type === "freeform" && "Free Response"}
-              </Badge>
-
-              <h3 className="text-xl font-semibold mb-6">
-                {currentQuestion.question}
-              </h3>
-
-              {/* Multiple Choice */}
-              {currentQuestion.type === "multiple-choice" &&
-                currentQuestion.options && (
-                  <div className="space-y-3 mb-6">
-                    {currentQuestion.options.map((option, index) => (
-                      <button
-                        key={index}
-                        onClick={() => setUserAnswer(option)}
-                        disabled={showFeedback}
-                        className={`w-full text-left p-4 rounded-xl border-2 transition-all duration-200 ${
-                          userAnswer === option
-                            ? "border-orange-500 bg-orange-500/10"
-                            : "border-white/10 hover:border-orange-500/50 hover:bg-orange-500/5"
-                        }`}
-                      >
-                        {option}
-                      </button>
-                    ))}
-                  </div>
-                )}
-
-              {/* True/False */}
-              {currentQuestion.type === "true-false" && (
-                <div className="grid grid-cols-2 gap-4 mb-6">
-                  {["True", "False"].map((option) => (
-                    <button
-                      key={option}
-                      onClick={() => setUserAnswer(option)}
-                      disabled={showFeedback}
-                      className={`p-6 rounded-xl border-2 transition-all duration-200 font-semibold text-lg ${
-                        userAnswer === option
-                          ? "border-orange-500 bg-orange-500/10"
-                          : "border-white/10 hover:border-orange-500/50 hover:bg-orange-500/5"
-                      }`}
-                    >
-                      {option}
-                    </button>
-                  ))}
-                </div>
-              )}
-
-              {/* Freeform */}
-              {currentQuestion.type === "freeform" && (
-                <div className="mb-6">
-                  <Input
-                    type="text"
-                    placeholder="Type your answer here..."
-                    value={userAnswer || ""}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      setUserAnswer(e.target.value)
-                    }
-                    disabled={showFeedback}
-                    className="w-full p-4 text-lg bg-white/5 border-2 border-white/10 rounded-xl focus:border-orange-500"
-                  />
-                </div>
-              )}
-
-              {!showFeedback && (
-                <div className="mb-6">
-                  <Button
-                    onClick={() => setShowHint(!showHint)}
-                    variant="outline"
-                    size="sm"
-                    className="border-yellow-500/30 text-yellow-500 hover:bg-yellow-500/10"
-                  >
-                    {showHint ? "Hide Hint" : "💡 Show Hint"}
-                  </Button>
-
-                  {showHint && (
-                    <div className="mt-4 p-4 bg-yellow-500/5 border border-yellow-500/20 rounded-lg">
-                      <p className="text-sm text-yellow-200">
-                        {currentQuestion.hint}
-                      </p>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {!showFeedback ? (
-                <Button
-                  onClick={checkAnswer}
-                  disabled={!userAnswer}
-                  className="w-full bg-orange-500 hover:bg-orange-600 text-white"
-                >
-                  Submit Answer
-                </Button>
-              ) : (
-                <>
-                  <div
-                    className={`mb-6 p-6 rounded-xl border-2 ${
-                      isCorrect
-                        ? "bg-green-500/10 border-green-500/50"
-                        : "bg-red-500/10 border-red-500/50"
-                    }`}
-                  >
-                    <div className="flex items-start gap-4">
-                      <div className="text-3xl">{isCorrect ? "🎉" : "📚"}</div>
-                      <div>
-                        <h3
-                          className={`text-lg font-semibold mb-2 ${
-                            isCorrect ? "text-green-400" : "text-red-400"
-                          }`}
-                        >
-                          {isCorrect ? "Correct!" : "Not quite"}
-                        </h3>
-                        <p className="text-gray-300">
-                          {isCorrect
-                            ? currentQuestion.feedback.correct
-                            : currentQuestion.feedback.incorrect}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-
-                  {currentQuestionIndex < selectedGuide.questions.length - 1 ? (
-                    <Button
-                      onClick={nextQuestion}
-                      className="w-full bg-orange-500 hover:bg-orange-600 text-white"
-                    >
-                      Next Question →
-                    </Button>
-                  ) : (
-                    <Button
-                      onClick={() => {
-                        setSelectedGuide(null);
-                        setCurrentQuestionIndex(0);
-                        setUserAnswer(null);
-                        setShowHint(false);
-                        setShowFeedback(false);
-                      }}
-                      className="w-full bg-orange-500 hover:bg-orange-600 text-white"
-                    >
-                      Finish Practice
-                    </Button>
-                  )}
-                </>
-              )}
-            </div>
-          ) : (
-            <p className="text-gray-400">No questions available yet!</p>
-          )}
-        </div>
-      </div>
-    );
+function answersByQuestionMap(
+  answers: PracticeAnswerResponse[],
+): Map<string, PracticeAnswerResponse> {
+  const m = new Map<string, PracticeAnswerResponse>();
+  for (const a of answers) {
+    if (a.question_id) m.set(a.question_id, a);
   }
+  return m;
+}
+
+interface PlayerProps {
+  phase: Extract<Phase, { kind: "playing" }>;
+  setPhase: (p: Phase) => void;
+}
+
+function Player({ phase, setPhase }: PlayerProps) {
+  const router = useRouter();
+  const { quiz, session, currentIndex, answersByQuestionId } = phase;
+  const currentQuestion = quiz.questions[currentIndex];
+  const existingAnswer = currentQuestion
+    ? answersByQuestionId.get(currentQuestion.id)
+    : undefined;
+
+  const [draftAnswer, setDraftAnswer] = useState<string | null>(
+    existingAnswer?.user_answer ?? null,
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [showHint, setShowHint] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+  const [completing, setCompleting] = useState(false);
+  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+
+  // Reset transient UI when the active question changes. We deliberately
+  // depend only on currentIndex so a fresh submit response (which mutates
+  // existingAnswer) doesn't blow away the draft mid-render.
+  useEffect(() => {
+    setDraftAnswer(existingAnswer?.user_answer ?? null);
+    setShowHint(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex]);
+
+  const total = quiz.questions.length;
+  const isLast = currentIndex === total - 1;
+  const showFeedback = Boolean(existingAnswer);
+
+  async function onSubmit() {
+    if (!currentQuestion || draftAnswer === null || draftAnswer === "") return;
+    setSubmitting(true);
+    try {
+      const answer = await submitPracticeAnswer(session.id, {
+        question_id: currentQuestion.id,
+        user_answer: draftAnswer,
+      });
+      const next = new Map(answersByQuestionId);
+      next.set(currentQuestion.id, answer);
+      setPhase({ ...phase, answersByQuestionId: next });
+    } catch (err: unknown) {
+      toast.error(err);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function onNext() {
+    if (currentIndex < total - 1) {
+      setPhase({ ...phase, currentIndex: currentIndex + 1 });
+    }
+  }
+
+  async function onComplete() {
+    setCompleting(true);
+    try {
+      const result = await completePracticeSession(session.id);
+      setPhase({ kind: "completed", result });
+    } catch (err: unknown) {
+      toast.error(err);
+    } finally {
+      setCompleting(false);
+    }
+  }
+
+  async function onLeaveConfirm() {
+    setLeaving(true);
+    try {
+      await abandonPracticeSession(session.id);
+      setShowLeaveConfirm(false);
+      router.push("/home");
+    } catch (err: unknown) {
+      toast.error(err);
+    } finally {
+      setLeaving(false);
+    }
+  }
+
+  if (!currentQuestion) return null;
 
   return (
     <div className="min-h-screen bg-black text-white">
-      {/* Hero Section */}
-      <div className="relative overflow-hidden border-b border-white/10">
-        <div className="absolute inset-0 bg-gradient-to-br from-orange-500/5 via-transparent to-blue-500/5" />
-        <div className="relative max-w-7xl mx-auto px-6 py-16">
-          <Badge className="mb-4 bg-orange-500/10 text-orange-500 border-orange-500/20">
-            Practice Mode
-          </Badge>
-          <h1 className="text-5xl font-bold mb-4">
-            Practice <span className="text-orange-500">Questions</span>
-          </h1>
-          <p className="text-xl text-gray-400 max-w-2xl">
-            Practice by topic, check your progress, and spend more time where
-            you need reinforcement.
-          </p>
+      <div className="border-b border-white/10 bg-white/5">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-4">
+            <Button
+              onClick={() => setShowLeaveConfirm(true)}
+              variant="ghost"
+              size="sm"
+              className="text-gray-400 hover:text-white"
+            >
+              ← Leave
+            </Button>
+            <div>
+              <h2 className="font-semibold">{quiz.title}</h2>
+              {quiz.description ? (
+                <p className="text-sm text-gray-400">{quiz.description}</p>
+              ) : null}
+            </div>
+          </div>
+          <div className="text-right">
+            <p className="text-sm text-gray-400">Progress</p>
+            <p className="text-lg font-semibold">
+              {currentIndex + 1} / {total}
+            </p>
+          </div>
         </div>
       </div>
 
-      {/* Study Guide Selection */}
-      <div className="max-w-7xl mx-auto px-6 py-12">
-        <h2 className="text-2xl font-semibold mb-6">Select a Study Guide</h2>
+      <div className="mx-auto max-w-4xl px-6 py-12">
+        <div className="rounded-xl border border-white/10 bg-white/5 p-8">
+          <Badge
+            className={cn(
+              "mb-6",
+              currentQuestion.type === "multiple-choice" &&
+                "border-blue-500/50 text-blue-400",
+              currentQuestion.type === "true-false" &&
+                "border-green-500/50 text-green-400",
+              currentQuestion.type === "freeform" &&
+                "border-purple-500/50 text-purple-400",
+            )}
+            variant="outline"
+          >
+            {labelForType(currentQuestion.type)}
+          </Badge>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {studyGuides.map((guide) => (
-            <button
-              key={guide.id}
-              onClick={() => setSelectedGuide(guide)}
-              className="text-left p-6 bg-white/5 border border-white/10 rounded-xl hover:border-orange-500/50 hover:bg-white/[0.07] transition-all duration-200 cursor-pointer"
-            >
-              <div className="flex items-start justify-between mb-4">
-                <Badge
-                  variant="outline"
-                  className="border-blue-500/50 text-blue-400"
+          <h3 className="mb-6 text-xl font-semibold">
+            {currentQuestion.question}
+          </h3>
+
+          {currentQuestion.type === "multiple-choice" &&
+            currentQuestion.options && (
+              <div className="mb-6 space-y-3">
+                {currentQuestion.options.map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    onClick={() => setDraftAnswer(option)}
+                    disabled={showFeedback || submitting}
+                    className={cn(
+                      "w-full rounded-xl border-2 p-4 text-left transition-all duration-200",
+                      draftAnswer === option
+                        ? "border-orange-500 bg-orange-500/10"
+                        : "border-white/10 hover:border-orange-500/50 hover:bg-orange-500/5",
+                    )}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+            )}
+
+          {currentQuestion.type === "true-false" && (
+            <div className="mb-6 grid grid-cols-2 gap-4">
+              {[
+                { label: "True", value: "true" },
+                { label: "False", value: "false" },
+              ].map(({ label, value }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setDraftAnswer(value)}
+                  disabled={showFeedback || submitting}
+                  className={cn(
+                    "rounded-xl border-2 p-6 text-lg font-semibold transition-all duration-200",
+                    draftAnswer === value
+                      ? "border-orange-500 bg-orange-500/10"
+                      : "border-white/10 hover:border-orange-500/50 hover:bg-orange-500/5",
+                  )}
                 >
-                  {guide.topic}
-                </Badge>
-                <span className="text-sm text-gray-400">
-                  {guide.questionCount} questions
-                </span>
-              </div>
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
 
-              <h3 className="text-xl font-semibold mb-2">{guide.name}</h3>
+          {currentQuestion.type === "freeform" && (
+            <div className="mb-6">
+              <Input
+                type="text"
+                placeholder="Type your answer here..."
+                value={draftAnswer ?? ""}
+                onChange={(e) => setDraftAnswer(e.target.value)}
+                disabled={showFeedback || submitting}
+                className="w-full rounded-xl border-2 border-white/10 bg-white/5 p-4 text-lg focus:border-orange-500"
+              />
+            </div>
+          )}
 
-              <div className="flex items-center text-sm text-gray-400 mt-4">
-                <span>Start Practice</span>
-                <span className="ml-2">→</span>
-              </div>
-            </button>
-          ))}
+          {!showFeedback && currentQuestion.hint ? (
+            <div className="mb-6">
+              <Button
+                onClick={() => setShowHint((v) => !v)}
+                variant="outline"
+                size="sm"
+                className="border-yellow-500/30 text-yellow-500 hover:bg-yellow-500/10"
+              >
+                {showHint ? "Hide Hint" : "💡 Show Hint"}
+              </Button>
+              {showHint ? (
+                <div className="mt-4 rounded-lg border border-yellow-500/20 bg-yellow-500/5 p-4">
+                  <p className="text-sm text-yellow-200">
+                    {currentQuestion.hint}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {existingAnswer ? (
+            <FeedbackBlock
+              question={currentQuestion}
+              answer={existingAnswer}
+              isLast={isLast}
+              completing={completing}
+              onNext={onNext}
+              onComplete={onComplete}
+            />
+          ) : (
+            <Button
+              onClick={onSubmit}
+              disabled={
+                submitting || draftAnswer === null || draftAnswer === ""
+              }
+              className="w-full bg-orange-500 text-white hover:bg-orange-600"
+            >
+              {submitting ? "Submitting..." : "Submit Answer"}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <ConfirmationDialog
+        open={showLeaveConfirm}
+        onOpenChange={setShowLeaveConfirm}
+        title="Leave practice?"
+        description="Your in-progress session will be discarded."
+        confirmLabel={leaving ? "Leaving..." : "Leave"}
+        cancelLabel="Stay"
+        destructive
+        disabled={leaving}
+        onConfirm={onLeaveConfirm}
+      />
+    </div>
+  );
+}
+
+function FeedbackBlock({
+  question,
+  answer,
+  isLast,
+  completing,
+  onNext,
+  onComplete,
+}: {
+  question: QuizQuestionResponse;
+  answer: PracticeAnswerResponse;
+  isLast: boolean;
+  completing: boolean;
+  onNext: () => void;
+  onComplete: () => void;
+}) {
+  const isCorrect = answer.is_correct === true;
+  const message = isCorrect
+    ? question.feedback.correct
+    : question.feedback.incorrect;
+
+  return (
+    <>
+      <div
+        className={cn(
+          "mb-6 rounded-xl border-2 p-6",
+          isCorrect
+            ? "border-green-500/50 bg-green-500/10"
+            : "border-red-500/50 bg-red-500/10",
+        )}
+      >
+        <div className="flex items-start gap-4">
+          <div className="text-3xl">{isCorrect ? "🎉" : "📚"}</div>
+          <div>
+            <h3
+              className={cn(
+                "mb-2 text-lg font-semibold",
+                isCorrect ? "text-green-400" : "text-red-400",
+              )}
+            >
+              {isCorrect ? "Correct!" : "Not quite"}
+            </h3>
+            {message ? <p className="text-gray-300">{message}</p> : null}
+            {!answer.verified ? (
+              <p className="mt-2 text-xs text-gray-400">
+                Freeform answers are scored by string match — your wording may
+                be acceptable even if marked otherwise.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {isLast ? (
+        <Button
+          onClick={onComplete}
+          disabled={completing}
+          className="w-full bg-orange-500 text-white hover:bg-orange-600"
+        >
+          {completing ? "Finishing..." : "Finish Practice"}
+        </Button>
+      ) : (
+        <Button
+          onClick={onNext}
+          className="w-full bg-orange-500 text-white hover:bg-orange-600"
+        >
+          Next Question →
+        </Button>
+      )}
+    </>
+  );
+}
+
+function ScoreScreen({ result }: { result: CompletedSessionResponse }) {
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <div className="mx-auto max-w-2xl px-6 py-20 text-center">
+        <Badge className="mb-6 border-orange-500/20 bg-orange-500/10 text-orange-500">
+          Practice Complete
+        </Badge>
+        <h1 className="mb-4 text-5xl font-bold">
+          {Math.round(result.score_percentage)}%
+        </h1>
+        <p className="mb-8 text-lg text-gray-400">
+          You got {result.correct_answers} of {result.total_questions} correct.
+        </p>
+        <div className="flex justify-center gap-3">
+          <Button asChild variant="outline">
+            <Link href="/home">Back home</Link>
+          </Button>
+          <Button
+            asChild
+            className="bg-orange-500 text-white hover:bg-orange-600"
+          >
+            <Link href="/me/study-guides">My study guides</Link>
+          </Button>
         </div>
       </div>
     </div>
   );
+}
+
+function NoQuizState() {
+  return (
+    <CenteredMessage
+      title="Pick a quiz to practice"
+      body="Open a study guide and start a quiz from there."
+      cta={{ label: "Browse my study guides", href: "/me/study-guides" }}
+    />
+  );
+}
+
+function EmptyQuizState({ quiz }: { quiz: QuizDetailResponse }) {
+  return (
+    <CenteredMessage
+      title="This quiz has no questions yet"
+      body={`"${quiz.title}" doesn't have any questions to practice.`}
+      cta={{
+        label: "Open the study guide",
+        href: `/study-guides/${quiz.study_guide_id}`,
+      }}
+    />
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <div className="mx-auto max-w-2xl px-6 py-20 text-center text-gray-400">
+        Loading practice session…
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <CenteredMessage
+      title="Practice unavailable"
+      body={message}
+      cta={{ label: "Back home", href: "/home" }}
+    />
+  );
+}
+
+function CenteredMessage({
+  title,
+  body,
+  cta,
+}: {
+  title: string;
+  body: string;
+  cta: { label: string; href: string };
+}) {
+  return (
+    <div className="min-h-screen bg-black text-white">
+      <div className="mx-auto max-w-2xl px-6 py-20 text-center">
+        <h1 className="mb-3 text-3xl font-semibold">{title}</h1>
+        <p className="mb-8 text-gray-400">{body}</p>
+        <Button
+          asChild
+          className="bg-orange-500 text-white hover:bg-orange-600"
+        >
+          <Link href={cta.href}>{cta.label}</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function labelForType(type: QuizQuestionResponse["type"]): string {
+  if (type === "multiple-choice") return "Multiple Choice";
+  if (type === "true-false") return "True / False";
+  return "Free Response";
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded study-guide fixtures in `/practice` with the real session lifecycle ([ASK-192](https://linear.app/askatlas/issue/ASK-192)).

- Reads `?quiz={id}`; runs `getQuiz` + `startPracticeSession` in parallel on mount.
- Walks the user one question at a time across MCQ / TF / freeform; submits via `submitPracticeAnswer` and renders feedback from the **server's** `is_correct` (no local string compare).
- On resume, skips to the first unanswered question. If every question is already answered (or the API hands back a `completed_at`), auto-calls `completePracticeSession` and lands on the score screen.
- "Leave" → `<ConfirmationDialog>` → `abandonPracticeSession` → redirect to `/home`.
- "Finish Practice" on the last question → `completePracticeSession` → `<ScoreScreen>` with percentage + correct/total + back-home + my-study-guides links.
- Empty states: no `?quiz=`, quiz with zero questions, error state.
- True/false answers normalized to lowercase `"true"`/`"false"` per API contract.
- Adds 6 Jest tests covering: no-quiz, empty-quiz, full happy path (start → submit → complete), mid-session resume, all-answered auto-complete, and abandon.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm eslint app/practice/` clean
- [x] `pnpm jest app/practice/page.test` — 6/6 passing
- [ ] Manual stage QA (see verification list)