### PR TITLE
fix(web): alias @clerk/nextjs/server in storybook to unblock docs deploy

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -31,11 +31,27 @@ const config: StorybookConfig = {
     // The /server subpath is aliased too because some stories pull
     // server actions from @/lib/api which import @clerk/nextjs/server
     // -- Vite can't resolve that subpath outside Next.js without help.
+    //
+    // Array form with anchored regexes is required: object-form aliases
+    // do prefix matching, so a `@clerk/nextjs` entry would rewrite
+    // `@clerk/nextjs/server` to `clerk-stub.tsx/server` and crash the
+    // build with UNLOADABLE_DEPENDENCY.
+    const stub = path.resolve(here, "clerk-stub.tsx");
     config.resolve = config.resolve ?? {};
-    config.resolve.alias = {
-      ...(config.resolve.alias as Record<string, string> | undefined),
-      "@clerk/nextjs": path.resolve(here, "clerk-stub.tsx"),
-    };
+    const existing = config.resolve.alias;
+    const existingArray = Array.isArray(existing)
+      ? existing
+      : existing
+        ? Object.entries(existing).map(([find, replacement]) => ({
+            find,
+            replacement: replacement as string,
+          }))
+        : [];
+    config.resolve.alias = [
+      { find: /^@clerk\/nextjs\/server$/, replacement: stub },
+      { find: /^@clerk\/nextjs$/, replacement: stub },
+      ...existingArray,
+    ];
     return config;
   },
 };


### PR DESCRIPTION
## Summary
- Object-form Vite aliases match by prefix, so `@clerk/nextjs` was rewriting `@clerk/nextjs/server` to `clerk-stub.tsx/server` and the storybook build crashed with `UNLOADABLE_DEPENDENCY` — failing `docs-deploy` for the last several `main` commits.
- Switch the `viteFinal` alias to array form with anchored regexes so both `@clerk/nextjs` and `@clerk/nextjs/server` resolve to the existing stub (which already exports `auth()`).

## Test plan
- [x] `STORYBOOK_BASE_URL=/AskAtlas/storybook pnpm build-storybook` succeeds locally
- [ ] `docs-deploy` workflow goes green on `main` after merge
- [ ] https://ask-atlas.github.io/AskAtlas/storybook/ loads