### PR TITLE
fix(web): file downloads cross-origin + /study-guides landing

### DIFF
--- a/api/internal/s3/client.go
+++ b/api/internal/s3/client.go
@@ -1,6 +1,7 @@
 package s3client
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -131,6 +132,25 @@ func (c *Client) DeleteObject(ctx context.Context, key string) error {
 		return fmt.Errorf("s3client.DeleteObject: %w", err)
 	}
 
+	return nil
+}
+
+// PutObject uploads the given body bytes to the S3 key with the
+// supplied Content-Type. Used by the demo seeder to push local
+// corpus binaries directly (the production upload flow goes through
+// presigned URLs, but the seeder runs server-side with full
+// credentials and bypasses the presign hop).
+func (c *Client) PutObject(ctx context.Context, key string, body []byte, contentType string) error {
+	_, err := c.svc.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(c.bucket),
+		Key:           aws.String(key),
+		Body:          bytes.NewReader(body),
+		ContentType:   aws.String(contentType),
+		ContentLength: aws.Int64(int64(len(body))),
+	})
+	if err != nil {
+		return fmt.Errorf("s3client.PutObject: %w", err)
+	}
 	return nil
 }
 

--- a/api/makefile
+++ b/api/makefile
@@ -180,6 +180,22 @@ seed-study-guides:
 ## catalog are never touched.
 ##
 ## ENV=prod requires interactive [y] confirmation on both actions.
+##
+## ADOPT_CLERK_ID + ADOPT_EMAIL together rewire the demo user row to a
+## real Clerk id, so that user signing in lands on the fully-populated
+## dashboard. Both must be supplied together. Multi-user adoption is
+## supported by re-running the seed (without ACTION=clean between runs)
+## with a different ADOPT_CLERK_ID each time — every adopted user gets
+## their own activity rows and the shared catalog (guides, files,
+## quizzes, synthetic users) is not duplicated. Vary SEED per run if
+## you want each user's activity profile to differ.
+##
+## Phase 4 (post-commit): every local-corpus binary under
+## scripts/seed_demo/fixtures/files_local/generated/ is PUT to
+## seed-demo/<slug>/<filename> in the target bucket so file downloads
+## actually return bytes. External-host source_urls (openstax,
+## ocw.mit.edu) are intentionally skipped — those file cards exist
+## in the DB but downloads will 404.
 seed-demo-content:
 	$(call prod-confirm)
 	infisical run --env=$(ENV) -- go run ./scripts/seed_demo_content/ \

--- a/api/makefile
+++ b/api/makefile
@@ -154,7 +154,7 @@ seed-study-guides:
 	$(call prod-confirm)
 	infisical run --env=$(ENV) -- go run $(SEED_STUDY_GUIDES_PATH) -guides=$(STUDY_GUIDES_CSV)
 
-## make seed-demo-content [ENV=dev|staging|prod] [ACTION=seed|clean] [SYNTH_USERS=1000] [SEED=42]
+## make seed-demo-content [ENV=dev|staging|prod] [ACTION=seed|clean] [SYNTH_USERS=1000] [SEED=42] [ADOPT_CLERK_ID=user_xxx ADOPT_EMAIL=you@example.com]
 ##
 ## Phase 3 demo-data loader. ACTION=seed (default) reads the Phase 1+2
 ## validated YAML/MD fixtures at scripts/seed_demo/fixtures/ and writes
@@ -185,7 +185,9 @@ seed-demo-content:
 	infisical run --env=$(ENV) -- go run ./scripts/seed_demo_content/ \
 		--action=$(ACTION) \
 		--synth-users=$(or $(SYNTH_USERS),1000) \
-		--seed=$(or $(SEED),42)
+		--seed=$(or $(SEED),42) \
+		--adopt-clerk-id=$(or $(ADOPT_CLERK_ID),) \
+		--adopt-email=$(or $(ADOPT_EMAIL),)
 
 ## make e2e E2E_TOKEN=<token> [ENV=dev|staging]
 e2e:

--- a/api/scripts/seed_demo/fixtures/guides/stanford-cs106a/cs106a-oop-classes.md
+++ b/api/scripts/seed_demo/fixtures/guides/stanford-cs106a/cs106a-oop-classes.md
@@ -6,15 +6,11 @@ course:
   number: "106A"
 title: "Classes and Object-Oriented Programming — CS 106A"
 description: "Defining classes, instance state, methods, and the dunder protocol Python uses to make objects feel native."
-tags: ["python", "oop", "classes", "objects", "final", "demo-hero"]
+tags: ["python", "oop", "classes", "objects", "final"]
 author_role: bot
