### PR TITLE
fix(web): align my-study-guides header with new-study-guide style

### DIFF
--- a/web/app/(dashboard)/me/study-guides/page.test.tsx
+++ b/web/app/(dashboard)/me/study-guides/page.test.tsx
@@ -65,7 +65,7 @@ describe("MyStudyGuidesPage", () => {
     await renderPage();
 
     expect(
-      screen.getByRole("heading", { level: 1, name: "My Study Guides" }),
+      screen.getByRole("heading", { level: 1, name: "My study guides" }),
     ).toBeInTheDocument();
     expect(screen.getByText("No study guides yet")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /create one/i })).toHaveAttribute(

--- a/web/app/(dashboard)/me/study-guides/page.tsx
+++ b/web/app/(dashboard)/me/study-guides/page.tsx
@@ -19,18 +19,18 @@ export default async function MyStudyGuidesPage() {
   const guides = res.study_guides.filter((g) => g.deleted_at === null);
 
   return (
-    <section className="mx-auto flex w-full max-w-[1184px] flex-col gap-6 px-10 py-8">
-      <header className="flex flex-wrap items-end justify-between gap-4">
-        <div className="flex flex-col gap-1.5">
+    <section className="flex flex-col gap-8 py-2">
+      <header className="flex flex-wrap items-end justify-between gap-x-6 gap-y-3">
+        <div className="space-y-1.5">
           <div className="flex items-center gap-3">
-            <h1 className="text-foreground text-[22px] font-semibold leading-tight tracking-[-0.4px]">
-              My Study Guides
+            <h1 className="text-foreground text-[28px] font-semibold leading-tight tracking-[-0.4px]">
+              My study guides
             </h1>
             <span className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 font-mono text-[12px] font-semibold">
               {guides.length}
             </span>
           </div>
-          <p className="text-muted-foreground text-[13px]">
+          <p className="text-muted-foreground text-sm">
             Access and manage the study guides you have created.
           </p>
         </div>


### PR DESCRIPTION
## Summary
The header on \`/me/study-guides\` used 22px text + custom container; the create-flow at \`/study-guides/new\` uses 28px + a different layout. Aligning the listing page to match the create page so they read as one section.

- h1: 22px → 28px (matches \`new-study-guide-form.tsx\`)
- subtitle: \`text-[13px]\` → \`text-sm\`
- container: bespoke \`max-w-[1184px]\` → shared \`flex flex-col gap-8 py-2\`
- header layout: matches the create page's flex pattern
- title casing: "My Study Guides" → "My study guides" (matches "New study guide")

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm jest me/study-guides/page.test\` 3/3 passing (updated heading assertion)
- [x] \`pnpm prettier --check\` clean