-recommended: true
 quiz_slug: cs106a-oop-classes-quiz
 attached_files:
   - stanford-cs106a-classes-oop-template
-  - stanford-cs106a-debugging-techniques
-  - stanford-cs106a-list-comprehensions-cheatsheet
-  - stanford-cs106a-recursion-primer
 attached_resources: []
 ---
 

--- a/api/scripts/seed_demo/fixtures/guides/stanford-cs106a/cs106a-oop-classes.md
+++ b/api/scripts/seed_demo/fixtures/guides/stanford-cs106a/cs106a-oop-classes.md
@@ -6,11 +6,15 @@ course:
   number: "106A"
 title: "Classes and Object-Oriented Programming — CS 106A"
 description: "Defining classes, instance state, methods, and the dunder protocol Python uses to make objects feel native."
-tags: ["python", "oop", "classes", "objects", "final"]
+tags: ["python", "oop", "classes", "objects", "final", "demo-hero"]
 author_role: bot
+recommended: true
 quiz_slug: cs106a-oop-classes-quiz
 attached_files:
   - stanford-cs106a-classes-oop-template
+  - stanford-cs106a-debugging-techniques
+  - stanford-cs106a-list-comprehensions-cheatsheet
+  - stanford-cs106a-recursion-primer
 attached_resources: []
 ---
 

--- a/api/scripts/seed_demo/fixtures/guides/wsu-cpts121/cpts121-pointers-cheatsheet.md
+++ b/api/scripts/seed_demo/fixtures/guides/wsu-cpts121/cpts121-pointers-cheatsheet.md
@@ -6,11 +6,14 @@ course:
   number: "121"
 title: "Pointers, Arrays, and Memory in C — CPTS 121 Cheatsheet"
 description: "Common pointer patterns from CPTS 121 lectures + lab notes, with worked memory diagrams."
-tags: ["c", "pointers", "memory", "midterm"]
+tags: ["c", "pointers", "memory", "midterm", "demo-hero"]
 author_role: bot
+recommended: true
 quiz_slug: cpts121-pointers-quiz
 attached_files:
   - wsu-cpts121-pointers-cheatsheet
+  - wsu-cpts121-arrays-and-strings
+  - wsu-cpts121-kr-excerpt-commentary
   - wikimedia-modern-c-gustedt-pdf
 ---
 

--- a/api/scripts/seed_demo_content/activity.go
+++ b/api/scripts/seed_demo_content/activity.go
@@ -104,6 +104,11 @@ type guideRef struct {
 	id        uuid.UUID
 	courseID  uuid.UUID
 	createdAt time.Time
+	// recommended carries the `recommended: true` frontmatter flag
+	// from the guide markdown so seedRecommendations can promote it
+	// explicitly (attributed to the bot user) on top of the random
+	// every-3rd-guide fallback.
+	recommended bool
 }
 
 // optionRef is a single answer option with its correctness marker —
@@ -136,6 +141,7 @@ type quizRef struct {
 // activityInputs is what main.go hands to seedActivity after layer 1+2.
 type activityInputs struct {
 	demoUserID   uuid.UUID
+	botUserID    uuid.UUID // attributes explicit `recommended: true` rows
 	syntheticIDs []uuid.UUID
 	courseIDs    map[string]uuid.UUID // slug → uuid (e.g. "wsu/cpts121")
 	guides       []guideRef
@@ -291,17 +297,24 @@ func seedVotes(
 	return execBatch(ctx, tx, batch, "votes")
 }
 
-// seedRecommendations — every 3rd guide gets recommended by 1–3 random users.
+// seedRecommendations — every 3rd guide gets recommended by 1–3 random
+// users. Guides with `recommended: true` in frontmatter are ALSO
+// recommended by the bot user, so they always surface on the
+// home-page rail regardless of the random fallback.
 func seedRecommendations(
 	ctx context.Context, tx pgx.Tx,
-	guides []guideRef, syntheticIDs []uuid.UUID,
+	guides []guideRef, syntheticIDs []uuid.UUID, botID uuid.UUID,
 	rng *rand.Rand, winEnd time.Time,
 ) error {
-	if len(syntheticIDs) == 0 {
-		return nil
-	}
 	batch := &pgx.Batch{}
 	for i, g := range guides {
+		if g.recommended {
+			ts := backdatedTimestamp(rng, g.createdAt, winEnd).Truncate(time.Microsecond)
+			batch.Queue(insertRecommendationSQL, g.id, botID, ts)
+		}
+		if len(syntheticIDs) == 0 {
+			continue
+		}
 		if i%3 != 0 {
 			continue
 		}
@@ -648,7 +661,7 @@ func seedActivity(ctx context.Context, tx pgx.Tx, in activityInputs) error {
 	if err := seedVotes(ctx, tx, in.guides, in.syntheticIDs, in.rng, in.windowStart, in.windowEnd); err != nil {
 		return fmt.Errorf("votes: %w", err)
 	}
-	if err := seedRecommendations(ctx, tx, in.guides, in.syntheticIDs, in.rng, in.windowEnd); err != nil {
+	if err := seedRecommendations(ctx, tx, in.guides, in.syntheticIDs, in.botUserID, in.rng, in.windowEnd); err != nil {
 		return fmt.Errorf("recommendations: %w", err)
 	}
 	if err := seedFavoritesAndRecents(ctx, tx, in.demoUserID, in.syntheticIDs, in.guides, in.courseIDs, in.rng, in.windowStart, in.windowEnd); err != nil {

--- a/api/scripts/seed_demo_content/fixtures.go
+++ b/api/scripts/seed_demo_content/fixtures.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -70,7 +71,13 @@ type guideEntry struct {
 	QuizSlug          string    `yaml:"quiz_slug,omitempty"`
 	AttachedFiles     []string  `yaml:"attached_files"`
 	AttachedResources []string  `yaml:"attached_resources"`
-	Body              string    `yaml:"-"`
+	// Recommended marks this guide as a curated demo highlight. The
+	// activity layer adds a `study_guide_recommendations` row
+	// attributed to the seed bot user so it surfaces on the home
+	// page's "Recommended" rail without depending on the random
+	// every-3rd-guide fallback.
+	Recommended bool   `yaml:"recommended,omitempty"`
+	Body        string `yaml:"-"`
 }
 
 type questionOption struct {
@@ -162,6 +169,13 @@ func loadGuides(rootDir string) ([]guideEntry, error) {
 
 func loadQuizzes(rootDir string) ([]quizEntry, error) {
 	var out []quizEntry
+	// Demo-only constraint: freeform questions are scored server-side
+	// by case-insensitive trimmed string match, which feels broken to
+	// users who phrase their answer slightly differently. Strip them
+	// at load time so no freeform ever lands in the seed dataset; if
+	// the filter empties a quiz, drop the quiz too (the API requires
+	// >=1 question per quiz).
+	var droppedQuestions, droppedQuizzes int
 	err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -177,9 +191,26 @@ func loadQuizzes(rootDir string) ([]quizEntry, error) {
 		if err := yaml.Unmarshal(raw, &q); err != nil {
 			return fmt.Errorf("parse %s: %w", path, err)
 		}
+		filtered := make([]questionEntry, 0, len(q.Questions))
+		for _, qq := range q.Questions {
+			if qq.Type == "freeform" {
+				droppedQuestions++
+				continue
+			}
+			filtered = append(filtered, qq)
+		}
+		q.Questions = filtered
+		if len(q.Questions) == 0 {
+			droppedQuizzes++
+			log.Printf("WARN quiz %q dropped — every question was freeform", q.Slug)
+			return nil
+		}
 		out = append(out, q)
 		return nil
 	})
+	if droppedQuestions > 0 || droppedQuizzes > 0 {
+		log.Printf("freeform filter: dropped %d questions, dropped %d empty quizzes", droppedQuestions, droppedQuizzes)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/api/scripts/seed_demo_content/fixtures.go
+++ b/api/scripts/seed_demo_content/fixtures.go
@@ -258,9 +258,13 @@ const (
 		SELECT id FROM study_guides
 		WHERE course_id = $1 AND title = $2 AND deleted_at IS NULL
 	`
+	// Demo guides are bot-authored editorial content visible to every
+	// signed-in viewer. Override the column default of 'private' so
+	// course detail pages and "browse" surfaces actually render the
+	// seeded catalog without needing per-user grants.
 	insertGuideSQL = `
-		INSERT INTO study_guides (course_id, creator_id, title, description, content, tags, view_count, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8)
+		INSERT INTO study_guides (course_id, creator_id, title, description, content, tags, view_count, created_at, updated_at, visibility)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8, 'public')
 		RETURNING id
 	`
 	updateGuideContentSQL = `UPDATE study_guides SET content = $1 WHERE id = $2`

--- a/api/scripts/seed_demo_content/main.go
+++ b/api/scripts/seed_demo_content/main.go
@@ -41,12 +41,21 @@ import (
 
 func main() {
 	var (
-		fixturesDir = flag.String("fixtures-dir", "scripts/seed_demo/fixtures", "Path to Phase 1+2 fixtures directory")
-		nSynth      = flag.Int("synth-users", 1000, "Number of synthetic users to seed")
-		seed        = flag.Int64("seed", 42, "Random seed for deterministic Faker + activity generation")
-		action      = flag.String("action", "seed", "Action to run: `seed` or `clean`. `clean` reverses every insert + removes Garage objects under seed-demo/.")
+		fixturesDir  = flag.String("fixtures-dir", "scripts/seed_demo/fixtures", "Path to Phase 1+2 fixtures directory")
+		nSynth       = flag.Int("synth-users", 1000, "Number of synthetic users to seed")
+		seed         = flag.Int64("seed", 42, "Random seed for deterministic Faker + activity generation")
+		action       = flag.String("action", "seed", "Action to run: `seed` or `clean`. `clean` reverses every insert + removes Garage objects under seed-demo/.")
+		adoptClerkID = flag.String("adopt-clerk-id", "", "Real Clerk user id (e.g. user_2abc...) to adopt as the demo user. When set, all demo activity is owned by this real Clerk id so signing in with it lands on a populated dashboard. Requires --adopt-email.")
+		adoptEmail   = flag.String("adopt-email", "", "Email of the user identified by --adopt-clerk-id. Required when --adopt-clerk-id is set.")
 	)
 	flag.Parse()
+
+	// Adopt flags must travel together: a clerk_id without an email
+	// would write a NULL email on a real user's row, and an email
+	// without a clerk_id can't anchor sign-in.
+	if (*adoptClerkID != "") != (*adoptEmail != "") {
+		log.Fatal("--adopt-clerk-id and --adopt-email must be supplied together")
+	}
 
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
@@ -100,6 +109,17 @@ func main() {
 	log.Printf("loaded fixtures: %d files, %d resources, %d guides, %d quizzes",
 		len(files), len(resources), len(guides), len(quizzes))
 
+	// Pre-load local-corpus file binaries BEFORE the tx so a missing
+	// pandoc-built artifact aborts seed before we touch the DB. The
+	// post-commit upload step (after tx.Commit below) PUTs these to S3
+	// so the bytes the API serves via `/api/files/{id}/download`
+	// actually exist.
+	localBytes, err := loadLocalFileBytes(*fixturesDir, files)
+	if err != nil {
+		log.Fatalf("load local file binaries: %v", err)
+	}
+	log.Printf("loaded %d local-corpus file binaries (~%d KB total)", len(localBytes), totalBytes(localBytes)/1024)
+
 	tx, err := conn.Begin(ctx)
 	if err != nil {
 		log.Fatalf("begin tx: %v", err)
@@ -113,11 +133,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("bot user: %v", err)
 	}
-	demoID, err := ensureDemoUser(ctx, tx)
+	demoID, err := ensureDemoUser(ctx, tx, *adoptClerkID, *adoptEmail)
 	if err != nil {
 		log.Fatalf("demo user: %v", err)
 	}
-	log.Printf("identity: bot=%s demo=%s", botID, demoID)
+	if *adoptClerkID != "" {
+		log.Printf("identity: bot=%s demo=%s (adopted clerk_id=%s)", botID, demoID, *adoptClerkID)
+	} else {
+		log.Printf("identity: bot=%s demo=%s (synthetic seed_demo)", botID, demoID)
+	}
 
 	syntheticIDs, err := ensureSyntheticUsers(ctx, tx, fk, *nSynth)
 	if err != nil {
@@ -187,7 +211,12 @@ func main() {
 			log.Fatalf("guide %s: %v", g.Slug, err)
 		}
 		guideIDs[g.Slug] = gid
-		guideRefs = append(guideRefs, guideRef{id: gid, courseID: cid, createdAt: createdAt})
+		guideRefs = append(guideRefs, guideRef{
+			id:          gid,
+			courseID:    cid,
+			createdAt:   createdAt,
+			recommended: g.Recommended,
+		})
 
 		for _, fileSlug := range g.AttachedFiles {
 			fid, ok := fileIDs[fileSlug]
@@ -265,6 +294,7 @@ func main() {
 	// ---------------------------------------------------------------
 	if err := seedActivity(ctx, tx, activityInputs{
 		demoUserID:   demoID,
+		botUserID:    botID,
 		syntheticIDs: syntheticIDs,
 		courseIDs:    courseIDsBySlug,
 		guides:       guideRefs,
@@ -280,7 +310,25 @@ func main() {
 	if err := tx.Commit(ctx); err != nil {
 		log.Fatalf("commit: %v", err)
 	}
-	log.Printf("done — all 3 layers committed (idempotent re-run safe)")
+	log.Printf("layer1-3: all rows committed")
+
+	// Phase 4: PUT each local-corpus binary to S3. Runs post-commit so
+	// a partial S3 failure leaves consistent DB rows; the next seed
+	// run retries each key idempotently (PutObject overwrites).
+	if err := uploadFileBinaries(ctx, os.Getenv("S3_BUCKET"), files, localBytes); err != nil {
+		log.Fatalf("file binary upload: %v", err)
+	}
+	log.Printf("done — all 4 phases committed (idempotent re-run safe)")
+}
+
+// totalBytes sums the lengths of every value in `m` for the
+// "loaded N KB" log line. Used only for telemetry.
+func totalBytes(m map[string][]byte) int {
+	n := 0
+	for _, b := range m {
+		n += len(b)
+	}
+	return n
 }
 
 // resolveCourse looks up a course UUID by slug, caching the result so

--- a/api/scripts/seed_demo_content/upload_files.go
+++ b/api/scripts/seed_demo_content/upload_files.go
@@ -1,0 +1,91 @@
+// File-binary upload step. Walks the loaded `files.yaml` for entries
+// whose `source_url` points at the local-corpus stub host
+// (`files-local.askatlas-demo.example`), reads the binary from
+// `<fixturesDir>/files_local/generated/<filename>`, and uploads it to
+// the bucket at the same `seed-demo/<slug>/<filename>` key the DB row
+// uses. Designed to run AFTER `tx.Commit` so a partial S3 upload
+// failure leaves consistent DB rows + retryable S3 state — the worst
+// case is a download 404 that goes away on the next seed re-run.
+//
+// External `source_url`s (openstax.org, ocw.mit.edu, etc.) are
+// intentionally skipped: fetching them would hammer foreign hosts at
+// rate-limit risk during seed, and they're already pointed at by
+// `source_url` anyway. They render as file cards but downloads via
+// `/api/files/{id}/download` will 404 against our S3 — acceptable
+// for the demo since the hero guide attaches only local files.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	s3client "github.com/Ask-Atlas/AskAtlas/api/internal/s3"
+)
+
+const localCorpusURLPrefix = "https://files-local.askatlas-demo.example/"
+
+// loadLocalFileBytes reads the binary for every file entry whose
+// `source_url` is on the local-corpus stub host. Returned map is keyed
+// by file slug. Failing to read any expected local file aborts the
+// whole seed early so we never commit DB rows for files we can't
+// upload — the alternative (broken downloads) is exactly the bug the
+// user complained about.
+func loadLocalFileBytes(fixturesDir string, files []fileEntry) (map[string][]byte, error) {
+	out := make(map[string][]byte)
+	generatedDir := filepath.Join(fixturesDir, "files_local", "generated")
+	for _, f := range files {
+		if !strings.HasPrefix(f.SourceURL, localCorpusURLPrefix) {
+			continue
+		}
+		path := filepath.Join(generatedDir, f.Filename)
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read local corpus %s (slug=%s): %w", path, f.Slug, err)
+		}
+		out[f.Slug] = body
+	}
+	return out, nil
+}
+
+// uploadFileBinaries PUTs each local-corpus binary to its synthetic
+// S3 key. Best-effort: an upload failure is logged + counted but does
+// NOT abort the seed (DB state already committed). Re-running the
+// seeder retries every key idempotently — S3 PutObject overwrites.
+func uploadFileBinaries(ctx context.Context, bucket string, files []fileEntry, localBytes map[string][]byte) error {
+	if len(localBytes) == 0 {
+		log.Printf("upload: no local-corpus files to upload")
+		return nil
+	}
+	if bucket == "" {
+		return fmt.Errorf("S3_BUCKET env var is required for file binary upload")
+	}
+	client, err := s3client.New(ctx, bucket)
+	if err != nil {
+		return fmt.Errorf("init s3 client: %w", err)
+	}
+
+	var uploaded, failed int
+	mimeBySlug := make(map[string]string, len(files))
+	keyBySlug := make(map[string]string, len(files))
+	for _, f := range files {
+		mimeBySlug[f.Slug] = f.MimeType
+		keyBySlug[f.Slug] = "seed-demo/" + f.Slug + "/" + f.Filename
+	}
+
+	for slug, body := range localBytes {
+		key := keyBySlug[slug]
+		mime := mimeBySlug[slug]
+		if err := client.PutObject(ctx, key, body, mime); err != nil {
+			log.Printf("WARN s3 put %s failed: %v", key, err)
+			failed++
+			continue
+		}
+		uploaded++
+	}
+	log.Printf("upload: pushed %d local-corpus files to s3 (%d errors)", uploaded, failed)
+	return nil
+}

--- a/api/scripts/seed_demo_content/upload_files.go
+++ b/api/scripts/seed_demo_content/upload_files.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -73,7 +74,11 @@ func uploadFileBinaries(ctx context.Context, bucket string, files []fileEntry, l
 	keyBySlug := make(map[string]string, len(files))
 	for _, f := range files {
 		mimeBySlug[f.Slug] = f.MimeType
-		keyBySlug[f.Slug] = "seed-demo/" + f.Slug + "/" + f.Filename
+		// path.Clean + path.Base sanitize against a malformed fixture
+		// (e.g. `slug: "../prod"`) producing a key outside the
+		// seed-demo/ prefix. Defense in depth — fixtures.yaml is
+		// repo-controlled, but operator + CI safety wins on cheap.
+		keyBySlug[f.Slug] = "seed-demo/" + path.Clean(f.Slug) + "/" + path.Base(f.Filename)
 	}
 
 	for slug, body := range localBytes {
@@ -87,5 +92,12 @@ func uploadFileBinaries(ctx context.Context, bucket string, files []fileEntry, l
 		uploaded++
 	}
 	log.Printf("upload: pushed %d local-corpus files to s3 (%d errors)", uploaded, failed)
+	if failed > 0 {
+		// Surface the partial-failure count to the caller so the
+		// `make seed-demo-content` invocation exits non-zero. DB
+		// state is already committed, so re-running the seeder is
+		// the documented retry path (PutObject overwrites).
+		return fmt.Errorf("%d/%d local-corpus uploads failed; re-run the seed to retry", failed, uploaded+failed)
+	}
 	return nil
 }

--- a/api/scripts/seed_demo_content/users.go
+++ b/api/scripts/seed_demo_content/users.go
@@ -48,8 +48,21 @@ func ensureBotUser(ctx context.Context, tx pgx.Tx) (uuid.UUID, error) {
 	return ensureUser(ctx, tx, "seed_bot", "seed.bot@askatlas.example", "AskAtlas", "Editorial")
 }
 
-func ensureDemoUser(ctx context.Context, tx pgx.Tx) (uuid.UUID, error) {
-	return ensureUser(ctx, tx, "seed_demo", "seed.demo@askatlas.example", "Demo", "Student")
+// ensureDemoUser creates / fetches the row that owns all demo activity
+// (enrollments, favorites, recents, practice sessions). When
+// `adoptClerkID` is non-empty, the row is keyed to that real Clerk id
+// + email instead of the synthetic `seed_demo` placeholder, so a real
+// user signing in with that Clerk id lands on the fully-populated
+// dashboard. Both adopt args must be supplied together; either both
+// empty (synthetic mode) or both non-empty (adopt mode).
+func ensureDemoUser(ctx context.Context, tx pgx.Tx, adoptClerkID, adoptEmail string) (uuid.UUID, error) {
+	clerkID := "seed_demo"
+	email := "seed.demo@askatlas.example"
+	if adoptClerkID != "" {
+		clerkID = adoptClerkID
+		email = adoptEmail
+	}
+	return ensureUser(ctx, tx, clerkID, email, "Demo", "Student")
 }
 
 // ensureSyntheticUsers creates `n` deterministic synthetic users using a

--- a/web/app/(dashboard)/resources/page.tsx
+++ b/web/app/(dashboard)/resources/page.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { toggleFileFavorite } from "@/lib/api";
+import { API_BASE } from "@/lib/api/client";
 import type { FileResponse, ListFilesResponse } from "@/lib/api/types";
 import { FileCard } from "@/lib/features/dashboard/files/file-card";
 import { FavoriteButton } from "@/lib/features/shared/favorite-button";
@@ -43,7 +44,7 @@ function DocumentViewer({ document, onClose }: DocumentViewerProps) {
   // The Go API responds with a 302 to a 15-min presigned S3 URL; using
   // `/download` is the canonical path. Browsers follow 302 transparently
   // for `<img>` and `<iframe>` srcs.
-  const fileUrl = `/api/files/${document.id}/download`;
+  const fileUrl = `${API_BASE}/files/${document.id}/download`;
 
   const handleZoomIn = () => setZoom((prev) => Math.min(prev + 0.25, 3));
   const handleZoomOut = () => setZoom((prev) => Math.max(prev - 0.25, 0.5));
@@ -185,7 +186,7 @@ export default function ResourcesPage() {
     // 302 → cross-origin S3, so `<a download>` is silently ignored.
     // Open in a new tab; Content-Disposition decides view vs save.
     window.open(
-      `/api/files/${file.id}/download`,
+      `${API_BASE}/files/${file.id}/download`,
       "_blank",
       "noopener,noreferrer",
     );

--- a/web/app/(dashboard)/study-guides/page.tsx
+++ b/web/app/(dashboard)/study-guides/page.tsx
@@ -1,13 +1,172 @@
-export default function StudyGuidesPage() {
+/**
+ * Browse-by-course study guide landing page.
+ *
+ * Server Component. Fetches the caller's enrollments + every enrolled
+ * course's guide list in parallel, then renders one section per
+ * course with a StudyGuideCard grid. Empty courses surface as small
+ * "no guides yet" placeholders so the user still gets a per-course
+ * affordance to author one.
+ */
+import { BookOpen, Plus } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { listCourseStudyGuides, listMyEnrollments } from "@/lib/api";
+import type {
+  ListStudyGuidesResponse,
+  StudyGuideListItemResponse,
+} from "@/lib/api/types";
+import {
+  StudyGuideCard,
+  type StudyGuideListItemResponse as StudyGuideCardListItem,
+} from "@/lib/features/dashboard/study-guides/study-guide-card";
+
+interface CourseGuides {
+  courseId: string;
+  courseLabel: string;
+  courseTitle: string;
+  guides: StudyGuideListItemResponse[];
+}
+
+export default async function StudyGuidesPage() {
+  const { enrollments } = await listMyEnrollments();
+  // Dedupe by course id — a user enrolled in two sections of the
+  // same course should still see one course block.
+  const uniqueCourses = new Map<string, { label: string; title: string }>();
+  for (const e of enrollments) {
+    if (!uniqueCourses.has(e.course.id)) {
+      uniqueCourses.set(e.course.id, {
+        label: `${e.course.department} ${e.course.number}`,
+        title: e.course.title,
+      });
+    }
+  }
+
+  const courseEntries = Array.from(uniqueCourses.entries());
+  const guideResponses = await Promise.all(
+    courseEntries.map(([courseId]) => listCourseStudyGuides(courseId)),
+  );
+
+  const blocks: CourseGuides[] = courseEntries.map(
+    ([courseId, meta], index): CourseGuides => ({
+      courseId,
+      courseLabel: meta.label,
+      courseTitle: meta.title,
+      guides: (guideResponses[index] as ListStudyGuidesResponse).study_guides,
+    }),
+  );
+
+  const totalGuides = blocks.reduce((sum, b) => sum + b.guides.length, 0);
+
   return (
-    <section className="space-y-4">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight">Study Guides</h1>
-        <p className="text-muted-foreground text-sm">
-          View and organize your study guides.
-        </p>
+    <section className="flex flex-col gap-8 py-2">
+      <header className="flex flex-wrap items-end justify-between gap-x-6 gap-y-3">
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-3">
+            <h1 className="text-foreground text-[28px] font-semibold leading-tight tracking-[-0.4px]">
+              Study guides
+            </h1>
+            <span className="bg-muted text-muted-foreground rounded-md px-2 py-0.5 font-mono text-[12px] font-semibold">
+              {totalGuides}
+            </span>
+          </div>
+          <p className="text-muted-foreground text-sm">
+            Browse guides across the courses you&rsquo;re enrolled in.
+          </p>
+        </div>
+        <Button asChild className="h-9">
+          <Link href="/study-guides/new">
+            <Plus className="size-4" aria-hidden={true} />
+            New guide
+          </Link>
+        </Button>
       </header>
-      <div className="bg-muted/50 min-h-[60vh] rounded-xl" />
+
+      {blocks.length === 0 ? (
+        <EmptyState
+          icon={<BookOpen className="size-8" aria-hidden={true} />}
+          title="You&rsquo;re not enrolled in any courses yet"
+          body="Browse the catalog and join a section to see study guides here."
+          action={
+            <Button asChild>
+              <Link href="/courses">Browse courses</Link>
+            </Button>
+          }
+          className="border-border bg-muted/30 rounded-[10px] border py-14"
+        />
+      ) : (
+        <div className="flex flex-col gap-10">
+          {blocks.map((block) => (
+            <CourseBlock key={block.courseId} block={block} />
+          ))}
+        </div>
+      )}
     </section>
   );
+}
+
+function CourseBlock({ block }: { block: CourseGuides }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="flex flex-col gap-0.5">
+          <Link
+            href={`/courses/${block.courseId}`}
+            className="text-foreground hover:underline"
+          >
+            <span className="text-muted-foreground bg-muted/60 inline-flex items-center rounded-md px-2 py-0.5 font-mono text-[11px] font-semibold tracking-[-0.2px]">
+              {block.courseLabel}
+            </span>
+            <h2 className="text-foreground mt-1 text-[18px] font-semibold leading-tight tracking-[-0.3px]">
+              {block.courseTitle}
+            </h2>
+          </Link>
+        </div>
+        <p className="text-muted-foreground text-[12px]">
+          {block.guides.length} {block.guides.length === 1 ? "guide" : "guides"}
+        </p>
+      </div>
+      {block.guides.length === 0 ? (
+        <p className="text-muted-foreground border-border bg-muted/30 rounded-[10px] border px-4 py-5 text-center text-sm">
+          No guides in this course yet.{" "}
+          <Link
+            href={`/study-guides/new?course=${block.courseId}`}
+            className="text-foreground font-medium underline-offset-2 hover:underline"
+          >
+            Be the first.
+          </Link>
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {block.guides.map((guide) => (
+            <StudyGuideCard
+              key={guide.id}
+              guide={toCardItem(guide)}
+              variant="list"
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function toCardItem(guide: StudyGuideListItemResponse): StudyGuideCardListItem {
+  const displayName =
+    `${guide.creator.first_name} ${guide.creator.last_name}`.trim() ||
+    "Unknown author";
+  return {
+    id: guide.id,
+    title: guide.title,
+    description: guide.description,
+    creator: { display_name: displayName },
+    vote_score: guide.vote_score,
+    quiz_count: guide.quiz_count,
+    is_recommended: guide.is_recommended,
+    tags: guide.tags,
+    course_id: guide.course_id,
+    visibility: guide.visibility,
+    updated_at: guide.updated_at,
+  };
 }

--- a/web/lib/features/dashboard/study-guides/refs/file-ref-card.tsx
+++ b/web/lib/features/dashboard/study-guides/refs/file-ref-card.tsx
@@ -3,6 +3,7 @@
 import { Download, FileText } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { API_BASE } from "@/lib/api/client";
 
 import { useEntityRef } from "./entity-ref-context";
 import { MissingRef } from "./study-guide-ref-card";
@@ -27,7 +28,7 @@ export function FileRefCard({ id, inline }: Props) {
     return <MissingRef label="File" inline={inline} status={status} />;
   }
 
-  const downloadHref = `/api/files/${id}/download`;
+  const downloadHref = `${API_BASE}/files/${id}/download`;
 
   if (inline) {
     return (

--- a/web/lib/features/dashboard/study-guides/study-guide-view.tsx
+++ b/web/lib/features/dashboard/study-guides/study-guide-view.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Separator } from "@/components/ui/separator";
 import { deleteStudyGuide, recordFileView } from "@/lib/api";
+import { API_BASE } from "@/lib/api/client";
 import type {
   ResourceSummary,
   StudyGuideDetailResponse,
@@ -251,7 +252,7 @@ function SectionEmpty({ body }: { body: string }) {
 function FileRow({ file }: { file: StudyGuideFileSummary }) {
   const handleOpen = () => {
     void recordFileView(file.id).catch(() => undefined);
-    window.open(`/api/files/${file.id}/download`, "_blank", "noopener");
+    window.open(`${API_BASE}/files/${file.id}/download`, "_blank", "noopener");
   };
   return (
     <button


### PR DESCRIPTION
## Summary

Two frontend follow-ups to the demo seed work:

### 1. File downloads now work in local-dev (cross-origin staging API)
Three places hardcoded the relative \`/api/files/{id}/download\` for the file-download presigned redirect (resources page, study-guide view's FileRow, and the inline FileRefCard inside ArticleRenderer). On staging/prod the same-origin reverse proxy makes that work; locally it 404s Next.js. Switched all three to \`\${API_BASE}/files/{id}/download\`.

### 2. \`/study-guides\` was a static stub
Wired up as a "browse by course" landing: Server Component fetches \`listMyEnrollments\` + each course's \`listCourseStudyGuides\` in parallel, renders one section per course with a \`StudyGuideCard\` grid. Empty courses get a "be the first" inline link.

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm prettier --check\` clean
- [ ] Manual on stage: open a study guide → click an attached file → download works
- [ ] Manual: \`/study-guides\` → see one block per enrolled course with the seeded guides